### PR TITLE
fix: allow TableHeader to take th attributes and TableCell to take td attributes

### DIFF
--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { TdHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableCellProps {
+interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
   children: React.ReactNode;
   className?: string;
 }

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { ThHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableHeaderProps {
+interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   children: React.ReactNode;
   className?: string;
 }


### PR DESCRIPTION
Currently, the way the types are set up, we can't set any attributes on `TableHeader` or `TableCell` except `className`. We should be able to set things like `scope` and `colspan`.

We've had to set `TableHeader` to `any` to get around this: https://github.com/dequelabs/walnut/pull/2042/files#diff-c0d076ba97b24a2d7584c89ff60baf472ce1e33c4b9399c3c3b9befac61527b6R23

Related: https://github.com/dequelabs/cauldron/issues/288