### PR TITLE
fix(styles): use psuedo element for topbar active border state

### DIFF
--- a/packages/styles/top-bar.css
+++ b/packages/styles/top-bar.css
@@ -31,8 +31,6 @@
 
 .TopBar > ul > li {
   box-sizing: border-box;
-  border-top: none;
-  border-bottom: none;
   height: var(--top-bar-height);
   cursor: pointer;
   position: relative;


### PR DESCRIPTION
`MenuItem--seperator` was clashing with `TopBar`'s borders.

![image](https://user-images.githubusercontent.com/1062039/85778677-6f0cd000-b6e8-11ea-8b5c-4a24eda0de9f.png)


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
