### PR TITLE
feat: support adding className to dialog header

### DIFF
--- a/packages/react/__tests__/src/components/Alert/index.js
+++ b/packages/react/__tests__/src/components/Alert/index.js
@@ -7,16 +7,23 @@ const defaults = { show: false, heading: { text: 'hi' } };
 
 test('returns null if passed a falsey "show" prop', () => {
   const alert = mount(<Alert {...defaults}>{'hello'}</Alert>);
-  console.log(alert.debug())
-  expect(alert.html()).toBe("");
+  expect(alert.html()).toBe('');
 });
 
 test('shows modal if passed a truthy "show" prop', () => {
-  const alert = mount(<Alert {...defaults} show={true}>{'hello'}</Alert>);
-  expect(alert.find('.Alert').exists()).toBe(true)
+  const alert = mount(
+    <Alert {...defaults} show={true}>
+      {'hello'}
+    </Alert>
+  );
+  expect(alert.find('.Alert').exists()).toBe(true);
 });
 
 test('should return no axe violations', async () => {
-  const alert = mount(<Alert show={true} heading={'title'}>Hello!</Alert>);
+  const alert = mount(
+    <Alert show={true} heading={'title'}>
+      Hello!
+    </Alert>
+  );
   expect(await axe(alert.html())).toHaveNoViolations();
 });

--- a/packages/react/__tests__/src/components/Dialog/index.js
+++ b/packages/react/__tests__/src/components/Dialog/index.js
@@ -103,7 +103,7 @@ test('does not render the close button given a thruthy "forceAction" prop', () =
   dialog.unmount();
 });
 
-test('supports heading from text', async () => {
+test('supports heading from text', () => {
   const dialog = mount(
     <Dialog {...defaults} heading={'hello title'} show={true}>
       {'body'}
@@ -113,9 +113,13 @@ test('supports heading from text', async () => {
   expect(dialog.find('h2').text()).toEqual('hello title');
 });
 
-test('supports heading from options', async () => {
+test('supports heading from options', () => {
   const dialog = mount(
-    <Dialog {...defaults} heading={{ text: 'hello title', level: 3 }} show={true}>
+    <Dialog
+      {...defaults}
+      heading={{ text: 'hello title', level: 3 }}
+      show={true}
+    >
       {'body'}
     </Dialog>
   );
@@ -130,4 +134,14 @@ test('should return no axe violations', async () => {
     </Dialog>
   );
   expect(await axe(dialog.html())).toHaveNoViolations();
+});
+
+test('allows className to be added to dialog header', () => {
+  const dialog = mount(
+    <Dialog {...defaults} headerClassName="Foo" show={true}>
+      {'body'}
+    </Dialog>
+  );
+
+  expect(dialog.find('.Dialog__header.Foo').exists()).toBe(true);
 });

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -13,6 +13,7 @@ import setRef from '../../utils/setRef';
 export interface DialogProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
+  headerClassName?: string;
   show?: boolean;
   dialogRef?: React.Ref<HTMLDivElement>;
   onClose: () => void;
@@ -42,6 +43,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
 
   static propTypes = {
     className: PropTypes.string,
+    headerClassName: PropTypes.string,
     show: PropTypes.bool,
     dialogRef: PropTypes.oneOfType([
       PropTypes.func,
@@ -99,6 +101,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
       heading,
       show,
       portal = document.body,
+      headerClassName,
       ...other
     } = this.props;
 
@@ -143,7 +146,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
           >
             <Scrim show={show} />
             <div className="Dialog__inner">
-              <div className="Dialog__header">
+              <div className={classNames('Dialog__header', headerClassName)}>
                 <Heading
                   className="Dialog__heading"
                   ref={(el: HTMLHeadingElement) => (this.heading = el)}


### PR DESCRIPTION
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Tested for accessibility
- [ ] Code is reviewed for security
