### PR TITLE
fix(styles): set close button for toast to have a minimum height of 24px

### DIFF
--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -36,6 +36,7 @@
 .Toast__dismiss {
   background: transparent;
   border: 0;
+  height: calc(var(--text-size-small) + 9px);
 }
 
 .Toast__dismiss:focus {


### PR DESCRIPTION
![toast with close button of 34x24 target size](https://user-images.githubusercontent.com/1062039/146060790-a731cda5-eb8e-4249-8ec5-c85188690f81.png)

closes #408 