### PR TITLE
feat: allow pointouts to specify their positioning in alignment with their target element

### DIFF
--- a/docs/patterns/components/Pointout/index.js
+++ b/docs/patterns/components/Pointout/index.js
@@ -3,6 +3,7 @@ import { Pointout, Code } from '@deque/cauldron-react';
 
 const Demo = () => {
   const buttonRef = React.createRef();
+  const longButtonRef = React.createRef();
   const ftpoRef = React.createRef();
 
   const [portal, setPortal] = useState(null);
@@ -60,6 +61,35 @@ const Demo = () => {
 </Pointout>`}
       </Code>
 
+      <h3>With Position</h3>
+      <button
+        className="Button--primary"
+        ref={longButtonRef}
+        style={{ marginBottom: '171px' }}
+      >
+        I'm a really big button with lots of text
+      </button>
+      <Pointout
+        target={longButtonRef}
+        heading={<h4>First time point out!</h4>}
+        dismissText="Close"
+        arrowPosition="top-right"
+        position="end"
+        portal={portal}
+      >
+        <p>This is a first time point out with a positioned pointout box</p>
+      </Pointout>
+      <Code language="javascript">
+        {`<Pointout
+  heading={<h4>First time point out!</h4>}
+  dismissText="Close"
+  arrowPosition="top-right"
+  position="end"
+>
+  <p>This is a first time point out with a positioned pointout box</p>
+</Pointout>`}
+      </Code>
+
       <h3>Targeted First Time Point Outs</h3>
       <p>
         First time point outs can specify a <code>target</code> prop that will
@@ -104,6 +134,7 @@ const Demo = () => {
       <Pointout
         ref={ftpoRef}
         arrowPosition="top-left"
+        position="center"
         heading={<h4>Targeted FTPO</h4>}
         dismissText="Close"
         target={buttonRef}

--- a/packages/react/src/components/Pointout/index.tsx
+++ b/packages/react/src/components/Pointout/index.tsx
@@ -17,6 +17,7 @@ export interface PointoutProps {
     | 'bottom-left'
     | 'left-bottom'
     | 'left-top';
+  position: 'start' | 'center' | 'end';
   heading?: React.ReactNode;
   className?: string;
   headerId: string;
@@ -55,7 +56,8 @@ export default class Pointout extends React.Component<
     dismissText: 'dismiss',
     previousText: 'previous',
     nextText: 'next',
-    arrowPosition: 'top-left'
+    arrowPosition: 'top-left',
+    position: 'center'
   };
 
   static propTypes = {
@@ -258,7 +260,7 @@ export default class Pointout extends React.Component<
   };
 
   positionRelativeToTarget = () => {
-    const { target, portal, arrowPosition } = this.props;
+    const { target, portal, arrowPosition, position } = this.props;
 
     if (!target) {
       return;
@@ -287,26 +289,50 @@ export default class Pointout extends React.Component<
       case 'right':
         style = {
           left: `${left}px`,
-          top: `${top + height / 2}px`
+          top: `${
+            position === 'center'
+              ? top + height / 2
+              : position === 'start'
+              ? top
+              : top + height
+          }px`
         };
         break;
       case 'bottom':
         style = {
           top: `${top}px`,
-          left: `${left + width / 2}px`
+          left: `${
+            position === 'center'
+              ? left + width / 2
+              : position === 'start'
+              ? left
+              : left + width
+          }px`
         };
         break;
       case 'left':
         style = {
           left: `${left + width}px`,
-          top: `${top + height / 2}px`
+          top: `${
+            position === 'center'
+              ? top + height / 2
+              : position === 'start'
+              ? top
+              : top + height
+          }px`
         };
         break;
       case 'top':
       default:
         style = {
           top: `${top + height}px`,
-          left: `${left + width / 2}px`
+          left: `${
+            position === 'center'
+              ? left + width / 2
+              : position === 'start'
+              ? left
+              : left + width
+          }px`
         };
         break;
     }
@@ -340,6 +366,7 @@ export default class Pointout extends React.Component<
       showNext,
       showPrevious,
       arrowPosition,
+      position,
       className,
       target,
       disableOffscreenPointout,
@@ -358,7 +385,8 @@ export default class Pointout extends React.Component<
         className={classNames(className, 'Pointout', {
           'Pointout--no-arrow': noArrow,
           'Pointout--auto': !!target,
-          [`Pointout__arrow--${arrowPosition}`]: !!arrowPosition && !noArrow
+          [`Pointout__arrow--${arrowPosition}`]: !!arrowPosition && !noArrow,
+          [`Pointout--${position}`]: !!target
         })}
         style={style}
         role={target ? undefined : 'region'}

--- a/packages/styles/pointout.css
+++ b/packages/styles/pointout.css
@@ -261,3 +261,35 @@
 .Pointout--auto.Pointout__arrow--right-bottom {
   transform: translateX(-100%) translateY(-100%) translateY(10px);
 }
+
+.Pointout--auto.Pointout--start[class*='top-'] {
+  transform: none;
+}
+
+.Pointout--auto.Pointout--start[class*='bottom-'] {
+  transform: translateY(-100%);
+}
+
+.Pointout--auto.Pointout--end[class*='top-'] {
+  transform: translateX(-100%);
+}
+
+.Pointout--auto.Pointout--end[class*='bottom-'] {
+  transform: translateY(-100%) translateX(-100%);
+}
+
+.Pointout--auto.Pointout--start[class*='left-'] {
+  transform: none;
+}
+
+.Pointout--auto.Pointout--start[class*='right-'] {
+  transform: translateX(-100%);
+}
+
+.Pointout--auto.Pointout--end[class*='left-'] {
+  transform: translateY(-100%);
+}
+
+.Pointout--auto.Pointout--end[class*='right-'] {
+  transform: translateX(-100%) translateY(-100%);
+}


### PR DESCRIPTION
This is needed for the extension to address some positioning issues with pointouts, and to allow for some more flexibility in where the pointout is.