### PR TITLE
fix: pass classnames from menubar to rendered ul

### DIFF
--- a/packages/react/__tests__/src/components/MenuBar/index.js
+++ b/packages/react/__tests__/src/components/MenuBar/index.js
@@ -80,6 +80,15 @@ test('handles right arrow', () => {
   expect(document.activeElement).toBe(menuItems.at(0).getDOMNode());
 });
 
+test('should pass-through classname', () => {
+  const wrapper = mount(
+    <MenuBar className="test">
+      <TopBarItem>1</TopBarItem>
+    </MenuBar>
+  );
+  expect(wrapper.children().props().className).toBe('test');
+});
+
 test('should return no axe violations', async () => {
   const topbar = mount(
     <MenuBar>

--- a/packages/react/src/components/MenuBar/index.tsx
+++ b/packages/react/src/components/MenuBar/index.tsx
@@ -144,7 +144,7 @@ export default class TopBar extends React.Component<
     const { children, className, thin, hasTrigger, ...other } = this.props;
 
     return (
-      <ul role="menubar">
+      <ul role="menubar" className={className}>
         {Children.map(
           children as React.ReactElement<HTMLLIElement>,
           this.renderChild


### PR DESCRIPTION
Fix for Menubar not passing the className prop to the rendered ul element. 