### PR TITLE
fix(react): Remove onClose prop from Alert

### DIFF
--- a/packages/react/src/components/Alert/index.tsx
+++ b/packages/react/src/components/Alert/index.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import Icon from '../Icon';
 import { Dialog, DialogContent, DialogFooter, DialogProps } from '../Dialog';
 
-interface AlertProps extends Omit<DialogProps, 'forceAction'> {
+interface AlertProps extends Omit<Omit<DialogProps, 'forceAction'>, 'onClose'> {
   variant?: 'default' | 'warning';
 }
 

--- a/packages/react/src/components/Alert/index.tsx
+++ b/packages/react/src/components/Alert/index.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import Icon from '../Icon';
 import { Dialog, DialogContent, DialogFooter, DialogProps } from '../Dialog';
 
-interface AlertProps extends Omit<Omit<DialogProps, 'forceAction'>, 'onClose'> {
+interface AlertProps extends Omit<DialogProps, 'forceAction' | 'onClose'> {
   variant?: 'default' | 'warning';
 }
 


### PR DESCRIPTION
The inherited `onClose` prop doesn't make sense in the `Alert` component. The patch from #168 made it optional, enabling this patch to remove it entirely.

Closes #105