### PR TITLE
fix(tooltip): prevent word breaks on tooltip content

### DIFF
--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -17,7 +17,7 @@
   background: #f2f2f2;
   padding: 8px;
   z-index: 9;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .Tooltip .rc-tooltip-arrow {


### PR DESCRIPTION
Tooltips are breaking on word inner text:

![image](https://user-images.githubusercontent.com/1062039/87327290-8118ac00-c4f9-11ea-917c-8e9dd5b2d1cf.png)

This changes it to `break-word` instead allowing for word breaking to happen, but only when necessary.

Related: https://github.com/dequelabs/attest-browser-extensions/issues/1266

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
