### PR TITLE
fix(styles): ensure that dialogs are anchored to the top of its relative container

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -12,6 +12,7 @@
   height: 100vh;
   overflow-x: auto;
   position: fixed;
+  top: 0;
 }
 
 .Dialog.Dialog--show {


### PR DESCRIPTION
Another fixed element adjacent to a dialog would push it out of the way. We should at a minimum, fix it to the top of whatever it's containing relative element is.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
