### PR TITLE
fix: more top bar and panel related styles for dark/light theme

### DIFF
--- a/packages/react/__tests__/src/components/Stepper/index.js
+++ b/packages/react/__tests__/src/components/Stepper/index.js
@@ -43,6 +43,12 @@ test('Step: renders li and children', () => {
 test('Step: renders tooltip tabstops', () => {
   const stepper = mount(<Step status="current" tooltip="bananas" />);
   expect(stepper.find('TooltipTabstop').exists()).toBe(true);
+  expect(
+    stepper
+      .find('li')
+      .getDOMNode()
+      .getAttribute('aria-current')
+  ).toBe('step');
 });
 
 test('Step: manages aria-current attribute', () => {

--- a/packages/styles/dropdown.css
+++ b/packages/styles/dropdown.css
@@ -40,6 +40,6 @@
 }
 
 .TopBar .Dropdown {
-  top: 42px;
+  top: var(--top-bar-height);
   right: 0;
 }

--- a/packages/styles/panel.css
+++ b/packages/styles/panel.css
@@ -22,7 +22,7 @@
 .Panel__Header-title {
   flex-grow: 1;
   display: flex;
-  padding: var(--space-half) 0;
+  padding: var(--space-half) var(--space-small);
 }
 
 .Panel__Header-actions {

--- a/packages/styles/panel.css
+++ b/packages/styles/panel.css
@@ -17,12 +17,14 @@
   display: flex;
   border-bottom: 1px solid var(--panel-border-color);
   align-items: center;
+  padding: var(--space-half) 0;
 }
 
 .Panel__Header-title {
   flex-grow: 1;
   display: flex;
-  padding: var(--space-half) var(--space-small);
+  font-weight: var(--font-weight-bold);
+  padding-left: var(--space-small);
 }
 
 .Panel__Header-actions {

--- a/packages/styles/panel.css
+++ b/packages/styles/panel.css
@@ -39,7 +39,7 @@
 }
 
 /* Dark Theme */
-.cauldron--theme-dark .Panel {
+.cauldron--theme-dark {
   --panel-border-color: #5d676f;
   --panel-header-background-color: var(--accent-dark);
   --panel-header-color: var(--white);

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -1,7 +1,7 @@
 .Toast {
   top: var(--top-bar-height);
   position: fixed;
-  color: var(--top-bar-background-color-active);
+  color: #0b0e11;
   font-size: var(--text-size-small);
   z-index: var(--z-index-toast);
   align-items: center;

--- a/packages/styles/top-bar.css
+++ b/packages/styles/top-bar.css
@@ -153,7 +153,7 @@
 .cauldron--theme-dark .TopBar {
   background-color: var(--top-bar-background-color);
   color: var(--top-bar-text-color);
-  border-bottom: solid 1px var(--top-bar-border-bottom-color);
+  border-bottom: none;
 }
 
 .cauldron--theme-dark .MenuItem--separator {


### PR DESCRIPTION
fix: more top-bar related styles for dark/light theme

- fixes topbar dropdown to show at the end of the topbar as in uxpin
- fixes toasts to keep same text color for both themes as described in uxpin
- removes topbar's bottom border for dark theme as in uxpin

uxpin: https://preview.uxpin.com/5a35f510bfb55e3e77f9dbd54a49203736113855#/pages/139526426/simulate/sitemap

https://preview.uxpin.com/68df515d0023cc4b79f25d43f7663e24e363b1b9#/pages/141465422/simulate/no-panels


#316 
