### PR TITLE
fix(styles): make heading take up full modal header height

### DIFF
--- a/packages/styles/modal.css
+++ b/packages/styles/modal.css
@@ -2,6 +2,7 @@
   display: none;
   width: 100%;
   box-sizing: border-box;
+  --modal-header-height: 48px;
 }
 
 .Modal.Modal--show {
@@ -24,7 +25,7 @@
   background-color: var(--button-background-color-secondary);
   position: relative;
   display: flex;
-  height: 48px;
+  height: var(--modal-header-height);
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
 }
@@ -36,6 +37,10 @@
 .Modal__header h5,
 .Modal__header h6,
 .Modal__header .Modal__close {
+  margin: 0;
+  height: var(--modal-header-height);
+  display: flex;
+  align-items: center;
   border-bottom: 4px solid transparent;
 }
 


### PR DESCRIPTION
<details>
  <summary>BEFORE</summary>

<img width="477" alt="Screen Shot 2020-08-20 at 2 35 29 PM" src="https://user-images.githubusercontent.com/3180185/90828416-d1eaa400-e2f2-11ea-8be8-60d5bb8bf672.png">
<img width="457" alt="Screen Shot 2020-08-20 at 2 35 21 PM" src="https://user-images.githubusercontent.com/3180185/90828419-d2833a80-e2f2-11ea-8f03-b20fc6e8f1b5.png">


</details>

<details>
  <summary>AFTER</summary>

<img width="505" alt="Screen Shot 2020-08-20 at 2 35 54 PM" src="https://user-images.githubusercontent.com/3180185/90828447-de6efc80-e2f2-11ea-98fb-6472a0bc54a7.png">
<img width="471" alt="Screen Shot 2020-08-20 at 2 35 59 PM" src="https://user-images.githubusercontent.com/3180185/90828451-dfa02980-e2f2-11ea-8025-7c44c6d9b95e.png">



</details>


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
