### PR TITLE
feat(react): Support YAML highlighint in Code component

### DIFF
--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -6,14 +6,16 @@ import classNames from 'classnames';
 import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
 import css from 'react-syntax-highlighter/dist/esm/languages/hljs/css';
 import xml from 'react-syntax-highlighter/dist/esm/languages/hljs/xml';
+import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
 
 SyntaxHighlighter.registerLanguage('javascript', js);
 SyntaxHighlighter.registerLanguage('css', css);
 SyntaxHighlighter.registerLanguage('html', xml);
+SyntaxHighlighter.registerLanguage('yaml', yaml);
 
 interface Props extends SyntaxHighlighterProps {
   children: React.ReactNode;
-  language?: 'javascript' | 'css' | 'html';
+  language?: 'javascript' | 'css' | 'html' | 'yaml';
   className?: string;
 }
 
@@ -35,7 +37,7 @@ Code.displayName = 'Code';
 
 Code.propTypes = {
   children: PropTypes.string.isRequired,
-  language: PropTypes.oneOf(['javascript', 'css', 'html']),
+  language: PropTypes.oneOf(['javascript', 'css', 'html', 'yaml']),
   className: PropTypes.string
 };
 


### PR DESCRIPTION
This patch adds support for syntax highlighting YAML.

The axe Linter documentation site needs this. I've tried manually registering the language in the site, but the TypeScript compiler gets _very_ angry with me and React emits tons of prop type warnings.