### PR TITLE
fix(docs): Makes code blocks focusable regions to allow keyboard users to scroll them

### DIFF
--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -61,7 +61,7 @@ const Demo = props => {
                 {DEMO_renderBefore}
                 <Component {...thinState} />
                 {DEMO_renderAfter}
-                <Code>
+                <Code role="region" tabIndex={0}>
                   {`${componentMarkup}${afterMarkup ? `\n${afterMarkup}` : ''}`}
                 </Code>
               </div>

--- a/docs/patterns/components/Address/index.js
+++ b/docs/patterns/components/Address/index.js
@@ -51,7 +51,7 @@ class AddressDemo extends Component {
             <AddressLine>1234 Sesame Street</AddressLine>
             <AddressCityStateZip city="Metrocity" state="AA" zip="8675309" />
           </Address>
-          <Code>
+          <Code role="region" tabIndex={0}>
             {`<Address>
   <AddressLine>1234 Sesame Street</AddressLine>
   <AddressCityStateZip city="Metrocity" state="AA" zip="8675309" />
@@ -63,7 +63,7 @@ class AddressDemo extends Component {
             <AddressLine>1234 Sesame Street</AddressLine>
             <AddressCityStateZip city="Metrocity" zip="8675309" />
           </Address>
-          <Code>
+          <Code role="region" tabIndex={0}>
             {`<Address>
   <AddressLine>1234 Sesame Street</AddressLine>
   <AddressCityStateZip city="Metrocity" zip="8675309" />
@@ -75,7 +75,7 @@ class AddressDemo extends Component {
             <AddressLine>1234 Sesame Street</AddressLine>
             <AddressCityStateZip city="Metrocity" state="AA" />
           </Address>
-          <Code>
+          <Code role="region" tabIndex={0}>
             {`<Address>
   <AddressLine>1234 Sesame Street</AddressLine>
   <AddressCityStateZip city="Metrocity" state="AA" />

--- a/docs/patterns/components/DescriptionList/index.js
+++ b/docs/patterns/components/DescriptionList/index.js
@@ -137,7 +137,7 @@ class DescriptionListDemo extends Component {
               </DescriptionList>
             </li>
           </ul>
-          <Code>
+          <Code role="region" tabIndex={0}>
             {`<DescriptionList collapsed={${collapsed}}>
   <DescriptionListItem>
     <DescriptionTerm>First name</DescriptionTerm>

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -79,7 +79,10 @@ const LoaderOverlayDemo = () => {
         <Button onClick={onClick} buttonRef={buttonRef}>
           Show loader for {LOADING_DURATION / 1000} seconds
         </Button>
-        <Code>{`<LoaderOverlay tabIndex={-1} ref={loaderRef}>
+        <Code
+          role="region"
+          tabIndex={0}
+        >{`<LoaderOverlay tabIndex={-1} ref={loaderRef}>
   <Loader />
   <div>Loading...</div>
 </LoaderOverlay>`}</Code>


### PR DESCRIPTION

resolves 1 issue type for the new a11y tests (#386):

> Scrollable region must have keyboard access

