### PR TITLE
fix(react): move next/prev pointout buttons to after content to allow for a more natural tab order

### DIFF
--- a/packages/react/src/components/Pointout/index.tsx
+++ b/packages/react/src/components/Pointout/index.tsx
@@ -376,28 +376,6 @@ export default class Pointout extends React.Component<
           </div>
         )}
         <div className="Pointout__box">
-          {showPrevious && (
-            <button
-              className="Pointout__previous"
-              type="button"
-              aria-label={previousText}
-              tabIndex={!!target && !disableOffscreenPointout ? -1 : 0}
-              {...previousButtonProps}
-            >
-              <Icon type="arrow-left" aria-hidden="true" />
-            </button>
-          )}
-          {showNext && (
-            <button
-              className="Pointout__next"
-              type="button"
-              aria-label={nextText}
-              tabIndex={!!target && !disableOffscreenPointout ? -1 : 0}
-              {...nextButtonProps}
-            >
-              <Icon type="arrow-right" aria-hidden="true" />
-            </button>
-          )}
           <button
             className="Pointout__dismiss"
             type="button"
@@ -426,6 +404,28 @@ export default class Pointout extends React.Component<
               })}
             {target ? removeIds(children) : children}
           </div>
+          {showPrevious && (
+            <button
+              className="Pointout__previous"
+              type="button"
+              aria-label={previousText}
+              tabIndex={!!target && !disableOffscreenPointout ? -1 : 0}
+              {...previousButtonProps}
+            >
+              <Icon type="arrow-left" aria-hidden="true" />
+            </button>
+          )}
+          {showNext && (
+            <button
+              className="Pointout__next"
+              type="button"
+              aria-label={nextText}
+              tabIndex={!!target && !disableOffscreenPointout ? -1 : 0}
+              {...nextButtonProps}
+            >
+              <Icon type="arrow-right" aria-hidden="true" />
+            </button>
+          )}
           {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
         </div>
       </div>
@@ -440,12 +440,6 @@ export default class Pointout extends React.Component<
             aria-labelledby={heading ? headingId : undefined}
             ref={el => (this.offscreenRef = el)}
           >
-            <button
-              type="button"
-              aria-label={previousText}
-              {...previousButtonProps}
-            />
-            <button type="button" aria-label={nextText} {...nextButtonProps} />
             <button
               type="button"
               aria-label={dismissText}
@@ -463,13 +457,27 @@ export default class Pointout extends React.Component<
                 })}
               {children}
             </div>
+            {showPrevious && (
+              <button
+                type="button"
+                aria-label={previousText}
+                {...previousButtonProps}
+              />
+            )}
+            {showNext && (
+              <button
+                type="button"
+                aria-label={nextText}
+                {...nextButtonProps}
+              />
+            )}
           </div>
           {createPortal(FTPO, portal as HTMLElement)}
         </React.Fragment>
       );
     }
 
-    return FTPO;
+    return target && portal ? createPortal(FTPO, portal as HTMLElement) : FTPO;
   }
 
   onCloseClick() {

--- a/packages/styles/pointout.css
+++ b/packages/styles/pointout.css
@@ -146,9 +146,9 @@
   right: var(--pointout-arrow-width);
 }
 
-.Pointout__dismiss svg,
-.Pointout__next svg,
-.Pointout__previous svg {
+.Pointout__dismiss .Icon svg,
+.Pointout__next .Icon svg,
+.Pointout__previous .Icon svg {
   height: 24px;
   width: 24px;
 }
@@ -172,7 +172,19 @@
   font-weight: var(--font-weight-normal);
   padding-bottom: var(--space-smallest);
   margin-bottom: var(--space-smallest);
-  border-bottom: 1px solid #fff;
+}
+
+.Pointout__content .Pointout__heading:after {
+  display: block;
+  content: '';
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(
+    to right,
+    var(--pointout-text-color),
+    var(--pointout-background-color)
+  );
+  transform: translateY(var(--space-smallest));
 }
 
 .Pointout__content p {
@@ -186,15 +198,16 @@
 }
 
 .Pointout__content:focus:before {
-  background: var(--top-bar-background-color);
+  background: #fff;
 }
 
 .Pointout__content:before {
   content: '';
-  height: 100%;
-  width: 3px;
+  height: calc(100% - 12px);
+  width: 2px;
   position: absolute;
-  left: -8px;
+  left: 3px;
+  top: 6px;
 }
 
 .Pointout--no-arrow .Pointout__arrow {


### PR DESCRIPTION
@schne324 and I worked through how the pointout should handle focus order, and based on https://github.com/dequelabs/axe-extension/issues/470#issuecomment-759088732 it feels natural to have Close → Content → Previous → Next in the tab order for the pointout.