### PR TITLE
fix(react): cursor jump caused by updating state on componentDidUpdate

### DIFF
--- a/packages/react/__tests__/src/components/TextField/index.js
+++ b/packages/react/__tests__/src/components/TextField/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { mount } from 'enzyme';
 import TextField from 'src/components/TextField';
 import axe from '../../../axe';
 
-test('controlled field', () => {
+test('using as controlled field does not maintain own state', () => {
   let input;
   const field = mount(
     <TextField label="Fred" value="" fieldRef={el => (input = el)} />
@@ -14,9 +14,37 @@ test('controlled field', () => {
     value: 'bar'
   });
   expect(input.value).toBe('bar');
+  expect(field.state('value')).toBe('');
 });
 
-test('uncontrolled field', () => {
+test('onChange prop', () => {
+  let input;
+  const TextContainer = () => {
+    const [textValue, setTextValue] = useState('');
+    return (
+      <>
+        <div id="textValueDiv">{textValue}</div>
+        <TextField
+          label="Fred"
+          value={textValue}
+          onChange={changedValue => {
+            setTextValue(changedValue);
+          }}
+          fieldRef={el => (input = el)}
+        />
+      </>
+    );
+  };
+
+  const fieldContainer = mount(<TextContainer />);
+
+  expect(fieldContainer.find('#textValueDiv').text()).toBe('');
+  input.value = 'foo';
+  fieldContainer.find('input').simulate('change');
+  expect(fieldContainer.find('#textValueDiv').text()).toBe('foo');
+});
+
+test('using as uncontrolled field maintains own state', () => {
   let input;
   const field = mount(
     <TextField label="Fred" defaultValue="foo" fieldRef={el => (input = el)} />
@@ -53,8 +81,44 @@ test('multiline=false renders input', done => {
   );
 });
 
+test('required renders required text', () => {
+  const field = mount(
+    <TextField label="Yo" required requiredText="This is required" />
+  );
+
+  expect(field.find('.Field__required-text').text()).toBe('This is required');
+});
+
+test('renders error when present', () => {
+  const field = mount(<TextField label="Yo" error="Something is wrong" />);
+  const errorElement = field.find('.Error');
+  const errorElementId = errorElement.instance().id;
+  expect(errorElement.text()).toBe('Something is wrong');
+  expect(
+    field
+      .find('input')
+      .getDOMNode()
+      .getAttribute('aria-describedby')
+  ).toBe(errorElementId);
+  expect(
+    field
+      .find('input')
+      .getDOMNode()
+      .getAttribute('aria-invalid')
+  ).toBe('true');
+});
+
 test('should return no axe violations', async () => {
-  const field = mount(<TextField label="Fred" value="" fieldRef={() => {}} />);
+  const field = mount(
+    <TextField
+      label="Fred"
+      value=""
+      required
+      requiredText="This is required"
+      error="Something is wrong"
+      fieldRef={() => {}}
+    />
+  );
 
   expect(await axe(field.html())).toHaveNoViolations();
 });

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -74,16 +74,6 @@ export default class TextField extends React.Component<
     this.onChange = this.onChange.bind(this);
   }
 
-  componentDidUpdate(prevProps: TextFieldProps) {
-    const { value } = this.props;
-
-    if (value === prevProps.value) {
-      return;
-    }
-
-    this.setState({ value });
-  }
-
   render() {
     const isRequired = !!this.props.required;
     // disabling `no-unused-vars` to prevent specific
@@ -91,7 +81,6 @@ export default class TextField extends React.Component<
     const {
       label,
       fieldRef,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       value,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onChange,
@@ -134,7 +123,7 @@ export default class TextField extends React.Component<
             'Field--has-error': error
           })}
           id={this.inputId}
-          value={this.state.value}
+          value={typeof value !== 'undefined' ? value : this.state.value}
           onChange={this.onChange}
           aria-invalid={!!error}
           ref={(input: HTMLInputElement | HTMLTextAreaElement | null) => {


### PR DESCRIPTION
closes: #352 
When a `value` prop is passed in, set the input `value` directly instead of from state. There's also no longer any need to update state with value on `componentDidUpdate` because of this change. This eliminates the issue where the cursor would jump to the end upon updating the value described in #352.

- the input value prop was always being set from state
- the `onChange` function of `TextField` was not updating state if a `value` prop was present
- `setState` was being called with the `value` prop on `componentDidUpdate`, which was causing the cursor to jump