### PR TITLE
fix(react): directly import Light syntax highlighter to avoid side effects and limit the number of languages bundled

### DIFF
--- a/packages/react/__tests__/reactSyntaxHighlighterMock.js
+++ b/packages/react/__tests__/reactSyntaxHighlighterMock.js
@@ -1,0 +1,3 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Light } = require('react-syntax-highlighter');
+module.exports = Light;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -114,6 +114,7 @@
     ],
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/__tests__/styleMock.js",
+      "react-syntax-highlighter/dist/esm/light": "<rootDir>/__tests__/reactSyntaxHighlighterMock.js",
       "react-syntax-highlighter/dist/esm/languages/hljs/(.*)": "<rootDir>/__tests__/hljsMock.js",
       "\\.svg$": "<rootDir>/__tests__/svgMock.js"
     }

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Light as SyntaxHighlighter,
-  SyntaxHighlighterProps
-} from 'react-syntax-highlighter';
+import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light';
 import classNames from 'classnames';
 import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
 import css from 'react-syntax-highlighter/dist/esm/languages/hljs/css';


### PR DESCRIPTION
It looks like the [default recommendation](https://github.com/react-syntax-highlighter/react-syntax-highlighter#light-build) for `react-syntax-highlighter` to create a light build is _still_ importing all of the languages, greatly increasing the bundle size:

<details>
  <summary>before webpack bundle (~1mb)</summary>

![webpack bundle analyzer results for webpack build](https://user-images.githubusercontent.com/1062039/99990799-e3bc6700-2d79-11eb-83f1-3f293318fb46.png)

</details>

Directly importing the `Light` module should greatly reduce the size and avoid side effects.