### PR TITLE
fix: do not reserve space for tooltip when hidden

### DIFF
--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -20,6 +20,8 @@
 
 .Tooltip--hidden {
   visibility: hidden;
+  /* Take the tooltip out of the DOM layout flow so it doesn't reserve space when hidden */
+  position: fixed !important;
 }
 
 .TooltipInfo {


### PR DESCRIPTION
The tooltips were still reserving space on the page when hidden, leading to double scroll bars in some cases (ex: https://github.com/dequelabs/walnut/issues/2330 and https://github.com/dequelabs/walnut/issues/2583). We still want them to be rendered, though, so that they can be used as labels (aria-labeledby). This PR changes the tooltip positioning to `fixed` when hidden so that they don't take up room.