### PR TITLE
fix: remove unused background color for disabled select

### DIFF
--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -10,7 +10,6 @@
 }
 
 .Field__select--disabled {
-  background: var(--field-background-color-disabled);
   opacity: 0.65;
 }
 


### PR DESCRIPTION
The pr fixes the margin-bottom with background color for dark theme select:

<img width="723" alt="Screen Shot 2021-12-08 at 2 11 43 PM" src="https://user-images.githubusercontent.com/83524297/145269434-b4955a08-b00f-4a09-890a-dce9d1aaa945.png">

Not very visible in Cauldron, but very obvious in extension:

<img width="405" alt="Screen Shot 2021-12-08 at 2 13 34 PM" src="https://user-images.githubusercontent.com/83524297/145269545-b98e3b1f-69ac-4ece-b566-e49f28e1251a.png">

