### PR TITLE
fix(styles): fix unnecessary border from lists inside of cards

### DIFF
--- a/packages/styles/card.css
+++ b/packages/styles/card.css
@@ -75,10 +75,6 @@
   box-sizing: border-box;
 }
 
-.Card__content ul li {
-  border-bottom: 1px solid var(--list-separator);
-}
-
 .Card__footer {
   padding: var(--space-small);
   text-align: center;


### PR DESCRIPTION
I have a pagination inside of a card pattern, but the list items there are showing a border on the bottom: 

![pagination items with thin 1px line under the components](https://user-images.githubusercontent.com/1062039/151581633-16a61bd6-2733-4aa1-a47a-1325606e6485.png)
