### PR TITLE
fix: Match types of OptionsMenuTriggerProps

### DIFF
--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -12,9 +12,9 @@ export interface OptionsMenuAlignmentProps {
 
 export interface OptionsMenuRenderTriggerProps {
   onClick: (event: Event) => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   'aria-expanded': boolean;
-  ref: React.RefObject<HTMLElement>;
+  ref: React.RefObject<HTMLButtonElement>;
 }
 
 export interface OptionsMenuProps extends OptionsMenuAlignmentProps {

--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -58,7 +58,7 @@ export default class OptionsMenu extends Component<
     align: PropTypes.oneOf(['left', 'right'])
   };
 
-  private triggerRef: React.RefObject<HTMLElement>;
+  private triggerRef: React.RefObject<HTMLButtonElement>;
 
   constructor(props: AllOptionsMenuProps) {
     super(props);


### PR DESCRIPTION
For the issue, please check: https://github.com/dequelabs/cauldron/issues/271
This needs to be fixed to implement ApiKey table in Walnut. For the ticket, please see: https://github.com/dequelabs/walnut/issues/2446