### PR TITLE
fix: remove pointer events from iconbutton icon

### DIFF
--- a/packages/react/src/components/Icon/index.css
+++ b/packages/react/src/components/Icon/index.css
@@ -1,6 +1,7 @@
 .Icon {
   display: inline-block;
   vertical-align: middle;
+  pointer-events: none;
 }
 
 .Icon svg {

--- a/packages/react/src/components/Icon/index.css
+++ b/packages/react/src/components/Icon/index.css
@@ -1,7 +1,6 @@
 .Icon {
   display: inline-block;
   vertical-align: middle;
-  pointer-events: none;
 }
 
 .Icon svg {

--- a/packages/styles/icon-button.css
+++ b/packages/styles/icon-button.css
@@ -16,6 +16,7 @@
 .IconButton .Icon {
   width: 100%;
   height: 100%;
+  pointer-events: none;
 }
 
 .IconButton:focus {


### PR DESCRIPTION
The icon was hijacking pointer events from being picked up by the underlying button.