### PR TITLE
Release 2021 07 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0](https://github.com/dequelabs/cauldron/compare/v0.2.6...v1.0.0) (2021-07-28)
+
+### ⚠ BREAKING CHANGES
+
+- **react:** Loader component now set role, aria-valuetext, aria-busy, aria-valuemin, and aria-valuemax instead of making a generic role (div) have an aria-label
+- **Select:** selects now have parity with <TextField /> s in that they always render an .Error div. This causes a slight layout difference with more space below each <Select />. The text "Required" will now show up with any <Select /> who is passed a true required prop.
+
+### Features
+
+- **react:** Sets progressbar attributes on Loader ([#289](https://github.com/dequelabs/cauldron/issues/289)) ([f865166](https://github.com/dequelabs/cauldron/commit/f8651666a321fa02a418152e97ad908cd429f3e4)), closes [#53](https://github.com/dequelabs/cauldron/issues/53)
+- **Select:** Adds support for required/error ([#296](https://github.com/dequelabs/cauldron/issues/296)) ([4b0dfec](https://github.com/dequelabs/cauldron/commit/4b0dfecfa295a550e27ced833e97dabf7ea9eb1c)), closes [#89](https://github.com/dequelabs/cauldron/issues/89)
+- **Toast:** Adds support for error type ([#297](https://github.com/dequelabs/cauldron/issues/297)) ([10d3089](https://github.com/dequelabs/cauldron/commit/10d308976042cc48100ca7e7d4994cba59801583)), closes [#106](https://github.com/dequelabs/cauldron/issues/106)
+- add download icon ([77f186d](https://github.com/dequelabs/cauldron/commit/77f186dbc6c24fd13071e5b40cfd0f2964bbc97d))
+
+### Bug Fixes
+
+- **react:** remove unsupported props for alert component ([#180](https://github.com/dequelabs/cauldron/issues/180)) ([f5bf264](https://github.com/dequelabs/cauldron/commit/f5bf264dc33bf62fa59f2ceae6ac0106ce161677))
+
 ### [0.2.6](https://github.com/dequelabs/cauldron/compare/v0.2.5...v0.2.6) (2021-07-23)
 
 ### Features

--- a/docs/patterns/components/Alert/index.js
+++ b/docs/patterns/components/Alert/index.js
@@ -25,11 +25,7 @@ export default class Demo extends Component {
         <h2>Demo</h2>
         <Button onClick={this.toggleDefaultAlert}>Default Alert</Button>
         <Button onClick={this.toggleWarningAlert}>Warning Alert</Button>
-        <Alert
-          heading="Default Alert"
-          onClose={this.toggleDefaultAlert}
-          show={showDefaultAlert}
-        >
+        <Alert heading="Default Alert" show={showDefaultAlert}>
           <AlertContent>Dismissable alert</AlertContent>
           <AlertActions>
             <Button onClick={this.toggleDefaultAlert}>Ok</Button>
@@ -38,12 +34,7 @@ export default class Demo extends Component {
             </Button>
           </AlertActions>
         </Alert>
-        <Alert
-          variant="warning"
-          heading="Danger Zone"
-          onClose={this.toggleWarningAlert}
-          show={showWarningAlert}
-        >
+        <Alert variant="warning" heading="Danger Zone" show={showWarningAlert}>
           <AlertContent>Welcome to the danger zone</AlertContent>
           <AlertActions>
             <Button variant="error" onClick={this.toggleWarningAlert}>
@@ -76,7 +67,6 @@ class Demo extends Component {
         <Button onClick={this.toggleWarningAlert}>Warning Alert</Button>
         <Alert
           heading="Default Alert"
-          onClose={this.toggleDefaultAlert}
           show={showDefaultAlert}
         >
           <AlertContent>Dismissable alert</AlertContent>
@@ -90,7 +80,6 @@ class Demo extends Component {
         <Alert
           variant="warning"
           heading="Danger Zone"
-          onClose={this.toggleWarningAlert}
           show={showWarningAlert}
         >
           <AlertContent>Welcome to the danger zone</AlertContent>

--- a/docs/patterns/components/Select/index.css
+++ b/docs/patterns/components/Select/index.css
@@ -1,12 +1,3 @@
-.select-demo .select-demo-button.Button--secondary {
-  margin: 5px 0;
-}
-
-/*
-  TODO peel this back when this gets resolved
-  https://github.com/dequelabs/pattern-library/issues/59
- */
-.select-demo [role='textbox'],
-.select-demo [role='textbox']:hover {
-  border: 0;
+.SelectDemo .Field__select {
+  max-width: 300px;
 }

--- a/docs/patterns/components/Select/index.js
+++ b/docs/patterns/components/Select/index.js
@@ -12,78 +12,103 @@ const options = [
   { key: 'saturday', value: 'Saturday', disabled: true },
   { key: 'sunday', value: 'Sunday' }
 ];
+const yesNoOptions = [
+  { key: 'yes', value: 'yes' },
+  { key: 'no', value: 'no' }
+];
 
 const SelectDemo = () => {
   const [currentValue, setCurrentValue] = useState('Maybe');
 
   return (
-    <Demo
-      component={Select}
-      states={[
-        {
-          label: 'Do you like yogurt?',
-          options: [
-            { key: 'yes', value: 'Yes' },
-            { key: 'no', value: 'No' },
-            { key: 'maybe', value: 'Maybe' }
-          ],
-          value: currentValue,
-          onChange: e => setCurrentValue(e.target.value),
-          DEMO_renderBefore: <h3>Controlled select</h3>
-        },
-        {
-          label: 'Day',
-          options,
-          defaultValue: 'Friday',
-          DEMO_renderBefore: <h3>Uncontrolled select</h3>
-        },
-        {
-          label: 'How many things do you want?',
-          children: (
-            <>
-              <option>0</option>
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-            </>
-          ),
-          defaultValue: 2,
-          DEMO_renderBefore: <h3>With jsx option children (uncontrolled)</h3>
-        }
-      ]}
-      propDocs={{
-        options: {
-          type: 'array',
-          required: true,
-          description:
-            'Array of objects containing: key, value, disabled (optional), and label (optional).'
-        },
-        defaultValue: {
-          type: 'any',
-          required: false,
-          description:
-            'The default element value. Use when the component is not controlled.'
-        },
-        value: {
-          type: 'any',
-          required: false,
-          description:
-            'Use for "controlled" selects. Caller is responsible for managing the value of the select element.'
-        },
-        onChange: {
-          type: 'function',
-          required: false,
-          description:
-            'This is required if using "controlled" input; otherwise it is optional',
-          defaultValue: '() => {}'
-        },
-        children: {
-          type: 'node',
-          description: 'the <option> or <optgroup> children'
-        }
-      }}
-    />
+    <div className="SelectDemo">
+      <Demo
+        component={Select}
+        states={[
+          {
+            label: 'Do you like yogurt?',
+            options: [
+              { key: 'yes', value: 'Yes' },
+              { key: 'no', value: 'No' },
+              { key: 'maybe', value: 'Maybe' }
+            ],
+            value: currentValue,
+            onChange: e => setCurrentValue(e.target.value),
+            DEMO_renderBefore: <h3>Controlled select</h3>
+          },
+          {
+            label: 'Day',
+            options,
+            defaultValue: 'Friday',
+            DEMO_renderBefore: <h3>Uncontrolled select</h3>
+          },
+          {
+            label: 'Foo?',
+            required: true,
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>Required</h3>
+          },
+          {
+            label: 'Bar?',
+            disabled: true,
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>Disabled</h3>
+          },
+          {
+            label: 'Baz?',
+            required: true,
+            error: 'Not enough baz!',
+            options: yesNoOptions,
+            DEMO_renderBefore: <h3>With error</h3>
+          },
+          {
+            label: 'How many things do you want?',
+            children: (
+              <>
+                <option>0</option>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+              </>
+            ),
+            defaultValue: 2,
+            DEMO_renderBefore: <h3>With jsx option children (uncontrolled)</h3>
+          }
+        ]}
+        propDocs={{
+          options: {
+            type: 'array',
+            required: true,
+            description:
+              'Array of objects containing: key, value, disabled (optional), and label (optional).'
+          },
+          defaultValue: {
+            type: 'any',
+            required: false,
+            description:
+              'The default element value. Use when the component is not controlled.'
+          },
+          value: {
+            type: 'any',
+            required: false,
+            description:
+              'Use for "controlled" selects. Caller is responsible for managing the value of the select element.'
+          },
+          onChange: {
+            type: 'function',
+            required: false,
+            description:
+              'This is required if using "controlled" input; otherwise it is optional',
+            defaultValue: '() => {}'
+          },
+          children: {
+            type: 'node',
+            description: 'the <option> or <optgroup> children'
+          }
+        }}
+      />
+    </div>
   );
 };
 

--- a/docs/patterns/components/TextField/index.css
+++ b/docs/patterns/components/TextField/index.css
@@ -1,7 +1,3 @@
-.TextField button {
-  margin: 0;
-}
-
-.TextField form {
+.TextField .Field {
   max-width: 300px;
 }

--- a/docs/patterns/components/TextField/index.js
+++ b/docs/patterns/components/TextField/index.js
@@ -1,107 +1,101 @@
 import React, { Component } from 'react';
 import { TextField, Button, Code } from '@deque/cauldron-react/';
+import { className } from '../../../props';
+import Demo from '../../../Demo';
 import './index.css';
 
-export default class Demo extends Component {
-  state = {
-    error: null
-  };
+const TextFieldDemo = () => {
+  return (
+    <div className="TextField">
+      <Demo
+        states={[
+          {
+            label: 'Resting'
+          },
+          {
+            disabled: true,
+            label: 'Disabled'
+          },
+          {
+            required: true,
+            label: 'Required'
+          },
+          {
+            required: true,
+            label: 'With error',
+            error: 'This field has an error!'
+          },
+          {
+            multiline: true,
+            label: 'Text area'
+          },
+          {
+            disabled: true,
+            multiline: true,
+            label: 'Text area disabled'
+          },
+          {
+            required: true,
+            multiline: true,
+            label: 'Text area required'
+          },
+          {
+            required: true,
+            multiline: true,
+            label: 'Text area with error',
+            error: 'This text area has an error!'
+          }
+        ]}
+        component={TextField}
+        propDocs={{
+          className,
+          label: {
+            type: 'ReactNode',
+            required: true,
+            description: 'The label for the field.'
+          },
+          error: {
+            type: 'string',
+            description: 'The field‘s error message.'
+          },
+          required: {
+            type: 'boolean',
+            description: 'Whether the field is required or not.'
+          },
+          defaultValue: {
+            type: 'string',
+            description:
+              'The default value to be applied to the field. Optionally used for "uncontrolled" fields.'
+          },
+          value: {
+            type: 'string',
+            description:
+              'The value to be applied to the field. Used for "controlled" fields.'
+          },
+          onChange: {
+            type: 'function',
+            description:
+              'onChange handler for the field. The field‘s value and original event object will be passed as the 2 parameters.'
+          },
+          fieldRef: {
+            type: 'ref',
+            description: 'Field element reference.'
+          },
+          requiredText: {
+            type: 'string',
+            description: 'Custom "required" text. Useful for localization.'
+          },
+          multiline: {
+            type: 'boolean',
+            description:
+              'If true, a textarea element will be rendered. Otherwise, an input[type="text"] will be rendered.'
+          }
+        }}
+      />
+    </div>
+  );
+};
 
-  validate = e => {
-    e.preventDefault();
-    const isEmpty = !this.input.value.trim();
-    this.setState({
-      error: isEmpty ? 'Name must not be blank.' : null
-    });
+TextFieldDemo.displayName = 'TextFieldDemo';
 
-    if (isEmpty) {
-      this.input.focus();
-    }
-  };
-
-  render() {
-    return (
-      <div className="TextField">
-        <h1>TextField</h1>
-        <p>
-          The TextField component can be controlled (using the <em>value</em>{' '}
-          and <em>onChange</em> props) or uncontrolled (like traditional HTML
-          inputs).
-        </p>
-        <h2>Demo</h2>
-        <form onSubmit={this.validate} noValidate>
-          <p id="text-field-help">
-            <em>Hint:</em> submit with the name field blank to trigger error!
-          </p>
-          <TextField
-            required
-            id="name"
-            label="Name"
-            aria-describedby="text-field-help"
-            error={this.state.error}
-            fieldRef={el => (this.input = el)}
-          />
-          <TextField
-            id="favorite-color"
-            label="Favorite Color"
-            value="green"
-            disabled
-          />
-          <TextField multiline label="Comment" />
-          <Button type="submit">Submit</Button>
-        </form>
-        <h2>Code Sample</h2>
-        <Code language="javascript">
-          {`
-import React from 'react';
-import {
-  TextField, Button
-} from '@deque/cauldron-react';
-
-export default class Demo extends Component {
-  state = {
-    error: null
-  };
-
-  validate = e => {
-    e.preventDefault();
-    const isEmpty = !this.input.value.trim();
-    this.setState({
-      error: isEmpty ? 'Name must not be blank.' : null
-    });
-
-    if (isEmpty) {
-      this.input.focus();
-    }
-  };
-
-  render() {
-    return (
-      <form onSubmit={this.validate} noValidate>
-        <p id="text-field-help"><em>Hint:</em> submit with the field blank to trigger error!</p>
-        <TextField
-          required
-          id="name"
-          label="Name"
-          aria-describedby="text-field-help"
-          error={this.state.error}
-          fieldRef={el => this.input = el}
-        />
-        <TextField
-          id="favorite-color"
-          label="Favorite Color"
-          value="green"
-          disabled
-        />
-        <TextField multiline label="Comment" />
-        <Button type="submit">Submit</Button>
-      </form>
-    );
-  }
-}
-      `}
-        </Code>
-      </div>
-    );
-  }
-}
+export default TextFieldDemo;

--- a/docs/patterns/components/Toast/index.js
+++ b/docs/patterns/components/Toast/index.js
@@ -96,6 +96,21 @@ export default class Demo extends Component {
                 Info
               </Button>
             )
+          },
+          {
+            type: 'error',
+            children: 'This toast tastes like toast!',
+            show: type === 'error',
+            onDismiss: () => this.onToastDismiss('error'),
+            DEMO_renderAfter: (
+              <Button
+                variant="error"
+                onClick={() => this.onTriggerClick('error')}
+                buttonRef={el => (this.error = el)}
+              >
+                Error
+              </Button>
+            )
           }
         ]}
         propDocs={{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cauldron",
   "private": true,
-  "version": "0.2.6",
+  "version": "1.0.0",
   "license": "MPL-2.0",
   "scripts": {
     "build": "concurrently \"yarn build:styles\" \"yarn build:react\" \"yarn build:docs\"",

--- a/packages/react/__tests__/src/components/Loader/index.js
+++ b/packages/react/__tests__/src/components/Loader/index.js
@@ -18,9 +18,15 @@ test('does not set aria-hidden if a label is provided', () => {
   expect(icon.is('[aria-hidden]')).toBe(false);
 });
 
-test('sets aria-label=props.label', () => {
-  const icon = mount(<Loader label="bananas" />);
-  expect(icon.getDOMNode().getAttribute('aria-label')).toBe('bananas');
+test('sets expected progressbar attributes given a label', () => {
+  const loader = mount(<Loader label="bananas" />);
+  const loaderNode = loader.getDOMNode();
+
+  expect(loaderNode.getAttribute('role')).toBe('progressbar');
+  expect(loaderNode.getAttribute('aria-valuetext')).toBe('bananas');
+  expect(loaderNode.getAttribute('aria-busy')).toBe('true');
+  expect(loaderNode.getAttribute('aria-valuemin')).toBe('0');
+  expect(loaderNode.getAttribute('aria-valuemax')).toBe('100');
 });
 
 test('returns no axe violations', async () => {

--- a/packages/react/__tests__/src/components/Select/index.js
+++ b/packages/react/__tests__/src/components/Select/index.js
@@ -34,6 +34,7 @@ test('renders the expected UI', () => {
   expect(wrapper.find('.Field__select--required')).toBeTruthy();
   expect(wrapper.find('.Field__select')).toBeTruthy();
   expect(wrapper.find('.Field__option')).toBeTruthy();
+  expect(wrapper.find('.Field__required-text').exists()).toBe(false);
 });
 
 test('sets option attributes properly', () => {
@@ -99,24 +100,97 @@ test('passes children properly', () => {
   expect(disabledOpt.text()).toBe('b');
 });
 
+test('renders required text', () => {
+  const selectWithDefaultRequiredText = withCustomOptions({ required: true });
+  const selectWithCustomRequiredText = withCustomOptions({
+    requiredText: 'Bananas',
+    required: true
+  });
+
+  expect(
+    selectWithDefaultRequiredText.find('.Field__required-text').text()
+  ).toBe('Required');
+  expect(
+    selectWithCustomRequiredText.find('.Field__required-text').text()
+  ).toBe('Bananas');
+});
+
+test('handles errors', () => {
+  const errorText = 'ErR0r';
+  const select = withCustomOptions({
+    error: errorText
+  });
+  const error = select.find('.Error');
+
+  expect(error.text()).toBe(errorText);
+  expect(select.find('select').prop('aria-describedby')).toBe(error.prop('id'));
+  expect(
+    select.find('.Field__label--has-error').hasClass('Field__label--has-error')
+  ).toBe(true);
+  expect(
+    select.find('.Field__select--wrapper').hasClass('Field--has-error')
+  ).toBe(true);
+});
+
 test('should return no axe violations', async () => {
+  const opts = [
+    { key: '1', value: 'Bar' },
+    { key: '2', value: 'Foo' },
+    { key: '3', value: 'Far' },
+    { key: '4', value: 'Fan' },
+    { key: '5', value: 'Fun' }
+  ];
   const select = mount(
     <div>
       <Select
         {...defaultProps}
         defaultValue="Bar"
         onChange={() => {}}
-        options={[
-          { key: '1', value: 'Bar' },
-          { key: '2', value: 'Foo' },
-          { key: '3', value: 'Far' },
-          { key: '4', value: 'Fan' },
-          { key: '5', value: 'Fun' }
-        ]}
+        options={opts}
       />
     </div>
   );
   expect(await axe(select.html())).toHaveNoViolations();
+
+  const disabledSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        disabled
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(disabledSelect.html())).toHaveNoViolations();
+
+  const requiredSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        required
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(requiredSelect.html())).toHaveNoViolations();
+
+  const errorSelect = mount(
+    <div>
+      <Select
+        {...defaultProps}
+        required
+        error="Bananananas"
+        defaultValue="Bar"
+        onChange={() => {}}
+        options={opts}
+      />
+    </div>
+  );
+  expect(await axe(errorSelect.html())).toHaveNoViolations();
 });
 
 test('supports "controlled" select', () => {

--- a/packages/react/__tests__/src/components/Toast/index.js
+++ b/packages/react/__tests__/src/components/Toast/index.js
@@ -116,6 +116,21 @@ test('caution renders the expected UI and icon', () => {
   ).toBe('caution');
 });
 
+test('error renders the expected UI and icon', () => {
+  const caution = mount(
+    <Toast {...defaultProps} show type="error">
+      {'hi'}
+    </Toast>
+  );
+  expect(caution.find('.Toast.Toast--error').exists()).toBeTruthy();
+  expect(
+    caution
+      .find('Icon')
+      .at(0)
+      .prop('type')
+  ).toBe('caution');
+});
+
 test('info renders the expected UI and icon', () => {
   const info = mount(
     <Toast {...defaultProps} show type="info">
@@ -179,7 +194,7 @@ test('toast should be focused by default', done => {
 });
 
 test('toast should not be focused with falsey focus prop', done => {
-  const wrapper = mount(
+  mount(
     <Toast {...defaultProps} show={true} focus={false}>
       {'hi'}
     </Toast>
@@ -191,11 +206,35 @@ test('toast should not be focused with falsey focus prop', done => {
 });
 
 test('should return no axe violations', async () => {
-  const toast = mount(
+  const confirmation = mount(
     <Toast {...defaultProps} show={true}>
       {'hi'}
     </Toast>
   );
+  const caution = mount(
+    <Toast {...defaultProps} type="caution" show={true}>
+      {'hi'}
+    </Toast>
+  );
+  const error = mount(
+    <Toast {...defaultProps} type="error" show={true}>
+      {'hi'}
+    </Toast>
+  );
+  const actionNeeded = mount(
+    <Toast {...defaultProps} type="action-needed" show={true}>
+      {'hi'}
+    </Toast>
+  );
+  const info = mount(
+    <Toast {...defaultProps} type="info" show={true}>
+      {'hi'}
+    </Toast>
+  );
 
-  expect(await axe(toast.html())).toHaveNoViolations();
+  expect(await axe(confirmation.html())).toHaveNoViolations();
+  expect(await axe(caution.html())).toHaveNoViolations();
+  expect(await axe(error.html())).toHaveNoViolations();
+  expect(await axe(actionNeeded.html())).toHaveNoViolations();
+  expect(await axe(info.html())).toHaveNoViolations();
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-react",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Fully accessible react components library for Deque Cauldron",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/Alert/index.tsx
+++ b/packages/react/src/components/Alert/index.tsx
@@ -3,7 +3,8 @@ import classnames from 'classnames';
 import Icon from '../Icon';
 import { Dialog, DialogContent, DialogFooter, DialogProps } from '../Dialog';
 
-interface AlertProps extends Omit<DialogProps, 'forceAction'> {
+interface AlertProps
+  extends Omit<DialogProps, 'forceAction' | 'closeButtonText'> {
   variant?: 'default' | 'warning';
 }
 

--- a/packages/react/src/components/Loader/index.tsx
+++ b/packages/react/src/components/Loader/index.tsx
@@ -10,9 +10,20 @@ export default function Loader({ label, className, ...other }: LoaderProps) {
   const props = {
     ...other,
     className: classNames('Loader', className),
-    'aria-label': label,
-    'aria-hidden': label ? false : true
+    'aria-hidden': !label
   };
+
+  if (label) {
+    props.role = 'progressbar';
+    props['aria-valuetext'] = label;
+    props['aria-busy'] = true;
+    props['aria-valuemin'] = 0;
+    props['aria-valuemax'] = 100;
+    // According to the  ARIA 1.2 spec (https://www.w3.org/TR/wai-aria-1.2/#progressbar),
+    // the aria-valuenow attribute SHOULD be omitted because the "value" of our progress
+    // is "indeterminate".
+  }
+
   return <div {...props} />;
 }
 

--- a/packages/react/src/components/Select/index.tsx
+++ b/packages/react/src/components/Select/index.tsx
@@ -1,6 +1,7 @@
 import React, { Ref, useEffect, useState } from 'react';
 import uid from '../../utils/rndid';
 import classNames from 'classnames';
+import tokenList from '../../utils/token-list';
 
 export interface SelectOption {
   key: string;
@@ -12,6 +13,8 @@ export interface SelectOption {
 export interface SelectProps
   extends Omit<React.HTMLProps<HTMLSelectElement>, 'children'> {
   label: string;
+  requiredText?: string;
+  error?: string;
   options?: SelectOption[];
   children?: React.ReactElement<HTMLOptionElement | HTMLOptGroupElement>[];
   value?: any;
@@ -28,7 +31,10 @@ const Select = React.forwardRef(
       label,
       id,
       required,
+      requiredText = 'Required',
+      error,
       value,
+      'aria-describedby': ariaDescribedby,
       defaultValue,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       onChange = () => {},
@@ -67,10 +73,12 @@ const Select = React.forwardRef(
     }, [value]);
 
     const selectId = id || uid();
+    const errorId = uid();
 
     const dynamicProps: {
       value?: any;
       defaultValue?: any;
+      'aria-describedby'?: string;
     } = {};
 
     if (isControlled) {
@@ -79,19 +87,31 @@ const Select = React.forwardRef(
       dynamicProps.defaultValue = defaultValue;
     }
 
+    if (error) {
+      dynamicProps['aria-describedby'] = tokenList(errorId, ariaDescribedby);
+    }
+
     // In order to support controlled selects, we
     // have to attach an `onChange` to the select.
     /* eslint-disable jsx-a11y/no-onchange */
     return (
       <div className="Field__select">
-        <div className="Field__select--label-wrapper">
-          <label htmlFor={selectId} className="Field__label">
-            {label}
-          </label>
-        </div>
+        <label
+          htmlFor={selectId}
+          className={classNames('Field__label', {
+            'Field__label--is-required': !!required,
+            'Field__label--has-error': !!error
+          })}
+        >
+          <span>{label}</span>
+          {required && (
+            <span className="Field__required-text">{requiredText}</span>
+          )}
+        </label>
         <div
           className={classNames('Field__select--wrapper', {
-            'Field__select--disabled': disabled
+            'Field__select--disabled': disabled,
+            'Field--has-error': !!error
           })}
         >
           <select
@@ -123,6 +143,9 @@ const Select = React.forwardRef(
               : children}
           </select>
           <div className="arrow-down" />
+        </div>
+        <div className="Error" id={errorId}>
+          {error}
         </div>
       </div>
     );

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -10,7 +10,7 @@ export interface TextFieldProps
   label: React.ReactNode;
   error?: React.ReactNode;
   defaultValue?: string;
-  onChange: (
+  onChange?: (
     value: string,
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
@@ -27,11 +27,14 @@ export default class TextField extends React.Component<
   TextFieldProps,
   TextFieldState
 > {
+  static displayName = 'TextField';
   static defaultProps = {
     error: null,
     required: false,
     defaultValue: null,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     onChange: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     fieldRef: () => {},
     requiredText: 'Required',
     multiline: false
@@ -88,11 +91,11 @@ export default class TextField extends React.Component<
     const {
       label,
       fieldRef,
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       value,
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onChange,
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       defaultValue,
       error = null,
       requiredText,
@@ -149,7 +152,10 @@ export default class TextField extends React.Component<
   }
 
   onChange(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    this.props.onChange(this.input?.value || '', e);
+    if (this.props.onChange) {
+      this.props.onChange(this.input?.value || '', e);
+    }
+
     if (typeof this.props.value !== 'undefined') {
       return;
     }

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -6,7 +6,7 @@ import { typeMap, tabIndexHandler } from './utils';
 import setRef from '../../utils/setRef';
 
 export interface ToastProps {
-  type: 'confirmation' | 'caution' | 'action-needed' | 'info';
+  type: 'confirmation' | 'caution' | 'error' | 'action-needed' | 'info';
   onDismiss: () => void;
   dismissText?: string;
   toastRef: React.Ref<HTMLDivElement>;
@@ -25,7 +25,9 @@ interface ToastState {
 export default class Toast extends React.Component<ToastProps, ToastState> {
   static defaultProps = {
     dismissText: 'Dismiss',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     onDismiss: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     toastRef: () => {},
     focus: true,
     show: false
@@ -95,6 +97,8 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
     const {
       type,
       children,
+      // prevent `onDismiss` from being passed-through to DOM
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onDismiss,
       dismissText,
       toastRef,

--- a/packages/react/src/components/Toast/utils.ts
+++ b/packages/react/src/components/Toast/utils.ts
@@ -17,6 +17,10 @@ export const typeMap = {
     className: 'error',
     icon: 'no'
   },
+  error: {
+    className: 'error',
+    icon: 'caution'
+  },
   info: {
     className: 'info',
     icon: 'info-circle-alt'

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -110,8 +110,8 @@ textarea.Field--has-error:focus,
 .Field__label {
   display: flex;
   text-align: left;
-  color: #333333;
-  font-size: var(--text-size-smaller);
+  color: var(--field-label-text-color);
+  font-size: var(--text-size-small);
   font-weight: var(--font-weight-bold);
   padding-bottom: var(--space-half);
   cursor: default;
@@ -126,8 +126,9 @@ textarea.Field--has-error:focus,
   text-align: right;
   margin-left: var(--space-large);
   font-style: italic;
-  font-weight: var(--font-weight-normal);
+  font-weight: var(--font-weight-thin);
   color: var(--field-required-text-color);
+  font-size: var(--text-size-smaller);
 }
 
 .Field__required-text::before {
@@ -162,10 +163,16 @@ textarea.Field--has-error:focus,
 .Field__textarea {
   display: block;
   min-height: 56px;
-  font-size: var(--text-size-smaller);
+  font-size: var(--text-size-small);
   min-width: var(--input-min-width);
   padding: var(--space-half);
   max-width: 500px;
+}
+
+.Field__textarea[disabled],
+.Field__textarea[aria-disabled='true'] {
+  background: var(--field-background-color-disabled);
+  border: 1px solid var(--field-border-color);
 }
 
 .Radio__overlay,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -109,6 +109,7 @@ textarea.Field--has-error:focus,
 
 .Field__label {
   display: flex;
+  align-items: center;
   text-align: left;
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-styles",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "license": "MPL-2.0",
   "description": "deque cauldron pattern library styles",
   "repository": "https://github.com/dequelabs/cauldron",

--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -7,14 +7,9 @@
   opacity: 0.45;
 }
 
-.Field__select--label-wrapper {
-  display: flex;
-  justify-content: space-between;
-}
-
 .Field__select--wrapper {
   position: relative;
-  width: var(--select-width);
+  min-width: var(--select-width);
 }
 
 .arrow-down {
@@ -30,14 +25,14 @@
 }
 
 .Field__select--wrapper select {
-  width: inherit;
+  width: 100%;
   min-height: var(--select-min-height);
   padding: var(--space-three-quarters) var(--space-smallest);
   border: 1px solid var(--field-border-color);
   font-family: Roboto;
   font-weight: normal;
   font-style: normal;
-  font-size: var(--text-size-smaller);
+  font-size: var(--text-size-small);
   color: var(--text-color-base);
   text-decoration: rgb(102, 102, 102);
   box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.05);
@@ -45,8 +40,8 @@
   appearance: none;
 }
 
-.Field__select--wrapper select:hover {
-  border-color: rgb(60, 122, 174);
+.Field__select--wrapper select:not([disabled]):hover {
+  border-color: var(--gray-90);
 }
 
 .Field__select--wrapper select:focus {
@@ -55,12 +50,15 @@
     rgba(60, 122, 174, 0.7) 0px 0px 4px 0px;
 }
 
-.Field__select--wrapper select:invalid {
+.Field__select--wrapper select:invalid,
+.Field--has-error select {
   border-width: var(--space-quarter);
   border-color: var(--field-border-color-error);
 }
 
-.Field__select--wrapper select:invalid:focus {
+.Field__select--wrapper select:invalid:focus,
+.Field__select--wrapper.Field--has-error select:focus,
+.Field__select--wrapper.Field--has-error select:hover {
   border-width: var(--space-quarter);
   border-color: var(--field-border-color-error);
   box-shadow: rgba(0, 0, 0, 0.05) 0px 1px 2px 0px inset,

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -69,6 +69,7 @@
   --field-border-color-disabled: rgba(204, 204, 204, 0.25);
   --field-background-color-disabled: #f7f7f7;
   --field-required-text-color: var(--gray-60);
+  --field-label-text-color: var(--gray-90);
 
   /* buttons */
   --button-background-color-primary: var(--accent-primary);


### PR DESCRIPTION
### ⚠ BREAKING CHANGES

- **react:** Loader component now set role, aria-valuetext, aria-busy, aria-valuemin, and aria-valuemax instead of making a generic role (div) have an aria-label
- **Select:** selects now have parity with <TextField /> s in that they always render an .Error div. This causes a slight layout difference with more space below each <Select />. The text "Required" will now show up with any <Select /> who is passed a true required prop.

### Features

- **react:** Sets progressbar attributes on Loader ([#289](https://github.com/dequelabs/cauldron/issues/289)) ([f865166](https://github.com/dequelabs/cauldron/commit/f8651666a321fa02a418152e97ad908cd429f3e4)), closes [#53](https://github.com/dequelabs/cauldron/issues/53)
- **Select:** Adds support for required/error ([#296](https://github.com/dequelabs/cauldron/issues/296)) ([4b0dfec](https://github.com/dequelabs/cauldron/commit/4b0dfecfa295a550e27ced833e97dabf7ea9eb1c)), closes [#89](https://github.com/dequelabs/cauldron/issues/89)
- **Toast:** Adds support for error type ([#297](https://github.com/dequelabs/cauldron/issues/297)) ([10d3089](https://github.com/dequelabs/cauldron/commit/10d308976042cc48100ca7e7d4994cba59801583)), closes [#106](https://github.com/dequelabs/cauldron/issues/106)
- add download icon ([77f186d](https://github.com/dequelabs/cauldron/commit/77f186dbc6c24fd13071e5b40cfd0f2964bbc97d))

### Bug Fixes

- **react:** remove unsupported props for alert component ([#180](https://github.com/dequelabs/cauldron/issues/180)) ([f5bf264](https://github.com/dequelabs/cauldron/commit/f5bf264dc33bf62fa59f2ceae6ac0106ce161677))