### PR TITLE
fix: use flexbox for modal layouts and include default spacing in the content

### DIFF
--- a/packages/styles/modal.css
+++ b/packages/styles/modal.css
@@ -14,6 +14,8 @@
   left: 50%;
   top: 100px;
   position: fixed;
+  display: flex;
+  flex-direction: column;
   z-index: var(--z-index-modal);
   transform: translate(-50%, 0);
   border-radius: 3px;
@@ -75,8 +77,7 @@
 }
 
 .Modal .Modal__content {
-  padding: 0 var(--space-large) 0 var(--space-large);
-  margin-bottom: 60px;
+  padding: var(--space-small) var(--space-large);
   overflow-y: auto;
 }
 
@@ -92,9 +93,6 @@
 }
 
 .Modal__footer {
-  position: absolute;
-  width: 100%;
-  bottom: 0;
   height: 60px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
A few modal layout changes are needed to help address: https://github.com/dequelabs/attest-browser-extensions/issues/2330

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
