### PR TITLE
fix(react): import cauldron namespace from types where needed

### DIFF
--- a/packages/react/src/components/ProgressBar/index.tsx
+++ b/packages/react/src/components/ProgressBar/index.tsx
@@ -1,3 +1,4 @@
+import { Cauldron } from '../../types';
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,4 @@
+import { Cauldron } from '../../types';
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/packages/react/src/global.d.ts
+++ b/packages/react/src/global.d.ts
@@ -7,9 +7,3 @@ declare module 'focusable' {
   function focusable(): string;
   export = focusable;
 }
-
-declare namespace Cauldron {
-  export type LabelProps =
-    | { 'aria-label': string }
-    | { 'aria-labelledby': string };
-}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,5 @@
+export namespace Cauldron {
+  export type LabelProps =
+    | { 'aria-label': string }
+    | { 'aria-labelledby': string };
+}


### PR DESCRIPTION
These changes are only needed in `3.0`, so no need to backport.

see #428 