### PR TITLE
fix(docs): sets banner role on topbar to resolve axe-core issue

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -160,7 +160,7 @@ const App = () => {
           defaultTitle="Deque Cauldron React"
         />
         <SkipLink target={'#main-content'} />
-        <TopBar>
+        <TopBar role="banner">
           <MenuBar thin={thin} hasTrigger>
             <TopBarTrigger onClick={onTriggerClick}>
               <button


### PR DESCRIPTION
resolves 1 issue type for the new a11y tests (#386):

> All page content should be contained by landmarks