### PR TITLE
feat(react): Sets progressbar attributes on Loader

### DIFF
--- a/packages/react/__tests__/src/components/Loader/index.js
+++ b/packages/react/__tests__/src/components/Loader/index.js
@@ -18,9 +18,15 @@ test('does not set aria-hidden if a label is provided', () => {
   expect(icon.is('[aria-hidden]')).toBe(false);
 });
 
-test('sets aria-label=props.label', () => {
-  const icon = mount(<Loader label="bananas" />);
-  expect(icon.getDOMNode().getAttribute('aria-label')).toBe('bananas');
+test('sets expected progressbar attributes given a label', () => {
+  const loader = mount(<Loader label="bananas" />);
+  const loaderNode = loader.getDOMNode();
+
+  expect(loaderNode.getAttribute('role')).toBe('progressbar');
+  expect(loaderNode.getAttribute('aria-valuetext')).toBe('bananas');
+  expect(loaderNode.getAttribute('aria-busy')).toBe('true');
+  expect(loaderNode.getAttribute('aria-valuemin')).toBe('0');
+  expect(loaderNode.getAttribute('aria-valuemax')).toBe('100');
 });
 
 test('returns no axe violations', async () => {

--- a/packages/react/src/components/Loader/index.tsx
+++ b/packages/react/src/components/Loader/index.tsx
@@ -10,9 +10,20 @@ export default function Loader({ label, className, ...other }: LoaderProps) {
   const props = {
     ...other,
     className: classNames('Loader', className),
-    'aria-label': label,
-    'aria-hidden': label ? false : true
+    'aria-hidden': !label
   };
+
+  if (label) {
+    props.role = 'progressbar';
+    props['aria-valuetext'] = label;
+    props['aria-busy'] = true;
+    props['aria-valuemin'] = 0;
+    props['aria-valuemax'] = 100;
+    // According to the  ARIA 1.2 spec (https://www.w3.org/TR/wai-aria-1.2/#progressbar),
+    // the aria-valuenow attribute SHOULD be omitted because the "value" of our progress
+    // is "indeterminate".
+  }
+
   return <div {...props} />;
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Loader component now set role, aria-valuetext, aria-busy, aria-valuemin, and aria-valuemax instead of making a generic role (div) have an aria-label.

closes #53


## AT Readouts

| Browser+AT | Readout |
|-------------|----------|
| Safari+VO    | Loading..., indeterminate, progress indicator |
| FF+NVDA    |  progress bar busy. Loading... |