### PR TITLE
fix(Step): Add an accessible name when using `tooltip={...}`

### DIFF
--- a/docs/patterns/components/Stepper/index.js
+++ b/docs/patterns/components/Stepper/index.js
@@ -118,6 +118,7 @@ const StepperDemo = () => {
                       <div>Status: Complete</div>
                     </>
                   }
+                  tooltipText="Foo Complete"
                 />
                 <Step
                   status="current"
@@ -127,6 +128,7 @@ const StepperDemo = () => {
                       <div>Status: Current</div>
                     </>
                   }
+                  tooltipText="Bar Current"
                 />
               </>
             )
@@ -191,6 +193,18 @@ const StepperDemo = () => {
             <TableCell>
               tooltip content to be rendered with the tooltip tabstop on the
               step (no visible label will be rendered)
+            </TableCell>
+            <TableCell>
+              <code>null</code>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>tooltipText</TableCell>
+            <TableCell>string</TableCell>
+            <TableCell>false</TableCell>
+            <TableCell>
+              text summary of the tooltip, used as the{' '}
+              <code>&lt;Step/&gt;</code>’s <code>aria-label</code>
             </TableCell>
             <TableCell>
               <code>null</code>

--- a/packages/react/__tests__/src/components/Stepper/index.js
+++ b/packages/react/__tests__/src/components/Stepper/index.js
@@ -41,7 +41,9 @@ test('Step: renders li and children', () => {
 });
 
 test('Step: renders tooltip tabstops', () => {
-  const stepper = mount(<Step status="current" tooltip="bananas" />);
+  const stepper = mount(
+    <Step status="current" tooltip="bananas" tooltipText="bananas" />
+  );
   expect(stepper.find('TooltipTabstop').exists()).toBe(true);
   expect(
     stepper
@@ -83,8 +85,8 @@ test('should return no axe violations', async () => {
 
   const stepperWithTooltip = mount(
     <Stepper>
-      <Step status="complete" tooltip="bananas" />
-      <Step status="current" tooltip="mangos" />
+      <Step status="complete" tooltip="bananas" tooltipText="bananas" />
+      <Step status="current" tooltip="mangos" tooltipText="mangos" />
     </Stepper>
   );
 

--- a/packages/react/src/components/Stepper/index.tsx
+++ b/packages/react/src/components/Stepper/index.tsx
@@ -14,6 +14,7 @@ interface StepWithChildren extends BaseStepProps {
 
 interface StepWithTooltip extends BaseStepProps {
   tooltip: React.ReactNode;
+  tooltipText: string;
 }
 
 type StepProps = StepWithChildren | StepWithTooltip;
@@ -46,6 +47,7 @@ export const Step = (props: StepProps) => {
             // it with the contents of the tooltip in the
             // tab stop's accessible name.
             association="aria-labelledby"
+            aria-label={isTooltip(props) ? props.tooltipText : undefined}
           >
             <div className="Stepper__step-indicator" />
           </TooltipTabstop>
@@ -67,6 +69,7 @@ Step.displayName = 'Step';
 Step.propTypes = {
   children: PropTypes.node,
   tooltip: PropTypes.node,
+  tooltipText: PropTypes.string,
   className: PropTypes.string
 };
 


### PR DESCRIPTION
This patch adds a new `tooltipText="..."` prop to the `<Step/>` component when using it in tooltip mode. This enables us to add an explicit accessible name to the underlying `<button/>`, which prevents axe-core from raising the following issue:

> Buttons must have discernible text

See https://axe.deque.com/issues/5b594e52-53b4-4ed4-8a41-bc22a630fb73

Closes #445