### PR TITLE
feat(checkbox): add labelDescription prop

### DIFF
--- a/docs/patterns/components/Checkbox/index.js
+++ b/docs/patterns/components/Checkbox/index.js
@@ -59,8 +59,23 @@ export default class CheckboxDemo extends Component {
               id: 'demo-checkbox-5',
               name: 'demo-checkbox-5',
               label: 'Demo checkbox 5',
-              value: '4',
+              value: '5',
               error: 'The fifth checkbox is required!'
+            },
+            {
+              id: 'demo-checkbox-6',
+              name: 'demo-checkbox-6',
+              label: 'Demo checkbox 6',
+              labelDescription: 'Has description text',
+              value: '6'
+            },
+            {
+              id: 'demo-checkbox-7',
+              name: 'demo-checkbox-7',
+              label: 'Demo checkbox 7',
+              labelDescription: 'Has description text',
+              value: '7',
+              error: "You made a mistake, but it's ok!"
             }
           ]}
           propDocs={{
@@ -80,6 +95,11 @@ export default class CheckboxDemo extends Component {
             label: {
               type: 'string',
               description: "The text of the checkbox's label",
+              required: true
+            },
+            labelDescription: {
+              type: 'string',
+              description: "The text description of the checkbox's label",
               required: true
             },
             value: {

--- a/packages/react/__tests__/src/components/Checkbox/index.js
+++ b/packages/react/__tests__/src/components/Checkbox/index.js
@@ -118,3 +118,15 @@ test('handles error prop', async () => {
   const input = wrapper.find('input').getDOMNode();
   expect(input.getAttribute('aria-describedby')).toBe(errorMessage.id);
 });
+
+test('handles labelDescription prop', async () => {
+  const wrapper = mount(
+    <Checkbox {...defaultProps} labelDescription={'/giphy bears'} />
+  );
+  expect(await axe(wrapper.html())).toHaveNoViolations();
+  const labelDescription = wrapper
+    .find('.Field__labelDescription')
+    .getDOMNode();
+  const input = wrapper.find('input').getDOMNode();
+  expect(input.getAttribute('aria-describedby')).toBe(labelDescription.id);
+});

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -15,6 +15,7 @@ import tokenList from '../../utils/token-list';
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;
   label: React.ReactNode;
+  labelDescription?: string;
   error?: React.ReactNode;
   customIcon?: React.ReactNode;
   checkboxRef?: Ref<HTMLInputElement>;
@@ -25,6 +26,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     {
       id,
       label,
+      labelDescription,
       error,
       checkboxRef,
       className,
@@ -49,11 +51,22 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       refProp(checkRef.current);
     }
 
-    const errorId = useMemo(() => nextId(), []);
+    const { errorId, labelDescriptionId } = useMemo(() => {
+      return {
+        labelDescriptionId: nextId(),
+        errorId: nextId()
+      };
+    }, []);
 
-    const ariaDescribedbyId = error
-      ? tokenList(errorId, ariaDescribedby)
-      : ariaDescribedby;
+    let ariaDescribedbyId = ariaDescribedby;
+
+    if (error) {
+      ariaDescribedbyId = tokenList(errorId, ariaDescribedbyId);
+    }
+
+    if (labelDescription) {
+      ariaDescribedbyId = tokenList(labelDescriptionId, ariaDescribedbyId);
+    }
 
     return (
       <>
@@ -99,12 +112,17 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               }
             }}
           />
+          {labelDescription && (
+            <span id={labelDescriptionId} className="Field__labelDescription">
+              {labelDescription}
+            </span>
+          )}
+          {error && (
+            <div id={errorId} className="Error">
+              {error}
+            </div>
+          )}
         </div>
-        {error && (
-          <div id={errorId} className="Error">
-            {error}
-          </div>
-        )}
       </>
     );
   }

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -280,6 +280,18 @@ textarea.Field--has-error:focus:hover,
   cursor: default;
 }
 
+.Icon + .Error {
+  flex-basis: 100%;
+  margin-top: var(--space-smallest);
+}
+
+.Field__labelDescription + .Error {
+  border-top: 1px solid var(--error);
+  margin-left: calc(24px + 2px + var(--space-half));
+  padding: 4px 0;
+  margin-top: 4px;
+}
+
 .Radio__overlay,
 .Checkbox__overlay {
   border: 1px solid transparent;


### PR DESCRIPTION
add: new prop (optional) for `labelDescription` that can be used to provide additional context to checkbox options
update: CSS style for error when paired with `labelDescription` as requested by @awpearlm 

closes: #527 