### PR TITLE
fix(styles): use before pseudo element for button indicators

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -24,17 +24,37 @@ button.Link {
   cursor: pointer;
 }
 
-.Button--primary:not([disabled]):not([aria-disabled='true']):hover,
-.Button--secondary:not([disabled]):not([aria-disabled='true']):hover,
-.Button--error:not([disabled]):not([aria-disabled='true']):hover {
-  box-shadow: 0 0 0 2px #fff, 0 0 0 3px var(--button-hover-outline-color);
-}
-
 .Button--primary:focus,
 .Button--secondary:focus,
+.Button--clear:focus,
 .Button--error:focus {
-  outline: 0;
-  box-shadow: 0 0 0 1px #fff, 0 0 1px 3px var(--button-focus-ring-color);
+  outline: none;
+}
+
+.Button--primary:before,
+.Button--secondary:before,
+.Button--clear:before,
+.Button--error:before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.Button--primary:not([disabled]):not([aria-disabled='true']):hover:before,
+.Button--secondary:not([disabled]):not([aria-disabled='true']):hover:before,
+.Button--error:not([disabled]):not([aria-disabled='true']):hover:before {
+  box-shadow: 0 0 0 1px var(--button-hover-outline-color);
+}
+
+.Button--primary:focus:before,
+.Button--secondary:focus:before,
+.Button--error:focus:before {
+  box-shadow: 0 0 1px 2px var(--button-focus-ring-color);
 }
 
 .Button--primary {


### PR DESCRIPTION
Replaces layered drop shadows with pseudo-element drop shadow for better focus/hover indicators.

Primary button hover:
<img width="129" alt="Screen Shot 2021-01-12 at 2 33 03 PM" src="https://user-images.githubusercontent.com/25124347/104363376-16b1ea00-54e3-11eb-8b02-ed2d61be04b3.png">

Primary button focus:
<img width="134" alt="Screen Shot 2021-01-12 at 2 33 29 PM" src="https://user-images.githubusercontent.com/25124347/104363423-26313300-54e3-11eb-88bc-9bbe35a758d1.png">
