### PR TITLE
fix(styles): use the same outline color for IconButton as the background

### DIFF
--- a/packages/styles/icon-button.css
+++ b/packages/styles/icon-button.css
@@ -44,5 +44,5 @@
 }
 
 .IconButton:not([disabled]):not([aria-disabled='true']):hover:before {
-  box-shadow: 0 0 0 1px var(--top-bar-text-color);
+  box-shadow: 0 0 0 1px var(--icon-button-background-color);
 }


### PR DESCRIPTION
I noticed the outline ring on hover did not match the background color of the button