### PR TITLE
fix(styles): remove height/width styles from Icon

### DIFF
--- a/packages/react/src/components/Icon/index.css
+++ b/packages/react/src/components/Icon/index.css
@@ -5,8 +5,6 @@
 
 .Icon svg {
   display: block;
-  width: inherit;
-  height: inherit;
 }
 
 /* Icon--right is the default orientation */

--- a/packages/styles/icon-button.css
+++ b/packages/styles/icon-button.css
@@ -19,6 +19,11 @@
   pointer-events: none;
 }
 
+.IconButton .Icon svg {
+  width: 100%;
+  height: 100%;
+}
+
 .IconButton:focus {
   outline: none;
 }


### PR DESCRIPTION
We shouldn't apply inherit styles to icon as consumers may want to size them differently. Individual components that use Icons should be able to freely override their sizes.