### PR TITLE
 fix(react): allow tooltip to be hidden on escape keypress

### DIFF
--- a/packages/react/__tests__/src/components/Tooltip/index.js
+++ b/packages/react/__tests__/src/components/Tooltip/index.js
@@ -60,6 +60,22 @@ test('should not overwrite user provided id and aria-describedby', async () => {
   ).toEqual('foo tooltipid');
 });
 
+test('should hide tooltip on escape keypress', async () => {
+  const wrapper = mount(<Wrapper />);
+  await update(wrapper);
+  expect(wrapper.find('.Tooltip').exists).toBeTruthy();
+  await act(async () => {
+    document.body.dispatchEvent(
+      new KeyboardEvent('keyup', {
+        bubbles: true,
+        key: 'Escape'
+      })
+    );
+  });
+  await update(wrapper);
+  expect(wrapper.find('.Tooltip').exists()).toBeFalsy();
+});
+
 test('should return no axe violations', async () => {
   const wrapper = mount(<Wrapper />);
   await update(wrapper);

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -82,7 +82,11 @@ export default function Tooltip({
 
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (
+        event.key === 'Escape' ||
+        event.key === 'Esc' ||
+        event.keyCode === 27
+      ) {
         setShowTooltip(false);
       }
     };

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -81,6 +81,24 @@ export default function Tooltip({
   }, [popperPlacement]);
 
   useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowTooltip(false);
+      }
+    };
+
+    if (showTooltip) {
+      document.body.addEventListener('keyup', handleEscape);
+    } else {
+      document.body.removeEventListener('keyup', handleEscape);
+    }
+
+    return () => {
+      document.body.removeEventListener('keyup', handleEscape);
+    };
+  }, [show]);
+
+  useEffect(() => {
     if (typeof show !== undefined) {
       targetElement?.addEventListener('mouseenter', show);
       targetElement?.addEventListener('mouseleave', hide);

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -87,14 +87,15 @@ export default function Tooltip({
       }
     };
 
+    const targetElement = document.body;
     if (showTooltip) {
-      document.body.addEventListener('keyup', handleEscape);
+      targetElement.addEventListener('keyup', handleEscape);
     } else {
-      document.body.removeEventListener('keyup', handleEscape);
+      targetElement.removeEventListener('keyup', handleEscape);
     }
 
     return () => {
-      document.body.removeEventListener('keyup', handleEscape);
+      targetElement.removeEventListener('keyup', handleEscape);
     };
   }, [show]);
 


### PR DESCRIPTION
This addresses the dismissable portion of [WCAG 2.1 - 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html). 