### PR TITLE
feat(react): implement new tooltips, replacing rc-tooltip

### DIFF
--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -65,7 +65,7 @@ class Demo extends Component {
             </thead>
             <tbody>
               {Object.entries(propDocs).map(([name, data]) => {
-                const defaultProp = defaultProps[name];
+                const defaultProp = data.defaultValue || defaultProps[name];
 
                 return (
                   <tr key={name}>

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -44,14 +44,14 @@ const DemoTooltip = () => {
         <Button secondary buttonRef={left}>
           Left
         </Button>
-        <Tooltip target={left} placement="left" show>
+        <Tooltip target={left} placement="left">
           On your left
         </Tooltip>
 
         <Button secondary buttonRef={right}>
           Right
         </Button>
-        <Tooltip target={right} placement="right" show>
+        <Tooltip target={right} placement="right">
           On your right
         </Tooltip>
       </div>

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -44,14 +44,14 @@ const DemoTooltip = () => {
         <Button secondary buttonRef={left}>
           Left
         </Button>
-        <Tooltip target={left} placement="left">
+        <Tooltip target={left} placement="left" show>
           On your left
         </Tooltip>
 
         <Button secondary buttonRef={right}>
           Right
         </Button>
-        <Tooltip target={right} placement="right">
+        <Tooltip target={right} placement="right" show>
           On your right
         </Tooltip>
       </div>

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -1,78 +1,173 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import Demo from '../../../Demo';
 import { Tooltip, Button, Code } from '@deque/cauldron-react/';
 import './index.css';
 
-const Demo = () => (
-  <div className="tooltip-demo">
-    <h1>Tooltip</h1>
-    <h2>Demo</h2>
-    <Tooltip overlay={<span>Tooltip aligned above trigger</span>} id="tool-top">
-      <Button secondary aria-describedby="tool-top">
-        Top
-      </Button>
-    </Tooltip>
-    <Tooltip
-      overlay={<span>Tooltip aligned to the right of trigger</span>}
-      id="tool-right"
-      placement="right"
-    >
-      <Button secondary aria-describedby="tool-right">
-        Right
-      </Button>
-    </Tooltip>
-    <Tooltip
-      overlay={<span>Tooltip aligned below the trigger</span>}
-      id="tool-bottom"
-      placement="bottom"
-    >
-      <Button secondary aria-describedby="tool-bottom">
-        Bottom
-      </Button>
-    </Tooltip>
-    <Tooltip
-      overlay={<span>Tooltip aligned to the left of trigger</span>}
-      id="tool-left"
-      placement="left"
-    >
-      <Button secondary aria-describedby="tool-left">
-        Left
-      </Button>
-    </Tooltip>
-    <p>
-      These tooltips
-      <Tooltip
-        overlay={
-          <span>
-            Adjusts alignment automatically based on available space in the
-            viewport.
-          </span>
-        }
-        id="tool-definition"
-      >
-        <span className="DefinitionButton">
-          <button aria-describedby="tool-definition">auto-adjust</button>
-        </span>
-      </Tooltip>
-      , so you do not have to worry about offscreen tooltips!
-    </p>
-    <h2>Code Sample</h2>
-    <Code language="javascript">
-      {`
-import React from 'react';
+const DemoTooltip = () => {
+  const top = useRef();
+  const bottom = useRef();
+  const left = useRef();
+  const right = useRef();
+  const topInfo = useRef();
+  const bottomInfo = useRef();
+  const leftInfo = useRef();
+  const rightInfo = useRef();
+
+  return (
+    <div className="tooltip-demo">
+      <h1>Tooltip</h1>
+
+      <p>
+        Cauldron's Tooltip relies on <a href="https://popper.js.org/">Popper</a>{' '}
+        to position tooltips dynamically.
+      </p>
+
+      <h2>Demo</h2>
+
+      <h3>Text Tooltips</h3>
+
+      <div>
+        <Button secondary buttonRef={top}>
+          Top
+        </Button>
+        <Tooltip target={top} placement="top">
+          On top
+        </Tooltip>
+
+        <Button secondary buttonRef={bottom}>
+          Bottom
+        </Button>
+        <Tooltip target={bottom} placement="bottom">
+          On bottom
+        </Tooltip>
+
+        <Button secondary buttonRef={left}>
+          Left
+        </Button>
+        <Tooltip target={left} placement="left">
+          On your left
+        </Tooltip>
+
+        <Button secondary buttonRef={right}>
+          Right
+        </Button>
+        <Tooltip target={right} placement="right">
+          On your right
+        </Tooltip>
+      </div>
+
+      <h3>Info Tooltips</h3>
+
+      <div>
+        <Button secondary buttonRef={topInfo}>
+          Top
+        </Button>
+        <Tooltip variant="info" target={topInfo} placement="top">
+          Here's an informational tooltip with more content on top.
+        </Tooltip>
+
+        <Button secondary buttonRef={bottomInfo}>
+          Bottom
+        </Button>
+        <Tooltip variant="info" target={bottomInfo} placement="bottom">
+          Here's an informational tooltip with more content on bottom.
+        </Tooltip>
+
+        <Button secondary buttonRef={leftInfo}>
+          Left
+        </Button>
+        <Tooltip variant="info" target={leftInfo} placement="left">
+          Here's an informational tooltip with more content on your left.
+        </Tooltip>
+
+        <Button secondary buttonRef={rightInfo}>
+          Right
+        </Button>
+        <Tooltip variant="info" target={rightInfo} placement="right">
+          Here's an informational tooltip with more content on your right.
+        </Tooltip>
+      </div>
+
+      <h2>Code Samples</h2>
+      <Code language="javascript">
+        {`import React from 'react';
 import { Tooltip, Button } from '@deque/cauldron-react';
 
-const Demo = () => (
-  <Tooltip
-    overlay={<span>Tooltip content (I align to the right of the trigger!)</span>}
-    id='tooltip-demo'
-    placement='right'
-  >
-    <Button secondary aria-describedby='tooltip-demo'>Tooltip trigger</Button>
-  </Tooltip>
-);
-      `}
-    </Code>
-  </div>
-);
+const Demo = () => {
+  const tooltipTargetRef = useRef()
+  const tooltipInfoTargetRef = useRef()
+  return (
+    <div>
+      <Button buttonRef={tooltipTargetRef}>Tooltip trigger</Button>
+      <Tooltip target={tooltipTargetRef} placement="right">
+        Tooltip content (I align to the right of the trigger!)
+      </Tooltip>
 
-export default Demo;
+      <Button buttonRef={tooltipInfoTargetRef}>Tooltip trigger</Button>
+      <Tooltip target={tooltipInfoTargetRef} placement="right" variant="info">
+        Tooltip content (I align to the right of the trigger!)
+      </Tooltip>
+    </div>
+  )
+};`}
+      </Code>
+
+      <p>
+        <code>&lt;Tooltip /&gt;</code> will auto-generate <code>id</code> for
+        the tooltip and <code>aria-describedby</code> for the target if no id is
+        provided for the tooltip. For more fine-tuned control of the target
+        description, you can provide your own <code>id</code> and{' '}
+        <code>aria-describedby</code> attributes.
+      </p>
+
+      <Code language="javascript">
+        {`<Button 
+  aria-describedby="tooltip someotherid" 
+  buttonRef={ref}
+>
+  Tooltip trigger
+</Button>
+<Tooltip id="tooltip" target={ref}>
+  Tooltip content
+</Tooltip>`}
+      </Code>
+
+      <Demo
+        component={Tooltip}
+        states={[]}
+        propDocs={{
+          target: {
+            type: 'Ref | HTMLElement',
+            description: 'The target element to attach the tooltip to.',
+            required: true
+          },
+          show: {
+            type: 'boolean',
+            description: 'Manually control the show state of the tooltip'
+          },
+          placement: {
+            type: 'string',
+            description:
+              'The position of the tooltip relative to its target element.',
+            required: false,
+            defaultValue: "'auto'"
+          },
+          variant: {
+            type: 'string',
+            description: 'The style of tooltip to display.',
+            required: false,
+            defaultValue: "'text'"
+          },
+          portal: {
+            type: 'Ref | HTMLElement',
+            description: 'The parent element to place the Tooltip in.',
+            required: false,
+            defaultValue: 'document.body'
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default DemoTooltip;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,15 +17,16 @@
     "test": "jest --maxWorkers=1 --coverage"
   },
   "dependencies": {
+    "@popperjs/core": "^2.5.4",
     "classnames": "^2.2.6",
     "focus-trap-react": "^3.0.5",
     "focusable": "^2.3.0",
     "keyname": "^0.1.0",
     "prop-types": "^15.6.0",
-    "rc-tooltip": "^3.7.2",
+    "react-id-generator": "^3.0.1",
+    "react-popper": "^2.2.4",
     "react-syntax-highlighter": "^13.5.1",
-    "tslib": "^2.0.0",
-    "unique-string": "^1.0.0"
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -8,8 +8,8 @@ import { usePopper } from 'react-popper';
 
 export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  variant: 'text' | 'info';
-  show: boolean | undefined;
+  variant?: 'text' | 'info';
+  show?: boolean | undefined;
   placement?: Placement;
   target: React.RefObject<HTMLElement> | HTMLElement;
   portal?: React.RefObject<HTMLElement> | HTMLElement;

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -92,30 +92,30 @@ export default function Tooltip({
     }
   }, [targetElement, id]);
 
-  return (
-    showTooltip &&
-    createPortal(
-      <div
-        id={id}
-        className={classnames('Tooltip', `Tooltip--${placement}`, {
-          TooltipInfo: variant === 'info'
-        })}
-        ref={setTooltipElement}
-        role="tooltip"
-        style={styles.popper}
-        {...attributes.popper}
-        {...props}
-      >
+  return showTooltip
+    ? createPortal(
         <div
-          className="TooltipArrow"
-          ref={setArrowElement}
-          style={styles.arrow}
-        />
-        {children}
-      </div>,
-      (portal && 'current' in portal ? portal.current : portal) || document.body
-    )
-  );
+          id={id}
+          className={classnames('Tooltip', `Tooltip--${placement}`, {
+            TooltipInfo: variant === 'info'
+          })}
+          ref={setTooltipElement}
+          role="tooltip"
+          style={styles.popper}
+          {...attributes.popper}
+          {...props}
+        >
+          <div
+            className="TooltipArrow"
+            ref={setArrowElement}
+            style={styles.arrow}
+          />
+          {children}
+        </div>,
+        (portal && 'current' in portal ? portal.current : portal) ||
+          document.body
+      )
+    : null;
 }
 
 Tooltip.displayName = 'Tooltip';

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { useId } from 'react-id-generator';
-import { Placement, Modifier, popper } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 import { usePopper } from 'react-popper';
 
 export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -1,38 +1,130 @@
-import React from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
+import classnames from 'classnames';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import RcTooltip from 'rc-tooltip';
+import { useId } from 'react-id-generator';
+import { Placement, Modifier, popper } from '@popperjs/core';
+import { usePopper } from 'react-popper';
 
-export interface TooltipProps {
-  placement: string;
+export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  overlay: React.ReactNode;
-  id: string;
+  variant: 'text' | 'info';
+  show: boolean | undefined;
+  placement?: Placement;
+  target: React.RefObject<HTMLElement> | HTMLElement;
+  portal?: React.RefObject<HTMLElement> | HTMLElement;
 }
 
 export default function Tooltip({
-  placement,
+  id: propId,
+  placement: initialPlacement = 'auto',
   children,
-  overlay,
-  id
+  portal,
+  target,
+  variant = 'text',
+  show: showProp = false,
+  ...props
 }: TooltipProps) {
+  const [id] = propId ? [propId] : useId(1, 'tooltip');
+  const [placement, setPlacement] = useState(initialPlacement);
+  const [showTooltip, setShowTooltip] = useState(!!showProp);
+  const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
+  const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(
+    null
+  );
+  const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
+
+  const { styles, attributes } = usePopper(targetElement, tooltipElement, {
+    placement: initialPlacement,
+    modifiers: [
+      { name: 'preventOverflow', options: { padding: 8 } },
+      { name: 'flip' },
+      { name: 'offset', options: { offset: [0, 8] } },
+      { name: 'arrow', options: { padding: 5, element: arrowElement } }
+    ]
+  });
+
+  const show = () => setShowTooltip(true);
+  const hide = ({ target }: FocusEvent | MouseEvent) => {
+    if (document.activeElement !== target) {
+      setShowTooltip(false);
+    }
+  };
+
+  useEffect(() => {
+    const targetElement =
+      target && 'current' in target ? target.current : target;
+    setTargetElement(targetElement);
+  }, [target]);
+
+  const popperPlacement: Placement =
+    (attributes.popper &&
+      (attributes.popper['data-popper-placement'] as Placement)) ||
+    initialPlacement;
+  useEffect(() => {
+    if (popperPlacement) {
+      setPlacement(popperPlacement);
+    }
+  }, [popperPlacement]);
+
+  useEffect(() => {
+    if (typeof show !== undefined) {
+      targetElement?.addEventListener('mouseenter', show);
+      targetElement?.addEventListener('mouseleave', hide);
+      targetElement?.addEventListener('focusin', show);
+      targetElement?.addEventListener('focusout', hide);
+    }
+    return () => {
+      targetElement?.removeEventListener('mouseenter', show);
+      targetElement?.removeEventListener('mouseleave', hide);
+      targetElement?.removeEventListener('focusin', show);
+      targetElement?.removeEventListener('focusout', hide);
+    };
+  }, [targetElement, show]);
+
+  useEffect(() => {
+    const ariaDescription = targetElement?.getAttribute('aria-describedby');
+    if (!ariaDescription?.includes(id || '')) {
+      targetElement?.setAttribute(
+        'aria-describedby',
+        [id, ariaDescription].filter(Boolean).join(' ')
+      );
+    }
+  }, [targetElement, id]);
+
   return (
-    <RcTooltip
-      placement={placement}
-      trigger={['hover', 'focus']}
-      overlay={overlay}
-      overlayClassName="Tooltip"
-      id={id}
-    >
-      {children}
-    </RcTooltip>
+    showTooltip &&
+    createPortal(
+      <div
+        id={id}
+        className={classnames('Tooltip', `Tooltip--${placement}`, {
+          TooltipInfo: variant === 'info'
+        })}
+        ref={setTooltipElement}
+        role="tooltip"
+        style={styles.popper}
+        {...attributes.popper}
+        {...props}
+      >
+        <div
+          className="TooltipArrow"
+          ref={setArrowElement}
+          style={styles.arrow}
+        />
+        {children}
+      </div>,
+      (portal && 'current' in portal ? portal.current : portal) || document.body
+    )
   );
 }
 
+Tooltip.displayName = 'Tooltip';
+
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
-  overlay: PropTypes.node.isRequired,
-  id: PropTypes.string.isRequired,
-  placement: PropTypes.string
+  show: PropTypes.bool,
+  placement: PropTypes.string,
+  variant: PropTypes.string,
+  target: PropTypes.any.isRequired,
+  portal: PropTypes.any
 };
-
-Tooltip.defaultProps = { placement: 'top' };

--- a/packages/react/src/global.d.ts
+++ b/packages/react/src/global.d.ts
@@ -7,5 +7,3 @@ declare module 'focusable' {
   function focusable(): string;
   export = focusable;
 }
-
-declare module 'rc-tooltip';

--- a/packages/react/src/index.css
+++ b/packages/react/src/index.css
@@ -1,4 +1,3 @@
-@import 'rc-tooltip/assets/bootstrap_white.css';
 @import './components/ExpandCollapsePanel/index.css';
 @import './components/Link/index.css';
 @import './components/Icon/index.css';

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -1871,6 +1871,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
+  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
+
 "@rollup/plugin-commonjs@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz#4285f9ec2db686a31129e5a2b415c94aa1f836f0"
@@ -2193,13 +2198,6 @@ acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
-
-add-dom-event-listener@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz#6a92db3a0dd0abc254e095c0f1dc14acbbaae310"
-  integrity sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==
-  dependencies:
-    object-assign "4.x"
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -2549,7 +2547,7 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-babel-runtime@6.x, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3011,22 +3009,10 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-classes@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
-  integrity sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=
-  dependencies:
-    component-indexof "0.0.3"
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
-component-indexof@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
-  integrity sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3123,19 +3109,6 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-random-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
-  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
-
-css-animation@^1.3.2:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/css-animation/-/css-animation-1.6.1.tgz#162064a3b0d51f958b7ff37b3d6d4de18e17039e"
-  integrity sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==
-  dependencies:
-    babel-runtime "6.x"
-    component-classes "^1.2.5"
 
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
@@ -3389,11 +3362,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-align@^1.7.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.11.1.tgz#7592be99a660a36cdedc1d6eeb22b8109d758cae"
-  integrity sha512-hN42DmUgtweBx0iBjDLO4WtKOMcK8yBmPx/fgdsgQadLuzPu/8co3oLdK5yMmeM/vnUd3yDyV6qV8/NzxBexQg==
 
 dom-serializer@0:
   version "0.2.2"
@@ -6082,7 +6050,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.x, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -6625,7 +6593,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6678,7 +6646,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-raf@^3.4.0, raf@^3.4.1:
+raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -6697,62 +6665,6 @@ randexp@0.4.6:
   dependencies:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
-
-rc-align@^2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.4.5.tgz#c941a586f59d1017f23a428f0b468663fb7102ab"
-  integrity sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==
-  dependencies:
-    babel-runtime "^6.26.0"
-    dom-align "^1.7.0"
-    prop-types "^15.5.8"
-    rc-util "^4.0.4"
-
-rc-animate@2.x:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.11.1.tgz#2666eeb6f1f2a495a13b2af09e236712278fdb2c"
-  integrity sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.6"
-    css-animation "^1.3.2"
-    prop-types "15.x"
-    raf "^3.4.0"
-    rc-util "^4.15.3"
-    react-lifecycles-compat "^3.0.4"
-
-rc-tooltip@^3.7.2:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.3.tgz#280aec6afcaa44e8dff0480fbaff9e87fc00aecc"
-  integrity sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==
-  dependencies:
-    babel-runtime "6.x"
-    prop-types "^15.5.8"
-    rc-trigger "^2.2.2"
-
-rc-trigger@^2.2.2:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-2.6.5.tgz#140a857cf28bd0fa01b9aecb1e26a50a700e9885"
-  integrity sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.6"
-    prop-types "15.x"
-    rc-align "^2.4.0"
-    rc-animate "2.x"
-    rc-util "^4.4.0"
-    react-lifecycles-compat "^3.0.4"
-
-rc-util@^4.0.4, rc-util@^4.15.3, rc-util@^4.4.0:
-  version "4.20.5"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.5.tgz#f7c77569e971ae6a8ad56f899cadd22275398325"
-  integrity sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==
-  dependencies:
-    add-dom-event-listener "^1.1.0"
-    prop-types "^15.5.10"
-    react-is "^16.12.0"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
 
 react-dom@^16.13.1:
   version "16.13.1"
@@ -6777,6 +6689,11 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-helmet@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.0.0.tgz#fcb93ebaca3ba562a686eb2f1f9d46093d83b5f8"
@@ -6787,15 +6704,23 @@ react-helmet@^6.0.0:
     react-fast-compare "^2.0.4"
     react-side-effect "^2.1.0"
 
+react-id-generator@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-id-generator/-/react-id-generator-3.0.1.tgz#30ec683954b3c0a5aa0732c4b98ed0f88fd85d00"
+  integrity sha512-YxorMaYxB8ItXA3Cuadcl/8ZaquU9Tzrrr5ogFL8tNqevF96cmCtx3LZLXYqBEj3BxoV9aBIK5yJjIuX/XHQ1A==
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+react-popper@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
+  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-router-dom@^5.1.2:
   version "5.1.2"
@@ -6831,10 +6756,10 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
   integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
-react-syntax-highlighter@13:
-  version "13.5.1"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.1.tgz#f21737cf6d582474a0f18b06b52613f4349c0e64"
-  integrity sha512-VVYTnFXF55WMRGdr3QNEzAzcypFZqH45kS7rqh90+AFeNGtui8/gV5AIOIJjwTsuP2UxcO9qvEq94Jq9BYFUhw==
+react-syntax-highlighter@^13.5.1:
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz#9712850f883a3e19eb858cf93fad7bb357eea9c6"
+  integrity sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "^10.1.1"
@@ -7361,11 +7286,6 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -8030,13 +7950,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-unique-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
-  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
-  dependencies:
-    crypto-random-string "^1.0.0"
-
 universalify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
@@ -8144,6 +8057,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"

--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -1,5 +1,6 @@
 .Tooltip {
   background-color: var(--tooltip-background-color);
+  border: 2px solid var(--tooltip-border-color);
   color: var(--tooltip-text-color);
   font-size: var(--text-size-smaller);
   padding: var(--space-half) var(--space-small);
@@ -44,24 +45,45 @@
 .TooltipArrow:before {
   content: '';
   position: absolute;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 7px solid var(--tooltip-border-color);
+  border-bottom: none;
+  transform: translateX(-50%);
+  transform-origin: top;
+}
+
+.TooltipArrow:after {
+  content: '';
+  position: absolute;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 5px solid var(--tooltip-background-color);
   border-bottom: none;
-  transform-origin: top;
+  z-index: 1;
   transform: translateX(-50%);
+  transform-origin: top;
 }
 
+[class*='Tooltip--bottom'] .TooltipArrow:after,
 [class*='Tooltip--bottom'] .TooltipArrow:before {
   transform: translateX(-50%) rotate(180deg);
 }
 
+[class*='Tooltip--left'] .TooltipArrow:after {
+  transform: rotate(-90deg) translateY(-5px);
+}
+
 [class*='Tooltip--left'] .TooltipArrow:before {
-  transform: rotate(-90deg) translateY(-4px) translateX(-1px);
+  transform: rotate(-90deg) translateY(-6px);
+}
+
+[class*='Tooltip--right'] .TooltipArrow:after {
+  transform: rotate(90deg) translateY(4px);
 }
 
 [class*='Tooltip--right'] .TooltipArrow:before {
-  transform: rotate(90deg) translateY(4px) translateX(1px);
+  transform: rotate(90deg) translateY(100%);
 }
 
 /*
@@ -72,21 +94,12 @@
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
   border-top: 7px solid var(--tooltip-info-border-color);
-  border-bottom: none;
-  transform: translateX(-50%);
-  transform-origin: top;
 }
 
 .TooltipInfo .TooltipArrow:after {
-  content: '';
-  position: absolute;
   border-left: 3px solid transparent;
   border-right: 3px solid transparent;
   border-top: 4px solid var(--tooltip-info-background-color);
-  border-bottom: none;
-  z-index: 1;
-  transform: translateX(-50%);
-  transform-origin: top;
 }
 
 .TooltipInfo[class*='Tooltip--bottom'] .TooltipArrow:after,

--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -4,7 +4,7 @@
   color: var(--tooltip-text-color);
   font-size: var(--text-size-smaller);
   padding: var(--space-half) var(--space-small);
-  border-radius: 3px;
+  border-radius: 4px;
   pointer-events: none;
   z-index: var(--z-index-tooltip);
 }

--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -1,95 +1,111 @@
 .Tooltip {
-  opacity: 1;
+  background-color: var(--tooltip-background-color);
+  color: var(--tooltip-text-color);
+  font-size: var(--text-size-smaller);
+  padding: var(--space-half) var(--space-small);
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: var(--z-index-tooltip);
 }
 
-/* NOTE: the rc-tooltip-* classes come from the
- * rc-tooltip module that is used under-the-hood
+.TooltipInfo {
+  background-color: var(--tooltip-info-background-color);
+  border: 2px solid var(--tooltip-info-border-color);
+  color: var(--tooltip-info-text-color);
+  max-width: 12.5rem;
+}
+
+/* TooltipArrow needs some dimensions to accurately calculate its positioning */
+.TooltipArrow {
+  height: 0.1px;
+  width: 0.1px;
+}
+
+[class*='Tooltip--top'] .TooltipArrow {
+  bottom: 0;
+}
+
+[class*='Tooltip--bottom'] .TooltipArrow {
+  top: 0;
+}
+
+[class*='Tooltip--left'] .TooltipArrow {
+  right: 0;
+}
+
+[class*='Tooltip--right'] .TooltipArrow {
+  left: 0;
+}
+
+/*
+ * Default tooltip arrow styles
  */
 
-.Tooltip .rc-tooltip-inner {
-  box-shadow: 0px 0px 2px 1px rgba(0, 0, 0, 0.3);
-  min-width: 145px;
-  max-width: 200px;
-  box-sizing: border-box;
-  border: 1px solid #999999;
-  border-radius: 2px;
-  font-size: 12px;
-  background: #f2f2f2;
-  padding: 8px;
-  z-index: 9;
-  word-break: break-word;
-}
-
-.Tooltip .rc-tooltip-arrow {
-  z-index: 10;
-}
-
-.Tooltip .rc-tooltip-arrow::before {
+.TooltipArrow:before {
   content: '';
   position: absolute;
-  width: 0;
-  height: 0;
-  border-style: solid;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--tooltip-background-color);
+  border-bottom: none;
+  transform-origin: top;
+  transform: translateX(-50%);
 }
 
-/* ALIGNED TOP */
-.Tooltip.rc-tooltip-placement-top .rc-tooltip-arrow {
-  border-width: 7.8px 4.5px 0 4.5px;
-  margin-left: -4.5px;
-  bottom: -6px;
-  border-top-color: #4d4d4d;
+[class*='Tooltip--bottom'] .TooltipArrow:before {
+  transform: translateX(-50%) rotate(180deg);
 }
 
-.Tooltip.rc-tooltip-placement-top .rc-tooltip-arrow::before {
-  left: 50%;
-  bottom: 1px;
-  margin-left: -4.5px;
-  border-width: 7.8px 4.5px 0 4.5px;
-  border-color: #f2f2f2 transparent transparent transparent;
+[class*='Tooltip--left'] .TooltipArrow:before {
+  transform: rotate(-90deg) translateY(-4px) translateX(-1px);
 }
 
-/* ALIGNED LEFT */
-.Tooltip.rc-tooltip-placement-left .rc-tooltip-arrow {
-  border-width: 4.5px 0 4.5px 7.8px;
-  right: -6px;
-  border-left-color: #4d4d4d;
+[class*='Tooltip--right'] .TooltipArrow:before {
+  transform: rotate(90deg) translateY(4px) translateX(1px);
 }
 
-.Tooltip.rc-tooltip-placement-left .rc-tooltip-arrow::before {
-  left: 50%;
-  bottom: -4.5px;
-  margin-left: -8.5px;
-  border-width: 4.5px 0 4.5px 7.8px;
-  border-color: transparent transparent transparent #f2f2f2;
+/*
+ * Info tooltip arrow styles
+ */
+
+.TooltipInfo .TooltipArrow:before {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 7px solid var(--tooltip-info-border-color);
+  border-bottom: none;
+  transform: translateX(-50%);
+  transform-origin: top;
 }
 
-/* ALIGNED RIGHT */
-.Tooltip.rc-tooltip-placement-right .rc-tooltip-arrow {
-  border-width: 4.5px 7.8px 4.5px 0;
-  margin-left: -1px;
-  margin-top: -4.5px;
-  border-right-color: #4d4d4d;
+.TooltipInfo .TooltipArrow:after {
+  content: '';
+  position: absolute;
+  border-left: 3px solid transparent;
+  border-right: 3px solid transparent;
+  border-top: 4px solid var(--tooltip-info-background-color);
+  border-bottom: none;
+  z-index: 1;
+  transform: translateX(-50%);
+  transform-origin: top;
 }
 
-.Tooltip.rc-tooltip-placement-right .rc-tooltip-arrow::before {
-  left: 50%;
-  bottom: -4.5px;
-  margin-left: 1.5px;
-  border-width: 4.5px 7.8px 4.5px 0;
-  border-color: transparent #f2f2f2 transparent transparent;
+.TooltipInfo[class*='Tooltip--bottom'] .TooltipArrow:after,
+.TooltipInfo[class*='Tooltip--bottom'] .TooltipArrow:before {
+  transform: translateX(-50%) rotate(180deg);
 }
 
-/* ALIGNED BOTTOM */
-.Tooltip.rc-tooltip-placement-bottom .rc-tooltip-arrow {
-  border-width: 0 4.5px 7.8px 4.5px;
-  border-bottom-color: #4d4d4d;
-  margin-top: -1px;
+.TooltipInfo[class*='Tooltip--left'] .TooltipArrow:after {
+  transform: rotate(-90deg) translateY(-3px);
 }
 
-.Tooltip.rc-tooltip-placement-bottom .rc-tooltip-arrow::before {
-  left: 50%;
-  margin-left: -4.5px;
-  margin-top: 0.5px;
-  border-width: 0 4.5px 7.8px 4.5px;
-  border-color: transparent transparent #f2f2f2 transparent;
+.TooltipInfo[class*='Tooltip--left'] .TooltipArrow:before {
+  transform: rotate(-90deg) translateY(-6px);
+}
+
+.TooltipInfo[class*='Tooltip--right'] .TooltipArrow:after {
+  transform: rotate(90deg) translateY(3px);
+}
+
+.TooltipInfo[class*='Tooltip--right'] .TooltipArrow:before {
+  transform: rotate(90deg) translateY(6px);
 }

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -51,7 +51,11 @@
   --button-focus-ring-color: #c11bde;
 
   /* tooltips */
-  --tooltip-border-color: #999999;
+  --tooltip-background-color: #333;
+  --tooltip-text-color: #f2f2f2;
+  --tooltip-info-background-color: #f2f2f2;
+  --tooltip-info-border-color: #333;
+  --tooltip-info-text-color: #333;
 
   /* borders */
   --top-bar-menuitem-separator: rgba(255, 255, 255, 0.4);

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -52,6 +52,7 @@
 
   /* tooltips */
   --tooltip-background-color: #333;
+  --tooltip-border-color: #fff;
   --tooltip-text-color: #f2f2f2;
   --tooltip-info-background-color: #f2f2f2;
   --tooltip-info-border-color: #333;


### PR DESCRIPTION
BREAKING CHANGE:
The api for for implementing a tooltip has changed.

Instead of `<Tooltip><button /><Tooltip>`, the tooltip takes a target ref or html element. 

```jsx
<Tooltip target={ref}>tooltip</Tooltip>
<button ref={ref}>button</button>
```

Closes #113 