### PR TITLE
feat(Select): Adds support for required/error

### DIFF
--- a/docs/patterns/components/Select/index.css
+++ b/docs/patterns/components/Select/index.css
@@ -1,12 +1,3 @@
-.select-demo .select-demo-button.Button--secondary {
-  margin: 5px 0;
-}
-
-/*
-  TODO peel this back when this gets resolved
-  https://github.com/dequelabs/pattern-library/issues/59
- */
-.select-demo [role='textbox'],
-.select-demo [role='textbox']:hover {
-  border: 0;
+.SelectDemo .Field__select {
+  max-width: 300px;
 }

--- a/docs/patterns/components/Select/index.js
+++ b/docs/patterns/components/Select/index.js
@@ -12,78 +12,103 @@ const options = [
   { key: 'saturday', value: 'Saturday', disabled: true },
   { key: 'sunday', value: 'Sunday' }
 ];
+const yesNoOptions = [
+  { key: 'yes', value: 'yes' },
+  { key: 'no', value: 'no' }
+];
 
 const SelectDemo = () => {
   const [currentValue, setCurrentValue] = useState('Maybe');
 
   return (
-    <Demo
-      component={Select}
-      states={[
-        {
-          label: 'Do you like yogurt?',
-          options: [
-            { key: 'yes', value: 'Yes' },
-            { key: 'no', value: 'No' },
-            { key: 'maybe', value: 'Maybe' }
-          ],
-          value: currentValue,
-          onChange: e => setCurrentValue(e.target.value),
-          DEMO_renderBefore: <h3>Controlled select</h3>
-        },
-        {
-          label: 'Day',
-          options,
-          defaultValue: 'Friday',
-          DEMO_renderBefore: <h3>Uncontrolled select</h3>
-        },
-        {
-          label: 'How many things do you want?',
-          children: (
-            <>
-              <option>0</option>
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-            </>
-          ),
-          defaultValue: 2,
-          DEMO_renderBefore: <h3>With jsx option children (uncontrolled)</h3>
-        }
-      ]}
-      propDocs={{
-        options: {
-          type: 'array',
-          required: true,
-          description:
-            'Array of objects containing: key, value, disabled (optional), and label (optional).'
-        },
-        defaultValue: {
-          type: 'any',
-          required: false,
-          description:
-            'The default element value. Use when the component is not controlled.'
-        },
-        value: {
-          type: 'any',
-          required: false,
-          description:
-            'Use for "controlled" selects. Caller is responsible for managing the value of the select element.'
-        },
-        onChange: {
-          type: 'function',
-          required: false,
-          description:
-            'This is required if using "controlled" input; otherwise it is optional',
-          defaultValue: '() => {}'
-        },
-        children: {
-          type: 'node',
-          description: 'the <option> or <optgroup> children'
-        }
-      }}
-    />
+    <div className="SelectDemo">
+      <Demo
+        component={Select}
+        states={[
+          {
+            label: 'Do you like yogurt?',
+            options: [
+              { key: 'yes', value: 'Yes' },
+              { key: 'no', value: 'No' },
+              { key: 'maybe', value: 'Maybe' }
+            ],
+            value: currentValue,
+            onChange: e => setCurrentValue(e.target.value),
+            DEMO_renderBefore: <h3>Controlled select</h3>
+          },
+          {
+            label: 'Day',
+            options,
+            defaultValue: 'Friday',
+            DEMO_renderBefore: <h3>Uncontrolled select</h3>
+          },
+          {
+            label: 'Foo?',
+            required: true,
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>Required</h3>
+          },
+          {
+            label: 'Bar?',
+            disabled: true,
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>Disabled</h3>
+          },
+          {
+            label: 'Baz?',
+            required: true,
+            error: 'Not enough baz!',
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>With error</h3>
+          },
+          {
+            label: 'How many things do you want?',
+            children: (
+              <>
+                <option>0</option>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+              </>
+            ),
+            defaultValue: 2,
+            DEMO_renderBefore: <h3>With jsx option children (uncontrolled)</h3>
+          }
+        ]}
+        propDocs={{
+          options: {
+            type: 'array',
+            required: true,
+            description:
+              'Array of objects containing: key, value, disabled (optional), and label (optional).'
+          },
+          defaultValue: {
+            type: 'any',
+            required: false,
+            description:
+              'The default element value. Use when the component is not controlled.'
+          },
+          value: {
+            type: 'any',
+            required: false,
+            description:
+              'Use for "controlled" selects. Caller is responsible for managing the value of the select element.'
+          },
+          onChange: {
+            type: 'function',
+            required: false,
+            description:
+              'This is required if using "controlled" input; otherwise it is optional',
+            defaultValue: '() => {}'
+          },
+          children: {
+            type: 'node',
+            description: 'the <option> or <optgroup> children'
+          }
+        }}
+      />
+    </div>
   );
 };
 

--- a/packages/react/__tests__/src/components/Select/index.js
+++ b/packages/react/__tests__/src/components/Select/index.js
@@ -133,23 +133,64 @@ test('handles errors', () => {
 });
 
 test('should return no axe violations', async () => {
+  const opts = [
+    { key: '1', value: 'Bar' },
+    { key: '2', value: 'Foo' },
+    { key: '3', value: 'Far' },
+    { key: '4', value: 'Fan' },
+    { key: '5', value: 'Fun' }
+  ];
   const select = mount(
     <div>
       <Select
         {...defaultProps}
         defaultValue="Bar"
         onChange={() => {}}
-        options={[
-          { key: '1', value: 'Bar' },
-          { key: '2', value: 'Foo' },
-          { key: '3', value: 'Far' },
-          { key: '4', value: 'Fan' },
-          { key: '5', value: 'Fun' }
-        ]}
+        options={opts}
       />
     </div>
   );
   expect(await axe(select.html())).toHaveNoViolations();
+
+  const disabledSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        disabled
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(disabledSelect.html())).toHaveNoViolations();
+
+  const requiredSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        required
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(requiredSelect.html())).toHaveNoViolations();
+
+  const errorSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        required
+        error="Bananananas"
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(errorSelect.html())).toHaveNoViolations();
 });
 
 test('supports "controlled" select', () => {

--- a/packages/react/__tests__/src/components/Select/index.js
+++ b/packages/react/__tests__/src/components/Select/index.js
@@ -34,6 +34,7 @@ test('renders the expected UI', () => {
   expect(wrapper.find('.Field__select--required')).toBeTruthy();
   expect(wrapper.find('.Field__select')).toBeTruthy();
   expect(wrapper.find('.Field__option')).toBeTruthy();
+  expect(wrapper.find('.Field__required-text').exists()).toBe(false);
 });
 
 test('sets option attributes properly', () => {
@@ -97,6 +98,38 @@ test('passes children properly', () => {
   expect(opts.length).toBe(3);
   const disabledOpt = select.find('[disabled]');
   expect(disabledOpt.text()).toBe('b');
+});
+
+test('renders required text', () => {
+  const selectWithDefaultRequiredText = withCustomOptions({ required: true });
+  const selectWithCustomRequiredText = withCustomOptions({
+    requiredText: 'Bananas',
+    required: true
+  });
+
+  expect(
+    selectWithDefaultRequiredText.find('.Field__required-text').text()
+  ).toBe('Required');
+  expect(
+    selectWithCustomRequiredText.find('.Field__required-text').text()
+  ).toBe('Bananas');
+});
+
+test('handles errors', () => {
+  const errorText = 'ErR0r';
+  const select = withCustomOptions({
+    error: errorText
+  });
+  const error = select.find('.Error');
+
+  expect(error.text()).toBe(errorText);
+  expect(select.find('select').prop('aria-describedby')).toBe(error.prop('id'));
+  expect(
+    select.find('.Field__label--has-error').hasClass('Field__label--has-error')
+  ).toBe(true);
+  expect(
+    select.find('.Field__select--wrapper').hasClass('Field--has-error')
+  ).toBe(true);
 });
 
 test('should return no axe violations', async () => {

--- a/packages/react/src/components/Select/index.tsx
+++ b/packages/react/src/components/Select/index.tsx
@@ -1,6 +1,7 @@
 import React, { Ref, useEffect, useState } from 'react';
 import uid from '../../utils/rndid';
 import classNames from 'classnames';
+import tokenList from '../../utils/token-list';
 
 export interface SelectOption {
   key: string;
@@ -12,6 +13,8 @@ export interface SelectOption {
 export interface SelectProps
   extends Omit<React.HTMLProps<HTMLSelectElement>, 'children'> {
   label: string;
+  requiredText?: string;
+  error?: string;
   options?: SelectOption[];
   children?: React.ReactElement<HTMLOptionElement | HTMLOptGroupElement>[];
   value?: any;
@@ -28,7 +31,10 @@ const Select = React.forwardRef(
       label,
       id,
       required,
+      requiredText = 'Required',
+      error,
       value,
+      'aria-describedby': ariaDescribedby,
       defaultValue,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       onChange = () => {},
@@ -67,10 +73,12 @@ const Select = React.forwardRef(
     }, [value]);
 
     const selectId = id || uid();
+    const errorId = uid();
 
     const dynamicProps: {
       value?: any;
       defaultValue?: any;
+      'aria-describedby'?: string;
     } = {};
 
     if (isControlled) {
@@ -79,19 +87,31 @@ const Select = React.forwardRef(
       dynamicProps.defaultValue = defaultValue;
     }
 
+    if (error) {
+      dynamicProps['aria-describedby'] = tokenList(errorId, ariaDescribedby);
+    }
+
     // In order to support controlled selects, we
     // have to attach an `onChange` to the select.
     /* eslint-disable jsx-a11y/no-onchange */
     return (
       <div className="Field__select">
-        <div className="Field__select--label-wrapper">
-          <label htmlFor={selectId} className="Field__label">
-            {label}
-          </label>
-        </div>
+        <label
+          htmlFor={selectId}
+          className={classNames('Field__label', {
+            'Field__label--is-required': !!required,
+            'Field__label--has-error': !!error
+          })}
+        >
+          <span>{label}</span>
+          {required && (
+            <span className="Field__required-text">{requiredText}</span>
+          )}
+        </label>
         <div
           className={classNames('Field__select--wrapper', {
-            'Field__select--disabled': disabled
+            'Field__select--disabled': disabled,
+            'Field--has-error': !!error
           })}
         >
           <select
@@ -123,6 +143,9 @@ const Select = React.forwardRef(
               : children}
           </select>
           <div className="arrow-down" />
+        </div>
+        <div className="Error" id={errorId}>
+          {error}
         </div>
       </div>
     );

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -109,6 +109,7 @@ textarea.Field--has-error:focus,
 
 .Field__label {
   display: flex;
+  align-items: center;
   text-align: left;
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);

--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -7,14 +7,9 @@
   opacity: 0.45;
 }
 
-.Field__select--label-wrapper {
-  display: flex;
-  justify-content: space-between;
-}
-
 .Field__select--wrapper {
   position: relative;
-  width: var(--select-width);
+  min-width: var(--select-width);
 }
 
 .arrow-down {
@@ -30,14 +25,14 @@
 }
 
 .Field__select--wrapper select {
-  width: inherit;
+  width: 100%;
   min-height: var(--select-min-height);
   padding: var(--space-three-quarters) var(--space-smallest);
   border: 1px solid var(--field-border-color);
   font-family: Roboto;
   font-weight: normal;
   font-style: normal;
-  font-size: var(--text-size-smaller);
+  font-size: var(--text-size-small);
   color: var(--text-color-base);
   text-decoration: rgb(102, 102, 102);
   box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.05);
@@ -45,8 +40,8 @@
   appearance: none;
 }
 
-.Field__select--wrapper select:hover {
-  border-color: rgb(60, 122, 174);
+.Field__select--wrapper select:not([disabled]):hover {
+  border-color: var(--gray-90);
 }
 
 .Field__select--wrapper select:focus {
@@ -55,12 +50,15 @@
     rgba(60, 122, 174, 0.7) 0px 0px 4px 0px;
 }
 
-.Field__select--wrapper select:invalid {
+.Field__select--wrapper select:invalid,
+.Field--has-error select {
   border-width: var(--space-quarter);
   border-color: var(--field-border-color-error);
 }
 
-.Field__select--wrapper select:invalid:focus {
+.Field__select--wrapper select:invalid:focus,
+.Field__select--wrapper.Field--has-error select:focus,
+.Field__select--wrapper.Field--has-error select:hover {
   border-width: var(--space-quarter);
   border-color: var(--field-border-color-error);
   box-shadow: rgba(0, 0, 0, 0.05) 0px 1px 2px 0px inset,


### PR DESCRIPTION
BREAKING CHANGE: selects now have parity with `<TextField />` s in that they always render an `.Error` div. This causes a slight layout difference with more space below each `<Select />`.  The text "Required" will now show up with any `<Select />` who is passed a `true` required prop.


closes #89 