### PR TITLE
build: Setup Amplify PR deployment previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,21 @@
+name: PR preview
+
+on: pull_request
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: setenv
+        run: echo "::set-output name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+      - uses: yinlinchen/amplify-preview-actions@master
+        with:
+          branch_name: ${{ steps.setenv.outputs.BRANCH_NAME }}
+          amplify_command: deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AmplifyAppId: d1gko6en628vir
+          AWS_REGION: us-east-1


### PR DESCRIPTION
A **super cool** undocumented feature of AWS Amplify is that deployment previews are not supported for open source repos. This patch implements an action which works around this limitation and _should_ create a preview for every opened PR.