### PR TITLE
fix(react): fix tooltip performance issue

### DIFF
--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -143,10 +143,10 @@ export default function Tooltip({
     return () => {
       targetElement.removeEventListener('keyup', handleEscape);
     };
-  }, [show]);
+  }, [showProp]);
 
   useEffect(() => {
-    if (typeof show !== undefined) {
+    if (typeof showProp !== undefined) {
       targetElement?.addEventListener('mouseenter', handleTriggerMouseEnter);
       targetElement?.addEventListener('mouseleave', handleTriggerMouseLeave);
       targetElement?.addEventListener('focusin', show);
@@ -158,7 +158,7 @@ export default function Tooltip({
       targetElement?.removeEventListener('focusin', show);
       targetElement?.removeEventListener('focusout', hide);
     };
-  }, [targetElement, show]);
+  }, [targetElement, showProp]);
 
   useEffect(() => {
     if (tooltipElement) {


### PR DESCRIPTION
This fixes a tooltip performance issue where the `useEffect` was intending to be acting on the `show` prop, but there was also an internal function named `show` causing the tooltip to re-run the useEffect for every render exponentially adding event listeners eventually causing anything using this to be very slow or crash.