### PR TITLE
fix(react): use correct grammar for pagination start/end text

### DIFF
--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -66,7 +66,7 @@ const PaginationDemo = () => {
               'The "x of y" status label (rendered as text in the middle of the pagination controls).',
             required: false,
             default: `<span>
-                Showing <strong>{itemStart}</strong> of{' '}
+                Showing <strong>{itemStart}</strong> to{' '}
                 <strong>{itemEnd}</strong> of <strong>{totalItems}</strong>
               </span>`
           },

--- a/packages/react/__tests__/src/components/Pagination/index.js
+++ b/packages/react/__tests__/src/components/Pagination/index.js
@@ -183,5 +183,5 @@ test('renders the expected default status label', () => {
     <Pagination totalItems={500} currentPage={3} itemsPerPage={17} />
   );
 
-  expect(wrapper.find('[role="log"]').text()).toBe('Showing 35 of 51 of 500');
+  expect(wrapper.find('[role="log"]').text()).toBe('Showing 35 to 51 of 500');
 });

--- a/packages/react/src/components/Pagination/index.tsx
+++ b/packages/react/src/components/Pagination/index.tsx
@@ -96,7 +96,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
             <span role="log" aria-atomic="true">
               {statusLabel || (
                 <span>
-                  Showing <strong>{itemStart}</strong> of{' '}
+                  Showing <strong>{itemStart}</strong> to{' '}
                   <strong>{itemEnd}</strong> of <strong>{totalItems}</strong>
                 </span>
               )}


### PR DESCRIPTION
Fixing _x of y of total_ to _x to y of total_ 