### PR TITLE
fix(react): Prevent `Cannot find namespace 'Cauldron'` error

### DIFF
--- a/packages/react/src/global.ts
+++ b/packages/react/src/global.ts
@@ -8,6 +8,7 @@ declare module 'focusable' {
   export = focusable;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace Cauldron {
   export type LabelProps =
     | { 'aria-label': string }


### PR DESCRIPTION
Due to using `tsc --declaration --emitDeclarationOnly` to emit our TypeScript definition files, the `src/global.d.ts` file is not re-emitted by the compiler. Simply renaming it (dropping the `.d`) will prevent the `Cannot find namespace 'Cauldron'` error we're seeing in v3.

Closes #428 