### PR TITLE
fix: type issues of OptionsMenu

### DIFF
--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -11,10 +11,10 @@ export interface OptionsMenuAlignmentProps {
 }
 
 export interface OptionsMenuRenderTriggerProps {
-  onClick: (event: Event) => void;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   'aria-expanded': boolean;
-  ref: React.RefObject<HTMLButtonElement>;
+  ref: React.Ref<HTMLButtonElement>;
 }
 
 export interface OptionsMenuProps extends OptionsMenuAlignmentProps {
@@ -66,7 +66,7 @@ export default class OptionsMenu extends Component<
     this.triggerRef = React.createRef();
   }
 
-  toggleMenu = (event: Event) => {
+  toggleMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     this.setState(({ show }) => ({ show: !show }));
     event.preventDefault();
   };


### PR DESCRIPTION
This is a continuation of https://github.com/dequelabs/cauldron/pull/393; `OnClick `and `ref` in `OptionsMenu` also have type discrepancies with types in `OptionMenuTriggerProps`.

Is there anything we can do to catch this earlier? Our demo is mostly javaScript, if we use typescript, will we be able to catch these issues before we merge?
