### PR TITLE
feat: support any node type in toast children

### DIFF
--- a/packages/react/__tests__/src/components/Toast/index.js
+++ b/packages/react/__tests__/src/components/Toast/index.js
@@ -57,6 +57,16 @@ test('handles transition from truthy show to falsey show prop', done => {
   }); // wait for animation timeouts / async setState calls
 });
 
+test('renders children within the "Toast__message-content" div', () => {
+  const wrapper = mount(
+    <Toast {...defaultProps} show={true}>
+      <strong>YO!</strong>
+    </Toast>
+  );
+
+  expect(wrapper.find('.Toast__message-content strong').text()).toBe('YO!');
+});
+
 test('confirmation renders the expected UI and icon', () => {
   const confirmation = mount(
     <Toast {...defaultProps} show={true}>

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -31,11 +31,7 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
 
   static propTypes = {
     // the ui to be added as the message of the toast
-    children: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-      PropTypes.array
-    ]).isRequired,
+    children: PropTypes.node.isRequired,
     // "confirmation", "caution", or "action-needed"
     type: PropTypes.string.isRequired,
     // function to be exectued when toast is dismissed
@@ -110,7 +106,7 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
         >
           <div className="Toast__message">
             <Icon type={typeMap[type].icon} />
-            <span>{children}</span>
+            <div className="Toast__message-content">{children}</div>
           </div>
           {type !== 'action-needed' && (
             <button

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -49,7 +49,7 @@
   align-items: center;
 }
 
-.Toast__message > span {
+.Toast__message .Toast__message-content {
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
 }
@@ -78,6 +78,6 @@
   outline: 0;
 }
 
-.Toast:focus .Toast__message > span {
+.Toast:focus .Toast__message > .Toast__message-content {
   border-bottom-color: var(--top-bar-background-color-active);
 }


### PR DESCRIPTION
BREAKING CHANGE: children are no longer rendered within a direct-child span element