### PR TITLE
fix(react): Allow `Step` to accept any LI props

### DIFF
--- a/packages/react/src/components/Stepper/index.tsx
+++ b/packages/react/src/components/Stepper/index.tsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TooltipTabstop from '../TooltipTabstop';
 
-interface BaseStepProps {
+interface BaseStepProps extends React.LiHTMLAttributes<HTMLLIElement> {
   status: 'current' | 'complete' | 'future';
-  className?: string;
 }
 
 interface StepWithChildren extends BaseStepProps {
@@ -19,12 +18,23 @@ interface StepWithTooltip extends BaseStepProps {
 
 type StepProps = StepWithChildren | StepWithTooltip;
 
-const isTooltip = (props: StepProps): props is StepWithTooltip => {
+const isTooltipProps = (props: unknown): props is StepWithTooltip => {
   return !!(props as StepWithTooltip).tooltip;
 };
 
 export const Step = (props: StepProps) => {
-  const { status, className, ...other } = props;
+  const { children, status, className, ...other } = props;
+  let tooltip: React.ReactNode | undefined;
+  let tooltipText: string | undefined;
+  let liProps: React.LiHTMLAttributes<HTMLLIElement>;
+  const isTooltip = isTooltipProps(other);
+
+  if (isTooltip) {
+    ({ tooltip, tooltipText, ...liProps } = other);
+  } else {
+    liProps = other;
+  }
+
   return (
     <li
       className={classNames(
@@ -33,30 +43,30 @@ export const Step = (props: StepProps) => {
         className
       )}
       aria-current={status === 'current' ? 'step' : 'false'}
-      {...other}
+      {...liProps}
     >
       <div className="Stepper__step-line" />
       <div className="Stepper__step-content">
-        {isTooltip(props) ? (
+        {isTooltip ? (
           <TooltipTabstop
             placement="bottom"
-            tooltip={props.tooltip}
+            tooltip={tooltip}
             // the pseudo content (ex: "1") is conveyed
             // by the list item's position in the set of
             // list items, therefore it is safe to clobber
             // it with the contents of the tooltip in the
             // tab stop's accessible name.
             association="aria-labelledby"
-            aria-label={isTooltip(props) ? props.tooltipText : undefined}
+            aria-label={tooltipText}
           >
             <div className="Stepper__step-indicator" />
           </TooltipTabstop>
         ) : (
           <>
             <div className="Stepper__step-indicator" />
-            {'children' in props && (
-              <div className="Stepper__step-label">{props.children}</div>
-            )}
+            {children ? (
+              <div className="Stepper__step-label">{children}</div>
+            ) : null}
           </>
         )}
       </div>
@@ -70,7 +80,7 @@ Step.propTypes = {
   children: PropTypes.node,
   tooltip: PropTypes.node,
   tooltipText: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 interface StepperProps {
@@ -88,7 +98,7 @@ Stepper.displayName = 'Stepper';
 
 Stepper.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default Stepper;

--- a/packages/react/src/components/Stepper/index.tsx
+++ b/packages/react/src/components/Stepper/index.tsx
@@ -30,7 +30,7 @@ export const Step = (props: StepProps) => {
   const isTooltip = isTooltipProps(other);
 
   if (isTooltip) {
-    ({ tooltip, tooltipText, ...liProps } = other);
+    ({ tooltip, tooltipText, ...liProps } = other as StepWithTooltip);
   } else {
     liProps = other;
   }


### PR DESCRIPTION
This patch updates the `react` package's `<Step/>` component's type definitions, allowing it to accept any `<li>` props. Additionally, we're no longer adding an invalid `tooltipText={...}` prop to the `<li>`, which prevents the following warning from the tests:

```
    console.error node_modules/react-dom/cjs/react-dom.development.js:88
      Warning: React does not recognize the `tooltipText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `tooltiptext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in li (created by Step)
          in Step (created by WrapperComponent)
          in WrapperComponent
```