### PR TITLE
fix(react): use background color instead of scrim for proper scrolling with dialogs

### DIFF
--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -141,7 +141,6 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
             }}
             {...other}
           >
-            <Scrim show={show} />
             <div className="Dialog__inner">
               <div className="Dialog__header">
                 <Heading

--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -13,6 +13,8 @@
   overflow-x: auto;
   position: fixed;
   top: 0;
+  background-color: var(--scrim-background-color);
+  padding-bottom: 50px;
 }
 
 .Dialog.Dialog--show {

--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -14,7 +14,6 @@
   position: fixed;
   top: 0;
   background-color: var(--scrim-background-color);
-  padding-bottom: 50px;
 }
 
 .Dialog.Dialog--show {


### PR DESCRIPTION
The scrim had some issues, namely that it was layered on top of the scrollbar and prevented the scrollbar from being directly interacted with, even while the outer container containing the modal was scrollable.