### PR TITLE
fix: export select types

### DIFF
--- a/packages/react/src/components/Select/index.tsx
+++ b/packages/react/src/components/Select/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import uid from '../../utils/rndid';
 import classNames from 'classnames';
 
-interface SelectOption {
+export interface SelectOption {
   key: string;
   value: string;
   disabled?: boolean;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,7 +36,11 @@ export {
   OptionsMenuTrigger,
   OptionsMenuWrapper
 } from './components/OptionsMenu';
-export { default as Select } from './components/Select';
+export {
+  default as Select,
+  SelectOption,
+  SelectProps
+} from './components/Select';
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as Checkbox } from './components/Checkbox';
 export { default as Tooltip } from './components/Tooltip';


### PR DESCRIPTION
Added missing type exports so users can pull them in when constructing props and options.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
