### PR TITLE
feat(button): handle style icons as children inside of buttons

### DIFF
--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -65,7 +65,8 @@ class Demo extends Component {
             </thead>
             <tbody>
               {Object.entries(propDocs).map(([name, data]) => {
-                const defaultProp = data.defaultValue || defaultProps[name];
+                const defaultProp =
+                  data.defaultValue || defaultProps[name] || data.default;
 
                 return (
                   <tr key={name}>

--- a/docs/patterns/components/Button/index.js
+++ b/docs/patterns/components/Button/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import Demo from '../../../Demo';
 import { Button, Icon } from '@deque/cauldron-react/';
 import { children, className } from '../../../props';
@@ -11,11 +11,22 @@ const ButtonDemo = () => (
         { children: 'Primary' },
         { children: 'Primary Disabled', disabled: true },
         { children: 'Primary thin', thin: true },
-        { children: 'Primary Icon', startIcon: <Icon type="plus" /> },
         {
-          children: 'Primary Icon thin',
-          thin: true,
-          startIcon: <Icon type="plus" />
+          children: (
+            <>
+              <Icon type="plus" />
+              Primary Icon
+            </>
+          )
+        },
+        {
+          children: (
+            <>
+              <Icon type="plus" />
+              Primary Icon thin
+            </>
+          ),
+          thin: true
         },
         { children: 'Secondary', variant: 'secondary' },
         {
@@ -25,15 +36,23 @@ const ButtonDemo = () => (
         },
         { children: 'Secondary thin', variant: 'secondary', thin: true },
         {
-          children: 'Secondary Icon',
-          variant: 'secondary',
-          endIcon: <Icon type="plus" style={{ fill: '#222' }} />
+          children: (
+            <>
+              Secondary Icon
+              <Icon type="plus" style={{ fill: '#222' }} />
+            </>
+          ),
+          variant: 'secondary'
         },
         {
-          children: 'Secondary Icon thin',
+          children: (
+            <>
+              Secondary Icon thin
+              <Icon type="plus" style={{ fill: '#222' }} />
+            </>
+          ),
           thin: true,
-          variant: 'secondary',
-          endIcon: <Icon type="plus" style={{ fill: '#222' }} />
+          variant: 'secondary'
         },
         { children: 'Error', variant: 'error' },
         { children: 'Error Disabled', variant: 'error', disabled: true },
@@ -57,16 +76,6 @@ const ButtonDemo = () => (
           type: 'boolean',
           description:
             'render button with "thin" modifier (reduces height of button)'
-        },
-        startIcon: {
-          type: 'node',
-          description:
-            'Add an <Icon type="plus"/> to be displayed before the button text'
-        },
-        endIcon: {
-          type: 'node',
-          description:
-            'Add an <Icon type="pencil"/> to be displayed after the button text'
         }
       }}
     />

--- a/docs/patterns/components/Button/index.js
+++ b/docs/patterns/components/Button/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Button } from '@deque/cauldron-react/';
+import { Button, Icon } from '@deque/cauldron-react/';
 import { children, className } from '../../../props';
 
 const ButtonDemo = () => (
@@ -11,6 +11,12 @@ const ButtonDemo = () => (
         { children: 'Primary' },
         { children: 'Primary Disabled', disabled: true },
         { children: 'Primary thin', thin: true },
+        { children: 'Primary Icon', startIcon: <Icon type="plus" /> },
+        {
+          children: 'Primary Icon thin',
+          thin: true,
+          startIcon: <Icon type="plus" />
+        },
         { children: 'Secondary', variant: 'secondary' },
         {
           children: 'Secondary Disabled',
@@ -18,6 +24,17 @@ const ButtonDemo = () => (
           disabled: true
         },
         { children: 'Secondary thin', variant: 'secondary', thin: true },
+        {
+          children: 'Secondary Icon',
+          variant: 'secondary',
+          endIcon: <Icon type="plus" style={{ fill: '#222' }} />
+        },
+        {
+          children: 'Secondary Icon thin',
+          thin: true,
+          variant: 'secondary',
+          endIcon: <Icon type="plus" style={{ fill: '#222' }} />
+        },
         { children: 'Error', variant: 'error' },
         { children: 'Error Disabled', variant: 'error', disabled: true },
         { children: 'Error thin', variant: 'error', thin: true },
@@ -40,6 +57,16 @@ const ButtonDemo = () => (
           type: 'boolean',
           description:
             'render button with "thin" modifier (reduces height of button)'
+        },
+        startIcon: {
+          type: 'node',
+          description:
+            'Add an <Icon type="plus"/> to be displayed before the button text'
+        },
+        endIcon: {
+          type: 'node',
+          description:
+            'Add an <Icon type="pencil"/> to be displayed after the button text'
         }
       }}
     />

--- a/packages/react/__tests__/src/components/Button/index.js
+++ b/packages/react/__tests__/src/components/Button/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { shallow } from 'enzyme';
 import Button from 'src/components/Button';
 import Icon from 'src/components/Icon';
@@ -26,30 +26,32 @@ test('should render button as link', () => {
   expect(button.hasClass('Link')).toBe(true);
 });
 
-test('should handle "startIcon" modifier', () => {
+test('should handle <Icon /> as child', () => {
   const button = shallow(
-    <Button startIcon={<Icon type="trash" />}>Delete</Button>
+    <Button>
+      <Icon type="trash" />
+      Delete
+    </Button>
   );
-  expect(
-    button.contains(
-      <span className="Button--start-icon">
-        <Icon type="trash" />
-      </span>
-    )
-  ).toBe(true);
+  expect(button.contains(<Icon type="trash" />)).toBe(true);
 });
 
-test('should handle "endIcon" modifier', () => {
-  const button = shallow(
-    <Button endIcon={<Icon type="trash" />}>Delete</Button>
+test('should console.warn if buttonRef prop is used', () => {
+  const originalWarn = console.warn;
+  const consoleOutput = [];
+  const mockedWarn = jest.fn(output => consoleOutput.push(output));
+  const btnRef = createRef();
+  console.warn = mockedWarn;
+
+  shallow(<Button buttonRef={btnRef}>Delete</Button>);
+
+  expect(mockedWarn).toBeCalledTimes(1);
+  expect(consoleOutput[0]).toBe(
+    "%c Warning: 'buttonRef' prop is deprecated, please use 'ref'. "
   );
-  expect(
-    button.contains(
-      <span className="Button--end-icon">
-        <Icon type="trash" />
-      </span>
-    )
-  ).toBe(true);
+
+  // reset
+  console.warn = originalWarn;
 });
 
 test('should handle "thin" modifier', () => {
@@ -62,7 +64,10 @@ test('should return no axe violations', async () => {
   const button = shallow(<Button variant="primary">primary</Button>);
   const buttonLink = shallow(<Button variant="link">link</Button>);
   const iconButton = shallow(
-    <Button startIcon={<Icon type="bolt" />}>scan</Button>
+    <Button>
+      <Icon type="bolt" />
+      scan
+    </Button>
   );
 
   expect(await axe(defaultButton.html())).toHaveNoViolations();

--- a/packages/react/__tests__/src/components/Button/index.js
+++ b/packages/react/__tests__/src/components/Button/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Button from 'src/components/Button';
+import Icon from 'src/components/Icon';
 import axe from '../../../axe';
 
 test('should render primary button', () => {
@@ -25,6 +26,32 @@ test('should render button as link', () => {
   expect(button.hasClass('Link')).toBe(true);
 });
 
+test('should handle "startIcon" modifier', () => {
+  const button = shallow(
+    <Button startIcon={<Icon type="trash" />}>Delete</Button>
+  );
+  expect(
+    button.contains(
+      <span className="Button--start-icon">
+        <Icon type="trash" />
+      </span>
+    )
+  ).toBe(true);
+});
+
+test('should handle "endIcon" modifier', () => {
+  const button = shallow(
+    <Button endIcon={<Icon type="trash" />}>Delete</Button>
+  );
+  expect(
+    button.contains(
+      <span className="Button--end-icon">
+        <Icon type="trash" />
+      </span>
+    )
+  ).toBe(true);
+});
+
 test('should handle "thin" modifier', () => {
   const button = shallow(<Button thin>link</Button>);
   expect(button.hasClass('Button--thin')).toBe(true);
@@ -34,8 +61,12 @@ test('should return no axe violations', async () => {
   const defaultButton = shallow(<Button>primary</Button>);
   const button = shallow(<Button variant="primary">primary</Button>);
   const buttonLink = shallow(<Button variant="link">link</Button>);
+  const iconButton = shallow(
+    <Button startIcon={<Icon type="bolt" />}>scan</Button>
+  );
 
   expect(await axe(defaultButton.html())).toHaveNoViolations();
   expect(await axe(button.html())).toHaveNoViolations();
   expect(await axe(buttonLink.html())).toHaveNoViolations();
+  expect(await axe(iconButton.html())).toHaveNoViolations();
 });

--- a/packages/react/__tests__/src/components/Button/index.js
+++ b/packages/react/__tests__/src/components/Button/index.js
@@ -36,24 +36,6 @@ test('should handle <Icon /> as child', () => {
   expect(button.contains(<Icon type="trash" />)).toBe(true);
 });
 
-test('should console.warn if buttonRef prop is used', () => {
-  const originalWarn = console.warn;
-  const consoleOutput = [];
-  const mockedWarn = jest.fn(output => consoleOutput.push(output));
-  const btnRef = createRef();
-  console.warn = mockedWarn;
-
-  shallow(<Button buttonRef={btnRef}>Delete</Button>);
-
-  expect(mockedWarn).toBeCalledTimes(1);
-  expect(consoleOutput[0]).toBe(
-    "%c Warning: 'buttonRef' prop is deprecated, please use 'ref'. "
-  );
-
-  // reset
-  console.warn = originalWarn;
-});
-
 test('should handle "thin" modifier', () => {
   const button = shallow(<Button thin>link</Button>);
   expect(button.hasClass('Button--thin')).toBe(true);

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,42 +1,16 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import classNames from 'classnames';
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'error' | 'link';
-  buttonRef?: React.Ref<HTMLButtonElement>;
-  disabled?: boolean; // todo, investigate why disabled is needed
   thin?: boolean;
 }
 
-export default class Button extends React.Component<ButtonProps> {
-  static defaultProps = {
-    variant: 'primary',
-    buttonRef: () => {}
-  };
-
-  static propTypes = {
-    variant: PropTypes.oneOf(['primary', 'secondary', 'error', 'link']),
-    children: PropTypes.node,
-    className: PropTypes.string,
-    buttonRef: PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.shape({ current: PropTypes.any })
-    ])
-  };
-
-  static displayName = 'Button';
-
-  render() {
-    const {
-      variant,
-      children,
-      className,
-      buttonRef,
-      thin,
-      ...other
-    } = this.props;
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { variant = 'primary', thin, children, className, ...other }: ButtonProps,
+    buttonRef
+  ) => {
     return (
       <button
         type={'button'}
@@ -54,4 +28,8 @@ export default class Button extends React.Component<ButtonProps> {
       </button>
     );
   }
-}
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,16 +1,40 @@
-import React, { ButtonHTMLAttributes, forwardRef } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef, ReactNode } from 'react';
 import classNames from 'classnames';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'error' | 'link';
   thin?: boolean;
+  startIcon?: ReactNode;
+  endIcon?: ReactNode;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { variant = 'primary', thin, children, className, ...other }: ButtonProps,
+    {
+      variant = 'primary',
+      thin,
+      children,
+      className,
+      startIcon,
+      endIcon,
+      ...other
+    }: ButtonProps,
     buttonRef
   ) => {
+    const leftIcon = startIcon && (
+      <span
+        className={classNames({ 'Button--start-icon': Boolean(startIcon) })}
+      >
+        {startIcon}
+      </span>
+    );
+
+    const rightIcon = endIcon && (
+      <span className={classNames({ 'Button--end-icon': Boolean(endIcon) })}>
+        {endIcon}
+      </span>
+    );
+
     return (
       <button
         type={'button'}
@@ -24,7 +48,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={buttonRef}
         {...other}
       >
+        {leftIcon}
         {children}
+        {rightIcon}
       </button>
     );
   }

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,11 +1,10 @@
-import React, { ButtonHTMLAttributes, forwardRef, ReactNode } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef, Ref } from 'react';
 import classNames from 'classnames';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  buttonRef?: Ref<HTMLButtonElement>;
   variant?: 'primary' | 'secondary' | 'error' | 'link';
   thin?: boolean;
-  startIcon?: ReactNode;
-  endIcon?: ReactNode;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -15,25 +14,17 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       thin,
       children,
       className,
-      startIcon,
-      endIcon,
+      buttonRef,
       ...other
     }: ButtonProps,
-    buttonRef
+    ref
   ) => {
-    const leftIcon = startIcon && (
-      <span
-        className={classNames({ 'Button--start-icon': Boolean(startIcon) })}
-      >
-        {startIcon}
-      </span>
-    );
-
-    const rightIcon = endIcon && (
-      <span className={classNames({ 'Button--end-icon': Boolean(endIcon) })}>
-        {endIcon}
-      </span>
-    );
+    if (buttonRef) {
+      console.warn(
+        "%c Warning: 'buttonRef' prop is deprecated, please use 'ref'. ",
+        'background: #222; color: #bada44'
+      );
+    }
 
     return (
       <button
@@ -45,12 +36,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           Link: variant === 'link',
           'Button--thin': thin
         })}
-        ref={buttonRef}
+        ref={ref || buttonRef}
         {...other}
       >
-        {leftIcon}
         {children}
-        {rightIcon}
       </button>
     );
   }

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -18,31 +18,22 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       ...other
     }: ButtonProps,
     ref
-  ) => {
-    if (buttonRef) {
-      console.warn(
-        "%c Warning: 'buttonRef' prop is deprecated, please use 'ref'. ",
-        'background: #222; color: #bada44'
-      );
-    }
-
-    return (
-      <button
-        type={'button'}
-        className={classNames(className, {
-          'Button--primary': variant === 'primary',
-          'Button--secondary': variant === 'secondary',
-          'Button--error': variant === 'error',
-          Link: variant === 'link',
-          'Button--thin': thin
-        })}
-        ref={ref || buttonRef}
-        {...other}
-      >
-        {children}
-      </button>
-    );
-  }
+  ) => (
+    <button
+      type={'button'}
+      className={classNames(className, {
+        'Button--primary': variant === 'primary',
+        'Button--secondary': variant === 'secondary',
+        'Button--error': variant === 'error',
+        Link: variant === 'link',
+        'Button--thin': thin
+      })}
+      ref={ref || buttonRef}
+      {...other}
+    >
+      {children}
+    </button>
+  )
 );
 
 Button.displayName = 'Button';

--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -12,9 +12,11 @@
   text-transform: uppercase;
   height: 36px;
   min-width: 100px;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
-  justify-content: center;
+  justify-items: center;
+  gap: 8px;
   --button-hover-outline-color: var(--button-background-color-primary);
 }
 
@@ -83,22 +85,16 @@ button.Link {
   background-color: var(--button-background-color-error-active);
 }
 
-.Button--start-icon {
-  display: inherit;
-  margin-right: 4px;
-  margin-left: -4px;
+.Button--primary .Icon,
+.Button--secondary .Icon,
+.Button--clear .Icon,
+.Button--error .Icon {
+  margin: 0 -4px;
 }
 
-.Button--end-icon {
-  display: inherit;
-  margin-right: -4px;
-  margin-left: 4px;
-}
-
-.Button--thin .Button--start-icon svg,
-.Button--thin .Button--end-icon svg {
-  width: 15px;
-  height: 15px;
+.Button--thin .Icon svg {
+  width: calc(var(--button-thin-height) - 8px);
+  height: calc(var(--button-thin-height) - 8px);
 }
 
 .DefinitionButton {
@@ -125,6 +121,7 @@ button.Link {
   height: var(--button-thin-height);
   min-width: 100px;
   font-size: var(--text-size-smallest);
+  line-height: var(--text-size-smallest);
   padding: 0 16px;
 }
 

--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -12,6 +12,9 @@
   text-transform: uppercase;
   height: 36px;
   min-width: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   --button-hover-outline-color: var(--button-background-color-primary);
 }
 
@@ -78,6 +81,24 @@ button.Link {
 
 .Button--error:active {
   background-color: var(--button-background-color-error-active);
+}
+
+.Button--start-icon {
+  display: inherit;
+  margin-right: 4px;
+  margin-left: -4px;
+}
+
+.Button--end-icon {
+  display: inherit;
+  margin-right: -4px;
+  margin-left: 4px;
+}
+
+.Button--thin .Button--start-icon svg,
+.Button--thin .Button--end-icon svg {
+  width: 15px;
+  height: 15px;
 }
 
 .DefinitionButton {


### PR DESCRIPTION
- **add**: startIcon and endIcon props that will place an `Icon` in `Button` either before or after button text
- **add**: tests to verify proper elements are added when an Icon is passed to either prop
- **refactor**: update `Button` code to be a Stateless Functional Component

Closes: #141