### PR TITLE
fix(react): use offscreen container instead of aria-label for icon elements

### DIFF
--- a/packages/react/__tests__/src/components/Icon/index.js
+++ b/packages/react/__tests__/src/components/Icon/index.js
@@ -11,16 +11,18 @@ test('sets aria-hidden to "true" if no label is passed', () => {
   const icon = mount(<Icon type="foo" />);
   // enzyme makes it hard to get attribute values...
   expect(icon.getDOMNode().getAttribute('aria-hidden')).toBe('true');
+  expect(icon.find('Offscreen').exists()).toBe(false);
 });
 
 test('sets aria-hidden to "false" if no label is passed', () => {
   const icon = mount(<Icon type="foo" label="Fred" />);
   expect(icon.getDOMNode().getAttribute('aria-hidden')).toBe('false');
+  expect(icon.find('Offscreen').exists()).toBe(true);
 });
 
-test('sets aria-label to the value of the label prop', () => {
+test('sets offscreen label to the value of the label prop', () => {
   const icon = mount(<Icon type="foo" label="Fred" />);
-  expect(icon.getDOMNode().getAttribute('aria-label')).toBe('Fred');
+  expect(icon.find('Offscreen').text()).toEqual('Fred');
 });
 
 test('supports ref prop', done => {

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, forwardRef } from 'react';
+import Offscreen from '../Offscreen';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -47,12 +48,9 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
       })
     };
 
-    if (label) {
-      data['aria-label'] = label;
-    }
-
     return (
       <div ref={ref} {...data}>
+        {label && <Offscreen>{label}</Offscreen>}
         {IconSVG && <IconSVG />}
       </div>
     );


### PR DESCRIPTION
Some screen readers don't read `aria-label` on generic elements, so moving this to an offscreen container.