### PR TITLE
feat: separate menubar from topbar

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import Home from './Home';
 import {
   TopBar,
+  MenuBar,
   TopBarTrigger,
   TopBarItem,
   Workspace,
@@ -128,56 +129,58 @@ class App extends Component {
             defaultTitle="Deque Cauldron React"
           />
           <SkipLink target={'#main-content'} />
-          <TopBar thin={thin} hasTrigger>
-            <TopBarTrigger onClick={this.onTriggerClick}>
-              <button
-                tabIndex={-1}
-                aria-label="Menu"
-                aria-haspopup="true"
-                ref={this.topBarTrigger}
-                aria-expanded={show}
+          <TopBar>
+            <MenuBar thin={thin} hasTrigger>
+              <TopBarTrigger onClick={this.onTriggerClick}>
+                <button
+                  tabIndex={-1}
+                  aria-label="Menu"
+                  aria-haspopup="true"
+                  ref={this.topBarTrigger}
+                  aria-expanded={show}
+                >
+                  <Icon type="fa-bars" />
+                </button>
+              </TopBarTrigger>
+              <TopBarItem>
+                <Link to="/" className="MenuItem__logo" tabIndex={-1}>
+                  <img src={logo} alt="" /> <span>Cauldron</span>
+                </Link>
+              </TopBarItem>
+
+              {/* The below line demonstrates the ability to conditionally include menu item children. */}
+              {false && <TopBarItem>Potato</TopBarItem>}
+
+              <TopBarMenu
+                id="topbar-menu"
+                className="MenuItem--align-right MenuItem--separator MenuItem--arrow-down"
+                menuItemRef={el => (this.topBarMenuItem = el)}
               >
-                <Icon type="fa-bars" />
-              </button>
-            </TopBarTrigger>
-            <TopBarItem>
-              <Link to="/" className="MenuItem__logo" tabIndex={-1}>
-                <img src={logo} alt="" /> <span>Cauldron</span>
-              </Link>
-            </TopBarItem>
+                <div className="TopBar__item--icon">
+                  {thin ? (
+                    <Icon type="fa-cog" label="Settings" />
+                  ) : (
+                    <Fragment>
+                      <Icon type="fa-cog" />
+                      <div>Settings</div>
+                    </Fragment>
+                  )}
+                </div>
+                <OptionsMenuList onSelect={this.onSettingsSelect}>
+                  <li>Default top bar</li>
+                  <li>Thin top bar</li>
+                </OptionsMenuList>
+              </TopBarMenu>
 
-            {/* The below line demonstrates the ability to conditionally include menu item children. */}
-            {false && <TopBarItem>Potato</TopBarItem>}
-
-            <TopBarMenu
-              id="topbar-menu"
-              className="MenuItem--align-right MenuItem--separator MenuItem--arrow-down"
-              menuItemRef={el => (this.topBarMenuItem = el)}
-            >
-              <div className="TopBar__item--icon">
-                {thin ? (
-                  <Icon type="fa-cog" label="Settings" />
-                ) : (
-                  <Fragment>
-                    <Icon type="fa-cog" />
-                    <div>Settings</div>
-                  </Fragment>
-                )}
-              </div>
-              <OptionsMenuList onSelect={this.onSettingsSelect}>
-                <li>Default top bar</li>
-                <li>Thin top bar</li>
-              </OptionsMenuList>
-            </TopBarMenu>
-
-            <TopBarItem className="MenuItem--separator">
-              <a
-                href="https://github.com/dequelabs/cauldron-react"
-                className="fa fa-github"
-                aria-label="Cauldron React on GitHub"
-                tabIndex={-1}
-              />
-            </TopBarItem>
+              <TopBarItem className="MenuItem--separator">
+                <a
+                  href="https://github.com/dequelabs/cauldron-react"
+                  className="fa fa-github"
+                  aria-label="Cauldron React on GitHub"
+                  tabIndex={-1}
+                />
+              </TopBarItem>
+            </MenuBar>
           </TopBar>
           <SideBar show={this.state.show} onDismiss={this.onTriggerClick}>
             {componentsList.map(name => {

--- a/packages/react/__tests__/src/components/MenuBar/index.js
+++ b/packages/react/__tests__/src/components/MenuBar/index.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import MenuBar from 'src/components/MenuBar';
+import { TopBarItem } from 'src/';
+import axe from '../../../axe';
+
+const [right, left] = [39, 37];
+const noop = () => {};
+
+test('renders', () => {
+  expect.assertions(1);
+  expect(
+    shallow(
+      <MenuBar>
+        <div />
+      </MenuBar>
+    )
+  ).toBeTruthy();
+});
+
+test('supports falsy children', () => {
+  expect.assertions(2);
+  const wrapper = shallow(
+    <MenuBar>
+      <div />
+      {false && <div />}
+    </MenuBar>
+  );
+  expect(wrapper).toBeTruthy();
+  expect(wrapper.children().length).toBe(1);
+});
+
+test('handles left arrow', () => {
+  const wrapper = mount(
+    <MenuBar>
+      <TopBarItem>1</TopBarItem>
+      <TopBarItem>2</TopBarItem>
+      <TopBarItem>3</TopBarItem>
+    </MenuBar>
+  );
+  const menuItems = wrapper.find('[role="menuitem"]');
+  // from 2nd to 1st
+  wrapper.instance().onKeyDown({
+    which: left,
+    preventDefault: noop,
+    target: menuItems.at(1).getDOMNode()
+  });
+  expect(document.activeElement).toBe(menuItems.at(0).getDOMNode());
+  // from 1st to 3rd (circularity)
+  wrapper.instance().onKeyDown({
+    which: left,
+    preventDefault: noop,
+    target: menuItems.at(0).getDOMNode()
+  });
+  expect(document.activeElement).toBe(menuItems.at(2).getDOMNode());
+});
+
+test('handles right arrow', () => {
+  const wrapper = mount(
+    <MenuBar>
+      <TopBarItem>1</TopBarItem>
+      <TopBarItem>2</TopBarItem>
+      <TopBarItem>3</TopBarItem>
+    </MenuBar>
+  );
+  const menuItems = wrapper.find('[role="menuitem"]');
+  // from 1st to 2nd
+  wrapper.instance().onKeyDown({
+    which: right,
+    preventDefault: noop,
+    target: menuItems.at(0).getDOMNode()
+  });
+  expect(document.activeElement).toBe(menuItems.at(1).getDOMNode());
+  // from 3rd to 1st (circularity)
+  wrapper.instance().onKeyDown({
+    which: right,
+    preventDefault: noop,
+    target: menuItems.at(2).getDOMNode()
+  });
+  expect(document.activeElement).toBe(menuItems.at(0).getDOMNode());
+});
+
+test('should return no axe violations', async () => {
+  const topbar = mount(
+    <MenuBar>
+      <TopBarItem>1</TopBarItem>
+      <TopBarItem>2</TopBarItem>
+      <TopBarItem>3</TopBarItem>
+    </MenuBar>
+  );
+  expect(await axe(topbar.html())).toHaveNoViolations();
+});

--- a/packages/react/__tests__/src/components/TopBar/TopBar.js
+++ b/packages/react/__tests__/src/components/TopBar/TopBar.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import TopBar from 'src/components/TopBar';
+import MenuBar from 'src/components/MenuBar';
 import { TopBarItem } from 'src/';
 import axe from '../../../axe';
-
-const [right, left] = [39, 37];
-const noop = () => {};
 
 test('renders', () => {
   expect.assertions(1);
@@ -30,62 +28,15 @@ test('supports falsy children', () => {
   expect(wrapper.children().length).toBe(1);
 });
 
-test('handles left arrow', () => {
-  const wrapper = mount(
-    <TopBar>
-      <TopBarItem>1</TopBarItem>
-      <TopBarItem>2</TopBarItem>
-      <TopBarItem>3</TopBarItem>
-    </TopBar>
-  );
-  const menuItems = wrapper.find('[role="menuitem"]');
-  // from 2nd to 1st
-  wrapper.instance().onKeyDown({
-    which: left,
-    preventDefault: noop,
-    target: menuItems.at(1).getDOMNode()
-  });
-  expect(document.activeElement).toBe(menuItems.at(0).getDOMNode());
-  // from 1st to 3rd (circularity)
-  wrapper.instance().onKeyDown({
-    which: left,
-    preventDefault: noop,
-    target: menuItems.at(0).getDOMNode()
-  });
-  expect(document.activeElement).toBe(menuItems.at(2).getDOMNode());
-});
-
-test('handles right arrow', () => {
-  const wrapper = mount(
-    <TopBar>
-      <TopBarItem>1</TopBarItem>
-      <TopBarItem>2</TopBarItem>
-      <TopBarItem>3</TopBarItem>
-    </TopBar>
-  );
-  const menuItems = wrapper.find('[role="menuitem"]');
-  // from 1st to 2nd
-  wrapper.instance().onKeyDown({
-    which: right,
-    preventDefault: noop,
-    target: menuItems.at(0).getDOMNode()
-  });
-  expect(document.activeElement).toBe(menuItems.at(1).getDOMNode());
-  // from 3rd to 1st (circularity)
-  wrapper.instance().onKeyDown({
-    which: right,
-    preventDefault: noop,
-    target: menuItems.at(2).getDOMNode()
-  });
-  expect(document.activeElement).toBe(menuItems.at(0).getDOMNode());
-});
-
 test('should return no axe violations', async () => {
   const topbar = mount(
     <TopBar>
-      <TopBarItem>1</TopBarItem>
-      <TopBarItem>2</TopBarItem>
-      <TopBarItem>3</TopBarItem>
+      <div>LOGO</div>
+      <MenuBar>
+        <TopBarItem>1</TopBarItem>
+        <TopBarItem>2</TopBarItem>
+        <TopBarItem>3</TopBarItem>
+      </MenuBar>
     </TopBar>
   );
   expect(await axe(topbar.html())).toHaveNoViolations();

--- a/packages/react/__tests__/src/components/TopBar/TopBarMenu.js
+++ b/packages/react/__tests__/src/components/TopBar/TopBarMenu.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import MenuItem from 'src/components/MenuItem';
 import TopBar from 'src/components/TopBar/TopBar';
 import TopBarMenu from 'src/components/TopBar/TopBarMenu';
+import MenuBar from 'src/components/MenuBar';
 import { OptionsMenuList } from 'src/components/OptionsMenu';
 import axe from '../../../axe';
 
@@ -38,11 +39,11 @@ test('should pass-through props', () => {
 
 test('should open menu with down key', () => {
   const wrapper = mount(
-    <TopBar>
+    <MenuBar>
       <MenuItem>a</MenuItem>
       <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
       <MenuItem>b</MenuItem>
-    </TopBar>
+    </MenuBar>
   );
   wrapper.setState({ focusIndex: 1 });
   const topBarMenu = wrapper.find('TopBarMenu');
@@ -54,13 +55,13 @@ test('should open menu with down key', () => {
 test('should call onKeyDown with down key', () => {
   const handleKeyDown = jest.fn();
   const wrapper = mount(
-    <TopBar>
+    <MenuBar>
       <MenuItem>a</MenuItem>
       <TopBarMenu {...defaultProps} onKeyDown={handleKeyDown}>
         {optionsMenu}
       </TopBarMenu>
       <MenuItem>b</MenuItem>
-    </TopBar>
+    </MenuBar>
   );
   wrapper.setState({ focusIndex: 1 });
   const topBarMenu = wrapper.find('TopBarMenu');
@@ -71,11 +72,11 @@ test('should call onKeyDown with down key', () => {
 
 test('should close menu with left key', () => {
   const wrapper = mount(
-    <TopBar>
+    <MenuBar>
       <MenuItem>a</MenuItem>
       <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
       <MenuItem>b</MenuItem>
-    </TopBar>
+    </MenuBar>
   );
   wrapper.setState({ focusIndex: 1 });
   const topBarMenu = wrapper.find('TopBarMenu');
@@ -87,11 +88,11 @@ test('should close menu with left key', () => {
 
 test('should close menu with right key', () => {
   const wrapper = mount(
-    <TopBar>
+    <MenuBar>
       <MenuItem>a</MenuItem>
       <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
       <MenuItem>b</MenuItem>
-    </TopBar>
+    </MenuBar>
   );
   wrapper.setState({ focusIndex: 1 });
   const topBarMenu = wrapper.find('TopBarMenu');
@@ -104,9 +105,11 @@ test('should close menu with right key', () => {
 test('should return no axe violations', async () => {
   const topbar = mount(
     <TopBar>
-      <MenuItem>a</MenuItem>
-      <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
-      <MenuItem>b</MenuItem>
+      <MenuBar>
+        <MenuItem>a</MenuItem>
+        <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
+        <MenuItem>b</MenuItem>
+      </MenuBar>
     </TopBar>
   );
 

--- a/packages/react/src/components/MenuBar/index.tsx
+++ b/packages/react/src/components/MenuBar/index.tsx
@@ -1,0 +1,155 @@
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import keyname from 'keyname';
+import { isWide } from '../../utils/viewport';
+
+export interface MenuBarProps extends React.HTMLAttributes<HTMLUListElement> {
+  children: React.ReactNode;
+  thin?: boolean;
+  hasTrigger?: boolean;
+}
+
+interface MenuBarState {
+  wide: boolean;
+}
+
+export default class TopBar extends React.Component<
+  MenuBarProps,
+  MenuBarState
+> {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    thin: PropTypes.bool,
+    hasTrigger: PropTypes.bool
+  };
+
+  static defaultProps = {
+    thin: false,
+    hasTrigger: false
+  };
+
+  private menuItems: HTMLLIElement[] = [];
+
+  constructor(props: MenuBarProps) {
+    super(props);
+    const wide = isWide();
+    this.state = {
+      wide
+    };
+
+    this.onKeyDown = this.onKeyDown.bind(this);
+  }
+
+  componentDidMount() {
+    this.handleThin();
+    window.addEventListener('resize', this.onResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onResize);
+  }
+
+  componentDidUpdate(prevProps: MenuBarProps) {
+    if (prevProps.thin === this.props.thin) {
+      return;
+    }
+
+    this.handleThin();
+  }
+
+  private onResize = () => {
+    const wide = isWide();
+
+    if (wide === this.state.wide) {
+      return;
+    }
+
+    this.setState({
+      wide
+    });
+  };
+
+  private handleThin = () => {
+    const { thin } = this.props;
+    if (thin) {
+      document.body.classList.add('TopBar--thin');
+      return;
+    }
+
+    document.body.classList.remove('TopBar--thin');
+  };
+
+  private renderChild = (child: React.ReactElement<any>, index: number) => {
+    if (!child) {
+      return null;
+    }
+
+    return cloneElement(child, {
+      key: index,
+      onKeyDown: (...args: any) => {
+        // @ts-ignore we're just spreading the original args
+        this.onKeyDown(...args);
+
+        if (child.props.onKeyDown) {
+          child.props.onKeyDown(...args);
+        }
+      },
+      tabIndex: 0,
+      menuItemRef: (menuItem: HTMLLIElement) => {
+        if (menuItem) {
+          this.menuItems.push(menuItem);
+        }
+
+        if (child.props.menuItemRef) {
+          child.props.menuItemRef(menuItem);
+        }
+      }
+    });
+  };
+
+  onKeyDown(e: React.KeyboardEvent<HTMLElement>) {
+    const key = keyname(e.which);
+    const menuItems = [...this.menuItems];
+
+    // account for hidden side bar trigger (hamburger)
+    if (this.state.wide && this.props.hasTrigger) {
+      menuItems.shift();
+    }
+
+    const currentIndex = menuItems.findIndex(menuitem => menuitem === e.target);
+    if (currentIndex === -1 || (key !== 'left' && key !== 'right')) {
+      return;
+    }
+
+    e.preventDefault();
+
+    let adjacentIndex = key === 'left' ? currentIndex - 1 : currentIndex + 1;
+    // circular arrow focus
+    if (adjacentIndex === -1) {
+      // first to last
+      adjacentIndex = menuItems.length - 1;
+    } else if (adjacentIndex === menuItems.length) {
+      // last to first
+      adjacentIndex = 0;
+    }
+
+    menuItems[adjacentIndex].focus();
+  }
+
+  render() {
+    this.menuItems = [];
+    // disabling no-unused-vars to prevent thin/hasTrigger from being passed through to div
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { children, className, thin, hasTrigger, ...other } = this.props;
+
+    return (
+      <ul role="menubar">
+        {Children.map(
+          children as React.ReactElement<HTMLLIElement>,
+          this.renderChild
+        )}
+      </ul>
+    );
+  }
+}

--- a/packages/react/src/components/TopBar/TopBar.tsx
+++ b/packages/react/src/components/TopBar/TopBar.tsx
@@ -6,150 +6,15 @@ import { isWide } from '../../utils/viewport';
 
 export interface TopBarProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  thin?: boolean;
-  hasTrigger?: boolean;
 }
 
-interface TopBarState {
-  wide: boolean;
-}
+const TopBar = (props: TopBarProps) => {
+  const { children, className, ...other } = props;
+  return (
+    <div className={classNames('TopBar', className)} {...other}>
+      {children}
+    </div>
+  );
+};
 
-export default class TopBar extends React.Component<TopBarProps, TopBarState> {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    thin: PropTypes.bool,
-    hasTrigger: PropTypes.bool
-  };
-
-  static defaultProps = {
-    thin: false,
-    hasTrigger: false
-  };
-
-  private menuItems: HTMLLIElement[] = [];
-
-  constructor(props: TopBarProps) {
-    super(props);
-    const wide = isWide();
-    this.state = {
-      wide
-    };
-
-    this.onKeyDown = this.onKeyDown.bind(this);
-  }
-
-  componentDidMount() {
-    this.handleThin();
-    window.addEventListener('resize', this.onResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.onResize);
-  }
-
-  componentDidUpdate(prevProps: TopBarProps) {
-    if (prevProps.thin === this.props.thin) {
-      return;
-    }
-
-    this.handleThin();
-  }
-
-  private onResize = () => {
-    const wide = isWide();
-
-    if (wide === this.state.wide) {
-      return;
-    }
-
-    this.setState({
-      wide
-    });
-  };
-
-  private handleThin = () => {
-    const { thin } = this.props;
-    if (thin) {
-      document.body.classList.add('TopBar--thin');
-      return;
-    }
-
-    document.body.classList.remove('TopBar--thin');
-  };
-
-  private renderChild = (child: React.ReactElement<any>, index: number) => {
-    if (!child) {
-      return null;
-    }
-
-    return cloneElement(child, {
-      key: index,
-      onKeyDown: (...args: any) => {
-        // @ts-ignore we're just spreading the original args
-        this.onKeyDown(...args);
-
-        if (child.props.onKeyDown) {
-          child.props.onKeyDown(...args);
-        }
-      },
-      tabIndex: 0,
-      menuItemRef: (menuItem: HTMLLIElement) => {
-        if (menuItem) {
-          this.menuItems.push(menuItem);
-        }
-
-        if (child.props.menuItemRef) {
-          child.props.menuItemRef(menuItem);
-        }
-      }
-    });
-  };
-
-  onKeyDown(e: React.KeyboardEvent<HTMLElement>) {
-    const key = keyname(e.which);
-    const menuItems = [...this.menuItems];
-
-    // account for hidden side bar trigger (hamburger)
-    if (this.state.wide && this.props.hasTrigger) {
-      menuItems.shift();
-    }
-
-    const currentIndex = menuItems.findIndex(menuitem => menuitem === e.target);
-    if (currentIndex === -1 || (key !== 'left' && key !== 'right')) {
-      return;
-    }
-
-    e.preventDefault();
-
-    let adjacentIndex = key === 'left' ? currentIndex - 1 : currentIndex + 1;
-    // circular arrow focus
-    if (adjacentIndex === -1) {
-      // first to last
-      adjacentIndex = menuItems.length - 1;
-    } else if (adjacentIndex === menuItems.length) {
-      // last to first
-      adjacentIndex = 0;
-    }
-
-    menuItems[adjacentIndex].focus();
-  }
-
-  render() {
-    this.menuItems = [];
-    // disabling no-unused-vars to prevent thin/hasTrigger from being passed through to div
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { children, className, thin, hasTrigger, ...other } = this.props;
-
-    return (
-      <div className={classNames('TopBar', className)} {...other}>
-        <ul role="menubar">
-          {Children.map(
-            children as React.ReactElement<HTMLLIElement>,
-            this.renderChild
-          )}
-        </ul>
-      </div>
-    );
-  }
-}
+export default TopBar;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,7 @@ export { default as Icon } from './components/Icon';
 export { default as Offscreen } from './components/Offscreen';
 export { default as Scrim } from './components/Scrim';
 export { default as MenuItem } from './components/MenuItem';
+export { default as MenuBar } from './components/MenuBar';
 export {
   default as TopBar,
   TopBarTrigger,

--- a/packages/styles/top-bar.css
+++ b/packages/styles/top-bar.css
@@ -9,6 +9,8 @@
   flex-direction: row;
   box-sizing: border-box;
   z-index: var(--z-index-top-bar);
+  display: flex;
+  align-items: center;
 }
 
 .TopBar--thin .TopBar {
@@ -19,6 +21,7 @@
   list-style-type: none;
   display: flex;
   align-items: center;
+  flex: auto;
 }
 
 .TopBar li button {


### PR DESCRIPTION
BREAKING CHANGE: topbar no longer renders role=menubar. New component `<MenuBar />` must now be used if menubar is desired

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
