### PR TITLE
fix(react): update loader to address issues with being announced in JAWS

### DIFF
--- a/docs/patterns/components/Loader/index.js
+++ b/docs/patterns/components/Loader/index.js
@@ -6,23 +6,12 @@ import { className } from '../../../props';
 const LoaderDemo = () => (
   <Demo
     component={Loader}
-    states={[
-      { 'aria-label': 'Loading...' },
-      {
-        'aria-labelledby': 'loading-text',
-        DEMO_renderAfter: <span id="loading-text">Loading...</span>
-      }
-    ]}
+    states={[{ label: 'Loading...' }, {}]}
     propDocs={{
-      'aria-label': {
+      label: {
         type: 'string',
         description:
-          'The desired label to be set on the loader. If not provided, aria-hidden="true" will be applied to the element.'
-      },
-      'aria-labelledby': {
-        type: 'string',
-        description:
-          'The desired associated element to use the associated accessible name. If not provided, aria-hidden="true" will be applied to the element.'
+          'The desired label will be rendered offscreen. If not provided, aria-hidden="true" will be applied to the element.'
       },
       className
     }}

--- a/docs/patterns/components/Loader/index.js
+++ b/docs/patterns/components/Loader/index.js
@@ -6,12 +6,23 @@ import { className } from '../../../props';
 const LoaderDemo = () => (
   <Demo
     component={Loader}
-    states={[{ label: 'Loading...' }, {}]}
+    states={[
+      { 'aria-label': 'Loading...' },
+      {
+        'aria-labelledby': 'loading-text',
+        DEMO_renderAfter: <span id="loading-text">Loading...</span>
+      }
+    ]}
     propDocs={{
-      label: {
+      'aria-label': {
         type: 'string',
         description:
-          'The desired label to be set on the loader as the aria-label. If not provided, aria-hidden="true" will be applied to the element.'
+          'The desired label to be set on the loader. If not provided, aria-hidden="true" will be applied to the element.'
+      },
+      'aria-labelledby': {
+        type: 'string',
+        description:
+          'The desired associated element to use the associated accessible name. If not provided, aria-hidden="true" will be applied to the element.'
       },
       className
     }}

--- a/packages/react/__tests__/src/components/Loader/index.js
+++ b/packages/react/__tests__/src/components/Loader/index.js
@@ -19,19 +19,10 @@ test('does not set aria-hidden if a label is provided', () => {
 });
 
 test('sets expected role attributes given an aria-label', () => {
-  const loader = mount(<Loader aria-label="bananas" />);
+  const loader = mount(<Loader label="bananas" />);
   const loaderNode = loader.getDOMNode();
 
   expect(loaderNode.getAttribute('role')).toBe('alert');
-  expect(loaderNode.getAttribute('aria-busy')).toBe('true');
-});
-
-test('sets expected role attributes given an aria-labelledby', () => {
-  const loader = mount(<Loader aria-labelledby="bananas" />);
-  const loaderNode = loader.getDOMNode();
-
-  expect(loaderNode.getAttribute('role')).toBe('alert');
-  expect(loaderNode.getAttribute('aria-busy')).toBe('true');
 });
 
 test('returns no axe violations', async () => {

--- a/packages/react/__tests__/src/components/Loader/index.js
+++ b/packages/react/__tests__/src/components/Loader/index.js
@@ -18,15 +18,20 @@ test('does not set aria-hidden if a label is provided', () => {
   expect(icon.is('[aria-hidden]')).toBe(false);
 });
 
-test('sets expected progressbar attributes given a label', () => {
-  const loader = mount(<Loader label="bananas" />);
+test('sets expected role attributes given an aria-label', () => {
+  const loader = mount(<Loader aria-label="bananas" />);
   const loaderNode = loader.getDOMNode();
 
-  expect(loaderNode.getAttribute('role')).toBe('progressbar');
-  expect(loaderNode.getAttribute('aria-valuetext')).toBe('bananas');
+  expect(loaderNode.getAttribute('role')).toBe('alert');
   expect(loaderNode.getAttribute('aria-busy')).toBe('true');
-  expect(loaderNode.getAttribute('aria-valuemin')).toBe('0');
-  expect(loaderNode.getAttribute('aria-valuemax')).toBe('100');
+});
+
+test('sets expected role attributes given an aria-labelledby', () => {
+  const loader = mount(<Loader aria-labelledby="bananas" />);
+  const loaderNode = loader.getDOMNode();
+
+  expect(loaderNode.getAttribute('role')).toBe('alert');
+  expect(loaderNode.getAttribute('aria-busy')).toBe('true');
 });
 
 test('returns no axe violations', async () => {

--- a/packages/react/src/components/Loader/index.tsx
+++ b/packages/react/src/components/Loader/index.tsx
@@ -1,34 +1,31 @@
+import { Cauldron } from '../../types';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
-  label: string;
-}
+export type LoaderProps = React.HTMLAttributes<HTMLDivElement> &
+  Partial<Cauldron.LabelProps>;
 
-export default function Loader({ label, className, ...other }: LoaderProps) {
+export default function Loader({ className, ...other }: LoaderProps) {
   const props = {
     ...other,
-    className: classNames('Loader', className),
-    'aria-hidden': !label
+    className: classNames('Loader', className)
   };
 
-  if (label) {
-    props.role = 'progressbar';
-    props['aria-valuetext'] = label;
+  const { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy } = props;
+  const hasLabel = ariaLabel || ariaLabelledBy;
+
+  if (hasLabel) {
+    props['role'] = 'alert';
     props['aria-busy'] = true;
-    props['aria-valuemin'] = 0;
-    props['aria-valuemax'] = 100;
-    // According to the  ARIA 1.2 spec (https://www.w3.org/TR/wai-aria-1.2/#progressbar),
-    // the aria-valuenow attribute SHOULD be omitted because the "value" of our progress
-    // is "indeterminate".
+  } else {
+    props['aria-hidden'] = true;
   }
 
   return <div {...props} />;
 }
 
 Loader.propTypes = {
-  label: PropTypes.string,
   className: PropTypes.string
 };
 

--- a/packages/react/src/components/Loader/index.tsx
+++ b/packages/react/src/components/Loader/index.tsx
@@ -1,23 +1,22 @@
 import { Cauldron } from '../../types';
 import React from 'react';
 import PropTypes from 'prop-types';
+import Offscreen from '../Offscreen';
 import classNames from 'classnames';
 
-export type LoaderProps = React.HTMLAttributes<HTMLDivElement> &
-  Partial<Cauldron.LabelProps>;
+export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  label?: string;
+}
 
-export default function Loader({ className, ...other }: LoaderProps) {
+export default function Loader({ className, label, ...other }: LoaderProps) {
   const props = {
     ...other,
     className: classNames('Loader', className)
   };
 
-  const { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy } = props;
-  const hasLabel = ariaLabel || ariaLabelledBy;
-
-  if (hasLabel) {
+  if (label?.length) {
     props['role'] = 'alert';
-    props['aria-busy'] = true;
+    props.children = <Offscreen>{label}</Offscreen>;
   } else {
     props['aria-hidden'] = true;
   }


### PR DESCRIPTION
JAWS was only reading the `role="alert"` element when navigating through the dom when there is name from contents, and not `aria-label`. 

closes #423 