### PR TITLE
feat(icon-button): exposes ref prop

### DIFF
--- a/packages/react/__tests__/src/components/IconButton/index.js
+++ b/packages/react/__tests__/src/components/IconButton/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import IconButton from 'src/components/IconButton';
@@ -23,11 +23,26 @@ test('should return no axe violations', async () => {
   expect(await axe(wrapper.html())).toHaveNoViolations();
 });
 
-test('supports ref prop', done => {
-  const ref = iconBtn => {
-    iconBtn.expect(iconBtn).toBeNull();
-    done();
+test('supports ref prop', async () => {
+  const TestElement = () => {
+    const ref = useRef(null);
+    return (
+      <>
+        <IconButton id="test-id" icon="pencil" label="Edit" ref={ref} />
+        <button
+          id="test-button"
+          onClick={() => {
+            ref.current.focus();
+          }}
+        >
+          Test
+        </button>
+      </>
+    );
   };
 
-  mount(<IconButton icon="pencil" label="Edit" ref={ref} />);
+  const mountedElement = mount(<TestElement />);
+  await update(mountedElement);
+  mountedElement.find('#test-button').simulate('click');
+  expect(document.activeElement.id).toBe('test-id');
 });

--- a/packages/react/__tests__/src/components/IconButton/index.js
+++ b/packages/react/__tests__/src/components/IconButton/index.js
@@ -17,8 +17,17 @@ test('should render button', async () => {
   expect(wrapper.find('button').exists()).toBe(true);
 });
 
-test.only('should return no axe violations', async () => {
+test('should return no axe violations', async () => {
   const wrapper = mount(<IconButton icon="pencil" label="Edit" />);
   await update(wrapper);
   expect(await axe(wrapper.html())).toHaveNoViolations();
+});
+
+test('supports ref prop', done => {
+  const ref = iconBtn => {
+    iconBtn.expect(iconBtn).toBeNull();
+    done();
+  };
+
+  mount(<IconButton icon="pencil" label="Edit" ref={ref} />);
 });

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -1,52 +1,50 @@
-import React, { useRef } from 'react';
-import PropTypes from 'prop-types';
+import React, { useRef, forwardRef } from 'react';
 import classnames from 'classnames';
 import { Placement } from '@popperjs/core';
 import Icon from '../Icon';
 import Tooltip from '../Tooltip';
-
 export interface IconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: string;
   label: string;
   tooltipPlacement?: Placement;
 }
-
-export default function IconButton({
-  icon,
-  label,
-  tooltipPlacement = 'auto',
-  className,
-  ...other
-}: IconButtonProps) {
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  return (
-    <React.Fragment>
-      <button
-        type={'button'}
-        className={classnames('IconButton', className)}
-        ref={buttonRef}
-        {...other}
-      >
-        <Icon type={icon} />
-      </button>
-      <Tooltip
-        target={buttonRef}
-        placement={tooltipPlacement}
-        association="aria-labelledby"
-        hideElementOnHidden
-      >
-        {label}
-      </Tooltip>
-    </React.Fragment>
-  );
-}
-
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      icon,
+      label,
+      tooltipPlacement = 'auto',
+      className,
+      ...other
+    }: IconButtonProps,
+    ref
+  ): JSX.Element => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    if (typeof ref === 'function') {
+      ref(buttonRef.current);
+    }
+    return (
+      <React.Fragment>
+        <button
+          type={'button'}
+          className={classnames('IconButton', className)}
+          ref={typeof ref === 'function' || !ref ? buttonRef : ref}
+          {...other}
+        >
+          <Icon type={icon} />
+        </button>
+        <Tooltip
+          target={typeof ref === 'function' || !ref ? buttonRef : ref}
+          placement={tooltipPlacement}
+          association="aria-labelledby"
+          hideElementOnHidden
+        >
+          {label}
+        </Tooltip>
+      </React.Fragment>
+    );
+  }
+);
 IconButton.displayName = 'IconButton';
-
-IconButton.propTypes = {
-  icon: PropTypes.string,
-  label: PropTypes.string,
-  tooltipPlayemnt: PropTypes.string,
-  buttonRef: PropTypes.any
-};
+export default IconButton;

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -4,6 +4,7 @@ import React, {
   useImperativeHandle,
   MutableRefObject
 } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Placement } from '@popperjs/core';
 import Icon from '../Icon';
@@ -51,5 +52,13 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     );
   }
 );
+
+IconButton.propTypes = {
+  icon: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  tooltipPlacement: PropTypes.any
+};
+
 IconButton.displayName = 'IconButton';
+
 export default IconButton;

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -1,4 +1,9 @@
-import React, { useRef, forwardRef } from 'react';
+import React, {
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+  MutableRefObject
+} from 'react';
 import classnames from 'classnames';
 import { Placement } from '@popperjs/core';
 import Icon from '../Icon';
@@ -9,6 +14,7 @@ export interface IconButtonProps
   label: string;
   tooltipPlacement?: Placement;
 }
+
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
@@ -20,22 +26,21 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     }: IconButtonProps,
     ref
   ): JSX.Element => {
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    if (typeof ref === 'function') {
-      ref(buttonRef.current);
-    }
+    const buttonRef = useRef() as MutableRefObject<HTMLButtonElement>;
+    useImperativeHandle(ref, () => buttonRef.current);
+
     return (
       <React.Fragment>
         <button
           type={'button'}
           className={classnames('IconButton', className)}
-          ref={typeof ref === 'function' || !ref ? buttonRef : ref}
+          ref={buttonRef}
           {...other}
         >
           <Icon type={icon} />
         </button>
         <Tooltip
-          target={typeof ref === 'function' || !ref ? buttonRef : ref}
+          target={buttonRef}
           placement={tooltipPlacement}
           association="aria-labelledby"
           hideElementOnHidden


### PR DESCRIPTION
*update*: icon button ref was just internal for the tooltip, adds ability to use ref freely