### PR TITLE
fix: fix issue with tooltip not updating placement

### DIFF
--- a/docs/patterns/components/Table/index.js
+++ b/docs/patterns/components/Table/index.js
@@ -7,7 +7,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-  Code
+  Code,
+  IconButton
 } from '@deque/cauldron-react/';
 import { children, className } from '../../../props';
 
@@ -162,14 +163,24 @@ const BasicTable = () => (
             >
               Email
             </TableHeader>
+            <TableHeader scope="col">Actions</TableHeader>
           </TableRow>
         </TableHead>
         <TableBody>
           {sortedData.map(contact => (
-            <TableRow>
+            <TableRow key={contact.email}>
               <TableCell>{contact.first_name}</TableCell>
               <TableCell>{contact.last_name}</TableCell>
               <TableCell>{contact.email}</TableCell>
+              <TableCell>
+                <IconButton
+                  icon="trash"
+                  label="Delete"
+                  onClick={() => {
+                    console.log(`Delete ${contact.email}`);
+                  }}
+                />
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -178,7 +178,7 @@ const Demo = () => {
           },
           show: {
             type: 'boolean',
-            description: 'Manually control the show state of the tooltip'
+            description: 'Whether or not the tooltip is shown initially.'
           },
           placement: {
             type: 'string',

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import classnames from 'classnames';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
@@ -44,15 +44,14 @@ export default function Tooltip({
   target,
   association = 'aria-describedby',
   variant = 'text',
-  show: showProp = false,
+  show: initialShow = false,
   hideElementOnHidden = false,
   className,
   ...props
 }: TooltipProps) {
   const [id] = propId ? [propId] : useId(1, 'tooltip');
-  const hovering = useRef(false);
-  const [placement, setPlacement] = useState(initialPlacement);
-  const [showTooltip, setShowTooltip] = useState(!!showProp);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showTooltip, setShowTooltip] = useState(!!initialShow);
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
   const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(
     null
@@ -73,55 +72,71 @@ export default function Tooltip({
     }
   );
 
-  const show = async () => {
-    if (update) {
-      await update();
-    }
-    setShowTooltip(true);
-    fireCustomEvent(true, targetElement);
-  };
-  const hide = ({ target }: FocusEvent | MouseEvent) => {
-    if (document.activeElement !== target) {
-      setTimeout(() => {
-        if (!hovering.current) {
-          setShowTooltip(false);
-          fireCustomEvent(false, targetElement);
-        }
-      }, TIP_HIDE_DELAY);
-    }
-  };
-  const handleTriggerMouseEnter = () => {
-    hovering.current = true;
-    show();
-  };
-  const handleTriggerMouseLeave = (e: MouseEvent) => {
-    hovering.current = false;
-    hide(e);
-  };
-  const handleTipMouseEnter = () => {
-    hovering.current = true;
-  };
-  const handleTipMouseLeave = (e: MouseEvent) => {
-    hovering.current = false;
-    hide(e);
-  };
-
+  // Keep targetElement in sync with target prop
   useEffect(() => {
     const targetElement =
       target && 'current' in target ? target.current : target;
     setTargetElement(targetElement);
   }, [target]);
 
-  const popperPlacement: Placement =
-    (attributes.popper &&
-      (attributes.popper['data-popper-placement'] as Placement)) ||
-    initialPlacement;
-  useEffect(() => {
-    if (popperPlacement) {
-      setPlacement(popperPlacement);
+  // Show the tooltip
+  const show: EventListener = useCallback(async () => {
+    // Clear the hide timeout if there was one pending
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
     }
-  }, [popperPlacement]);
+    // Make sure we update the tooltip position when showing
+    // in case the target's position changed without popper knowing
+    if (update) {
+      await update();
+    }
+    setShowTooltip(true);
+    fireCustomEvent(true, targetElement);
+  }, [
+    targetElement,
+    // update starts off as null
+    update
+  ]);
 
+  // Hide the tooltip
+  const hide: EventListener = useCallback(() => {
+    if (!hideTimeoutRef.current) {
+      hideTimeoutRef.current = setTimeout(() => {
+        hideTimeoutRef.current = null;
+        setShowTooltip(false);
+        fireCustomEvent(false, targetElement);
+      }, TIP_HIDE_DELAY);
+    }
+  }, [targetElement]);
+
+  // Handle hover and focus events for the targetElement
+  useEffect(() => {
+    targetElement?.addEventListener('mouseenter', show);
+    targetElement?.addEventListener('mouseleave', hide);
+    targetElement?.addEventListener('focusin', show);
+    targetElement?.addEventListener('focusout', hide);
+
+    return () => {
+      targetElement?.removeEventListener('mouseenter', show);
+      targetElement?.removeEventListener('mouseleave', hide);
+      targetElement?.removeEventListener('focusin', show);
+      targetElement?.removeEventListener('focusout', hide);
+    };
+  }, [targetElement, show, hide]);
+
+  // Handle hover events for the tooltipElement
+  useEffect(() => {
+    tooltipElement?.addEventListener('mouseenter', show);
+    tooltipElement?.addEventListener('mouseleave', hide);
+
+    return () => {
+      tooltipElement?.removeEventListener('mouseenter', show);
+      tooltipElement?.removeEventListener('mouseleave', hide);
+    };
+  }, [tooltipElement, show, hide]);
+
+  // Only listen to key ups when the tooltip is visible
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
       if (
@@ -143,35 +158,9 @@ export default function Tooltip({
     return () => {
       targetElement.removeEventListener('keyup', handleEscape);
     };
-  }, [showProp]);
+  }, [showTooltip]);
 
-  useEffect(() => {
-    if (typeof showProp !== undefined) {
-      targetElement?.addEventListener('mouseenter', handleTriggerMouseEnter);
-      targetElement?.addEventListener('mouseleave', handleTriggerMouseLeave);
-      targetElement?.addEventListener('focusin', show);
-      targetElement?.addEventListener('focusout', hide);
-    }
-    return () => {
-      targetElement?.removeEventListener('mouseenter', show);
-      targetElement?.removeEventListener('mouseleave', hide);
-      targetElement?.removeEventListener('focusin', show);
-      targetElement?.removeEventListener('focusout', hide);
-    };
-  }, [targetElement, showProp]);
-
-  useEffect(() => {
-    if (tooltipElement) {
-      tooltipElement?.addEventListener('mouseenter', handleTipMouseEnter);
-      tooltipElement?.addEventListener('mouseleave', handleTipMouseLeave);
-    }
-
-    return () => {
-      tooltipElement?.removeEventListener('mouseenter', handleTipMouseEnter);
-      tooltipElement?.removeEventListener('mouseleave', handleTipMouseLeave);
-    };
-  }, [tooltipElement]);
-
+  // Keep the target's id in sync
   useEffect(() => {
     const attrText = targetElement?.getAttribute(association);
     if (!attrText?.includes(id || '')) {
@@ -181,6 +170,11 @@ export default function Tooltip({
       );
     }
   }, [targetElement, id]);
+
+  const placement: Placement =
+    (attributes.popper &&
+      (attributes.popper['data-popper-placement'] as Placement)) ||
+    initialPlacement;
 
   return showTooltip || hideElementOnHidden
     ? createPortal(


### PR DESCRIPTION
Ref: https://github.com/dequelabs/cauldron/issues/539

The issue was that `usePopper`'s `update` can be null to start with (see: https://popper.js.org/react-popper/v2/hook/#update-forceupdate-and-state). However, the `show` method was only being bound on the first render when `update` was still `null` (I believe this was introduced by https://github.com/dequelabs/cauldron/pull/505). So the tooltip's placement was not getting updated on `show`, which is a problem with table sorting because React shuffles elements around without popper knowing about it.

While I was in here, I also addressed some other issues and tried to simplify the code some. I have called these out as comments in this PR.