### PR TITLE
fix: render null instead of false in empty cases

### DIFF
--- a/packages/react/src/components/Address/index.tsx
+++ b/packages/react/src/components/Address/index.tsx
@@ -25,11 +25,11 @@ export const AddressLine = ({
   className,
   ...other
 }: AddressLineProps) =>
-  !!children && (
+  children ? (
     <div className={classNames('Address__line', className)} {...other}>
       {children}
     </div>
-  );
+  ) : null;
 
 AddressLine.displayName = 'AddressLine';
 AddressLine.propTypes = {
@@ -50,7 +50,7 @@ export const AddressCityStateZip = ({
   className,
   ...other
 }: AddressCityStateZipProps) =>
-  !!(city || state || zip) && (
+  city || state || zip ? (
     <div
       className={classNames('Address__city-state-zip', className)}
       {...other}
@@ -59,7 +59,7 @@ export const AddressCityStateZip = ({
         .filter(Boolean)
         .join(' ')}
     </div>
-  );
+  ) : null;
 
 AddressCityStateZip.displayName = 'AddressCityStateZip';
 AddressCityStateZip.propTypes = {


### PR DESCRIPTION
Typescript didn't like that these elements returned false. It expects `JSX.Element` to either be an element or null