### PR TITLE
chore: Replace PR checkbox with review app

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,0 @@
-## Reviewer checks
-
-**Required fields, to be filled out by PR reviewer(s)**
-- [ ] Follows the commit message policy, appropriate for next version
-- [ ] Tested for accessibility
-- [ ] Code is reviewed for security

--- a/.github/review.yml
+++ b/.github/review.yml
@@ -1,0 +1,1 @@
+review_merges: true


### PR DESCRIPTION
This patch removes the PR template and sets up the review app in its place. If merged, I'll make the review app a required check.