### PR TITLE
fix(styles): use inline-grid for buttons to fix layout issues

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -12,7 +12,7 @@
   text-transform: uppercase;
   height: 36px;
   min-width: 100px;
-  display: grid;
+  display: inline-grid;
   grid-auto-flow: column;
   align-items: center;
   justify-items: center;


### PR DESCRIPTION
@schne324 noticed that buttons were being displayed weird in the extension. `inline-grid` restores the original layout (`inline-block`) while allowing for grid elements in the button.