### PR TITLE
fix: fix loader

### DIFF
--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -43,6 +43,10 @@ const LoaderOverlayDemo = () => {
       propDocs={{
         className,
         children,
+        label: {
+          type: 'string',
+          description: 'A primary label for the loader.'
+        },
         variant: {
           type: 'string',
           description: 'Loader variant, can be "small" or "large".'

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -9,34 +9,35 @@ interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   label?: string;
 }
 
-const LoaderOverlay = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, variant, label, ...other }: LoaderOverlayProps, ref) => (
-  <div
-    className={classNames(
-      'Loader__overlay',
-      className,
-      variant === 'large'
-        ? 'Loader__overlay--large'
-        : variant === 'small'
-        ? 'Loader__overlay--small'
-        : ''
-    )}
-    ref={ref}
-    {...other}
-  >
-    <div className="Loader__overlay__loader">
-      <Loader variant={variant} />
-      <AxeLoader />
+const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
+  ({ className, variant, label, ...other }: LoaderOverlayProps, ref) => (
+    <div
+      className={classNames(
+        'Loader__overlay',
+        className,
+        variant === 'large'
+          ? 'Loader__overlay--large'
+          : variant === 'small'
+          ? 'Loader__overlay--small'
+          : ''
+      )}
+      ref={ref}
+      {...other}
+    >
+      <div className="Loader__overlay__loader">
+        <Loader variant={variant} />
+        <AxeLoader />
+      </div>
+      {label ? <span className="Loader__overlay__label">{label}</span> : null}
+      {other.children}
     </div>
-    {label ? <span className="Loader__overlay__label">{label}</span> : null}
-    {other.children}
-  </div>
-));
+  )
+);
 
 LoaderOverlay.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
+  variant: PropTypes.oneOf(['large', 'small']),
+  label: PropTypes.string
 };
 
 LoaderOverlay.displayName = 'LoaderOverlay';

--- a/packages/styles/loader.css
+++ b/packages/styles/loader.css
@@ -92,7 +92,7 @@
   justify-content: center;
   min-height: var(--loader-ring-size);
   min-width: var(--loader-ring-size);
-  margin: 0 0 var(--space-small) 0;
+  margin-bottom: var(--space-small);
 }
 
 .Loader__overlay--large .Loader__overlay__loader {

--- a/packages/styles/loader.css
+++ b/packages/styles/loader.css
@@ -26,6 +26,7 @@
 }
 
 .Loader {
+  margin: 50px auto;
   position: relative;
   display: flex;
   height: var(--loader-ring-size);
@@ -91,7 +92,7 @@
   justify-content: center;
   min-height: var(--loader-ring-size);
   min-width: var(--loader-ring-size);
-  margin-bottom: var(--space-small);
+  margin: 0 0 var(--space-small) 0;
 }
 
 .Loader__overlay--large .Loader__overlay__loader {

--- a/packages/styles/loader.css
+++ b/packages/styles/loader.css
@@ -112,6 +112,7 @@
 
 .Loader__overlay .Loader {
   position: absolute;
+  margin: 0;
 }
 
 .Loader__overlay svg {


### PR DESCRIPTION
Fixing a couple of regressions with the loader:

- Allow `label` and `variant` props to be set for the loader overlay. (Since they are not included in the propTypes, they can't be set)
- Restore the default layout styles for the loader (previously, was `50px auto`)