### PR TITLE
chore(release): v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.1](https://github.com/dequelabs/cauldron/compare/v3.0.0...v3.0.1) (2021-11-17)
+
+### Bug Fixes
+
+- **react:** import cauldron namespace from types where needed ([#429](https://github.com/dequelabs/cauldron/issues/429)) ([400a919](https://github.com/dequelabs/cauldron/commit/400a919d600a09e233b20b245e62a1d4c5af7cd1))
+
 ## [3.0.0](https://github.com/dequelabs/cauldron/compare/v2.0.0...v3.0.0) (2021-11-15)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cauldron",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MPL-2.0",
   "scripts": {
     "build": "concurrently \"yarn build:styles\" \"yarn build:react\" \"yarn build:docs\"",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-react",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Fully accessible react components library for Deque Cauldron",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/ProgressBar/index.tsx
+++ b/packages/react/src/components/ProgressBar/index.tsx
@@ -1,3 +1,4 @@
+import { Cauldron } from '../../types';
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,4 @@
+import { Cauldron } from '../../types';
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/packages/react/src/global.d.ts
+++ b/packages/react/src/global.d.ts
@@ -7,9 +7,3 @@ declare module 'focusable' {
   function focusable(): string;
   export = focusable;
 }
-
-declare namespace Cauldron {
-  export type LabelProps =
-    | { 'aria-label': string }
-    | { 'aria-labelledby': string };
-}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,5 @@
+export namespace Cauldron {
+  export type LabelProps =
+    | { 'aria-label': string }
+    | { 'aria-labelledby': string };
+}

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-styles",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MPL-2.0",
   "description": "deque cauldron pattern library styles",
   "repository": "https://github.com/dequelabs/cauldron",


### PR DESCRIPTION
### [3.0.1](https://github.com/dequelabs/cauldron/compare/v3.0.0...v3.0.1) (2021-11-17)

### Bug Fixes

- **react:** import cauldron namespace from types where needed ([#429](https://github.com/dequelabs/cauldron/issues/429)) ([400a919](https://github.com/dequelabs/cauldron/commit/400a919d600a09e233b20b245e62a1d4c5af7cd1))