### PR TITLE
fix: Correct dialog content padding according to design

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -85,7 +85,7 @@
 }
 
 .Dialog__content {
-  padding: calc(var(--space-small) - 4px) var(--dialog-padding);
+  padding: var(--dialog-padding);
 }
 
 .Dialog__content p:first-child {
@@ -137,6 +137,7 @@
   display: flex;
   justify-content: center;
   border-top: none;
+  padding-top: 0;
 }
 
 /* Dark Theme */


### PR DESCRIPTION
This will only affect dialogs with a fixed height

<img width="487" alt="Screen Shot 2021-12-08 at 2 08 34 PM" src="https://user-images.githubusercontent.com/83524297/145269018-986c6669-8ef8-4cb2-be93-9c23e6824f1c.png">

<img width="474" alt="Screen Shot 2021-12-08 at 2 08 43 PM" src="https://user-images.githubusercontent.com/83524297/145269038-364a2354-b00a-49db-b73c-a5e57c866987.png">

<img width="476" alt="Screen Shot 2021-12-08 at 2 08 55 PM" src="https://user-images.githubusercontent.com/83524297/145269050-3196f156-48be-4918-aebf-85389efd0ec1.png">

<img width="478" alt="Screen Shot 2021-12-08 at 2 09 04 PM" src="https://user-images.githubusercontent.com/83524297/145269065-4870f5da-6655-44a6-aebd-740f606212c9.png">


