### PR TITLE
fix(docs): gives skip nav a unique accessible name

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -159,7 +159,7 @@ const App = () => {
           titleTemplate="%s | Deque Cauldron React"
           defaultTitle="Deque Cauldron React"
         />
-        <SkipLink target={'#main-content'} />
+        <SkipLink target={'#main-content'} aria-label="Skip" />
         <TopBar>
           <MenuBar thin={thin} hasTrigger>
             <TopBarTrigger onClick={onTriggerClick}>


### PR DESCRIPTION
resolves 1 issue type for the new a11y tests (#386):

> Ensures landmarks are unique

---

VO readout:

> Link, skip to Main Content, Skip, navigation

<img width="600" alt="Link, skip to Main Content, Skip, navigation" src="https://user-images.githubusercontent.com/3180185/144520560-dd8748d1-2255-487e-8730-cd19497139a6.png">


ever so slightly redundant but resolve an axe-core issue by giving this navigation element a unique accessible name