### PR TITLE
fix(react): allow strings or other values to be set on a dialog heading

### DIFF
--- a/packages/react/src/components/Alert/index.tsx
+++ b/packages/react/src/components/Alert/index.tsx
@@ -24,7 +24,7 @@ const Alert = ({
       text: (
         <React.Fragment>
           <Icon type={variant === 'default' ? 'info-circle-alt' : 'caution'} />
-          {typeof heading === 'object' && 'text' in heading
+          {heading !== null && typeof heading === 'object' && 'text' in heading
             ? heading.text
             : heading}
         </React.Fragment>

--- a/packages/react/src/components/Alert/index.tsx
+++ b/packages/react/src/components/Alert/index.tsx
@@ -30,7 +30,7 @@ const Alert = ({
         </React.Fragment>
       ),
       level:
-        typeof heading === 'object' && 'level' in heading
+        heading !== null && typeof heading === 'object' && 'level' in heading
           ? heading.level
           : undefined
     }}

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -18,6 +18,7 @@ export interface DialogProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
   forceAction?: boolean;
   heading:
+    | React.ReactNode
     | React.ReactElement<any>
     | {
         text: React.ReactElement<any>;


### PR DESCRIPTION
We currently can't use strings as heading values because of typescript:

```tsx
// Our current types get very angry at this
<Dialog heading={'Heading'}>...</Dialog>
```

This patches to allow any `ReactNode` as a heading so strings or numbers or other nodes can be used.

