### PR TITLE
Fix/move focus to loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 $ yarn
 ```
 
+### build (if first time building dev environment, must be run before yarn dev)
+
+```sh
+$ yarn build
+```
+
 ### dev
 
 (watches/rebuilds react, styles, and docs)
@@ -30,12 +36,6 @@ $ yarn dev
 ```
 
 navigate browser to http://localhost:8000
-
-### build
-
-```sh
-$ yarn build
-```
 
 ### run tests
 

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -29,9 +29,11 @@ const LoaderOverlayDemo = () => {
       return;
     }
 
+    /*
     if (loading) {
       return loaderRef.current.focus();
     }
+    */
 
     buttonRef.current.focus();
   }, [loading]);
@@ -62,6 +64,7 @@ const LoaderOverlayDemo = () => {
               ref={loaderRef}
               label="Loading..."
               variant="large"
+              focus
             >
               <p>
                 Explanatory secondary text goes here. Let them know what's

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -50,8 +50,10 @@ const LoaderOverlayDemo = () => {
           type: 'boolean',
           description: 'whether or not to focus the loader on initial render'
         },
-        ref: {
-          type: 'ref'
+        loaderRef: {
+          type: 'function',
+          description:
+            'DEPRECATED - replace with "focus" prop - optional ref function to move focus to loader on mount'
         }
       }}
     >

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -49,6 +49,9 @@ const LoaderOverlayDemo = () => {
         focus: {
           type: 'boolean',
           description: 'whether or not to focus the loader on initial render'
+        },
+        ref: {
+          type: 'ref'
         }
       }}
     >

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -28,7 +28,6 @@ const LoaderOverlayDemo = () => {
       mounted.current = true;
       return;
     }
-
     buttonRef.current.focus();
   }, [loading]);
 

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -14,6 +14,7 @@ const LOADING_DURATION = 5000;
 const LoaderOverlayDemo = () => {
   const mounted = useRef(false);
   const buttonRef = useRef();
+  const loaderRef = useRef();
   const [loading, setLoading] = useState(false);
   const onClick = () => {
     setLoading(true);

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -13,7 +13,6 @@ const LOADING_DURATION = 5000;
 
 const LoaderOverlayDemo = () => {
   const mounted = useRef(false);
-  const loaderRef = useRef();
   const buttonRef = useRef();
   const [loading, setLoading] = useState(false);
   const onClick = () => {
@@ -28,12 +27,6 @@ const LoaderOverlayDemo = () => {
       mounted.current = true;
       return;
     }
-
-    /*
-    if (loading) {
-      return loaderRef.current.focus();
-    }
-    */
 
     buttonRef.current.focus();
   }, [loading]);
@@ -52,6 +45,10 @@ const LoaderOverlayDemo = () => {
         variant: {
           type: 'string',
           description: 'Loader variant, can be "small" or "large".'
+        },
+        focus: {
+          type: 'boolean',
+          description: 'whether or not to focus the loader on initial render'
         }
       }}
     >
@@ -61,7 +58,6 @@ const LoaderOverlayDemo = () => {
             <Scrim show />
             <LoaderOverlay
               tabIndex={-1}
-              ref={loaderRef}
               label="Loading..."
               variant="large"
               focus
@@ -100,7 +96,7 @@ const LoaderOverlayDemo = () => {
         <Code
           role="region"
           tabIndex={0}
-        >{`<LoaderOverlay tabIndex={-1} ref={loaderRef} label="Loading...">
+        >{`<LoaderOverlay tabIndex={-1} label="Loading..." focus>
   <p>Explanatory secondary text goes here. Let them know what's happening, alright?</p>
 </LoaderOverlay>`}</Code>
       </div>

--- a/packages/react/__tests__/src/components/LoaderOverlay/index.js
+++ b/packages/react/__tests__/src/components/LoaderOverlay/index.js
@@ -49,7 +49,7 @@ test('handles focus', () => {
   });
 });
 
-test('does not being focused', () => {
+test('handles not being focused', () => {
   const loaderOverlay = mount(
     <LoaderOverlay className="baz" role="alert" label="loading">
       Some text
@@ -58,6 +58,20 @@ test('does not being focused', () => {
 
   setTimeout(() => {
     expect(document.activeElement).not.toBe(loaderOverlay.getDOMNode());
+  });
+});
+
+test('handles being passed a ref', () => {
+  const loaderRef = React.createRef([]);
+
+  const loaderOverlay = mount(
+    <LoaderOverlay className="baz" role="alert" label="loading" ref={loaderRef}>
+      Some text
+    </LoaderOverlay>
+  );
+
+  setTimeout(() => {
+    expect(document.activeElement).toBe(loaderOverlay.getDOMNode());
   });
 });
 

--- a/packages/react/__tests__/src/components/LoaderOverlay/index.js
+++ b/packages/react/__tests__/src/components/LoaderOverlay/index.js
@@ -62,7 +62,7 @@ test('handles not being focused', () => {
 });
 
 test('handles being passed a ref', () => {
-  const loaderRef = React.createRef([]);
+  const loaderRef = React.createRef(null);
 
   const loaderOverlay = mount(
     <LoaderOverlay className="baz" role="alert" label="loading" ref={loaderRef}>
@@ -71,7 +71,7 @@ test('handles being passed a ref', () => {
   );
 
   setTimeout(() => {
-    expect(document.activeElement).toBe(loaderOverlay.getDOMNode());
+    expect(document.activeElement).toStrictEqual(loaderOverlay.getDOMNode());
   });
 });
 

--- a/packages/react/__tests__/src/components/LoaderOverlay/index.js
+++ b/packages/react/__tests__/src/components/LoaderOverlay/index.js
@@ -37,6 +37,30 @@ test('handles variants', () => {
   expect(largeNode.classList.contains('Loader__overlay--large')).toBe(true);
 });
 
+test('handles focus', () => {
+  const loaderOverlay = mount(
+    <LoaderOverlay className="baz" role="alert" label="loading" focus>
+      Some text
+    </LoaderOverlay>
+  );
+
+  setTimeout(() => {
+    expect(document.activeElement).toBe(loaderOverlay.getDOMNode());
+  });
+});
+
+test('does not being focused', () => {
+  const loaderOverlay = mount(
+    <LoaderOverlay className="baz" role="alert" label="loading">
+      Some text
+    </LoaderOverlay>
+  );
+
+  setTimeout(() => {
+    expect(document.activeElement).not.toBe(loaderOverlay.getDOMNode());
+  });
+});
+
 test('returns no axe violations', async () => {
   const loaderOverlay = shallow(<LoaderOverlay>Hello world</LoaderOverlay>);
 

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -12,30 +12,18 @@ interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
   ({ className, variant, label, focus, ...other }: LoaderOverlayProps, ref) => {
-    // const overlayRef = ref || null;
     const overlayRef = createRef<HTMLDivElement>();
-    //let overlayRef = createRef<HTMLDivElement>()
+
     useEffect(() => {
       if (!!focus && overlayRef) {
-        console.log('Should be focused');
-        console.log(ref);
-        console.log(overlayRef);
         setTimeout(() => {
           return overlayRef.current?.focus();
         });
-        console.log(document.activeElement);
         return;
       }
       return;
     }, []);
-    /*
-    if (!!focus && ref) {
-      console.log("Should be focused")
-      console.log(ref)
-      console.log(htmlElRef)
-      htmlElRef.current?.focus()
-    } */
-    console.log('I guess not focus?');
+
     return (
       <div
         className={classNames(
@@ -49,7 +37,6 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
         )}
         ref={overlayRef}
         tabIndex={-1}
-        // ref={ref}
         {...other}
       >
         <div className="Loader__overlay__loader">

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -8,53 +8,59 @@ interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
   label?: string;
   focus?: boolean;
+  children?: React.ReactNode;
 }
 
-const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
-  ({ className, variant, label, focus, ...other }: LoaderOverlayProps, ref) => {
-    const overlayRef = createRef<HTMLDivElement>();
+const LoaderOverlay = ({
+  className,
+  variant,
+  label,
+  focus,
+  children,
+  ...other
+}: LoaderOverlayProps) => {
+  const overlayRef = createRef<HTMLDivElement>();
 
-    useEffect(() => {
-      if (!!focus && overlayRef) {
-        setTimeout(() => {
-          return overlayRef.current?.focus();
-        });
-        return;
-      }
-      return;
-    }, []);
+  useEffect(() => {
+    if (!!focus && overlayRef) {
+      setTimeout(() => {
+        return overlayRef.current?.focus();
+      });
+    }
+    return;
+  }, []);
 
-    return (
-      <div
-        className={classNames(
-          'Loader__overlay',
-          className,
-          variant === 'large'
-            ? 'Loader__overlay--large'
-            : variant === 'small'
-            ? 'Loader__overlay--small'
-            : ''
-        )}
-        ref={overlayRef}
-        tabIndex={-1}
-        {...other}
-      >
-        <div className="Loader__overlay__loader">
-          <Loader variant={variant} />
-          <AxeLoader />
-        </div>
-        {label ? <span className="Loader__overlay__label">{label}</span> : null}
-        {other.children}
+  return (
+    <div
+      className={classNames(
+        'Loader__overlay',
+        className,
+        variant === 'large'
+          ? 'Loader__overlay--large'
+          : variant === 'small'
+          ? 'Loader__overlay--small'
+          : ''
+      )}
+      ref={overlayRef}
+      tabIndex={-1}
+      {...other}
+    >
+      <div className="Loader__overlay__loader">
+        <Loader variant={variant} />
+        <AxeLoader />
       </div>
-    );
-  }
-);
+      {label ? <span className="Loader__overlay__label">{label}</span> : null}
+      {children}
+    </div>
+  );
+};
 
 LoaderOverlay.propTypes = {
   className: PropTypes.string,
   variant: PropTypes.oneOf(['large', 'small']),
   label: PropTypes.string,
-  focus: PropTypes.bool
+  focus: PropTypes.bool,
+  children: PropTypes.node
 };
 
 LoaderOverlay.displayName = 'LoaderOverlay';

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -28,10 +28,6 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
     const overlayRef = createRef<HTMLDivElement>();
 
     useEffect(() => {
-      console.log(fallbackFocus);
-      console.log(overlayRef);
-      console.log(ref);
-
       if ((!!focus && overlayRef) || (ref && fallbackFocus)) {
         setTimeout(() => {
           return overlayRef.current?.focus();

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Loader from '../Loader';
@@ -7,37 +7,67 @@ import AxeLoader from './axe-loader';
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
   label?: string;
+  focus?: boolean;
 }
 
 const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
-  ({ className, variant, label, ...other }: LoaderOverlayProps, ref) => (
-    <div
-      className={classNames(
-        'Loader__overlay',
-        className,
-        variant === 'large'
-          ? 'Loader__overlay--large'
-          : variant === 'small'
-          ? 'Loader__overlay--small'
-          : ''
-      )}
-      ref={ref}
-      {...other}
-    >
-      <div className="Loader__overlay__loader">
-        <Loader variant={variant} />
-        <AxeLoader />
+  ({ className, variant, label, focus, ...other }: LoaderOverlayProps, ref) => {
+    // const overlayRef = ref || null;
+    const overlayRef = createRef<HTMLDivElement>();
+    //let overlayRef = createRef<HTMLDivElement>()
+    useEffect(() => {
+      if (!!focus && overlayRef) {
+        console.log('Should be focused');
+        console.log(ref);
+        console.log(overlayRef);
+        setTimeout(() => {
+          return overlayRef.current?.focus();
+        });
+        console.log(document.activeElement);
+        return;
+      }
+      return;
+    }, []);
+    /*
+    if (!!focus && ref) {
+      console.log("Should be focused")
+      console.log(ref)
+      console.log(htmlElRef)
+      htmlElRef.current?.focus()
+    } */
+    console.log('I guess not focus?');
+    return (
+      <div
+        className={classNames(
+          'Loader__overlay',
+          className,
+          variant === 'large'
+            ? 'Loader__overlay--large'
+            : variant === 'small'
+            ? 'Loader__overlay--small'
+            : ''
+        )}
+        ref={overlayRef}
+        tabIndex={-1}
+        // ref={ref}
+        {...other}
+      >
+        <div className="Loader__overlay__loader">
+          <Loader variant={variant} />
+          <AxeLoader />
+        </div>
+        {label ? <span className="Loader__overlay__label">{label}</span> : null}
+        {other.children}
       </div>
-      {label ? <span className="Loader__overlay__label">{label}</span> : null}
-      {other.children}
-    </div>
-  )
+    );
+  }
 );
 
 LoaderOverlay.propTypes = {
   className: PropTypes.string,
   variant: PropTypes.oneOf(['large', 'small']),
-  label: PropTypes.string
+  label: PropTypes.string,
+  focus: PropTypes.bool
 };
 
 LoaderOverlay.displayName = 'LoaderOverlay';

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -7,53 +7,64 @@ import AxeLoader from './axe-loader';
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
   label?: string;
-  focus?: boolean;
+  focus?: boolean | null;
   children?: React.ReactNode;
+  loaderRef?: HTMLDivElement;
 }
 
-const LoaderOverlay = ({
-  className,
-  variant,
-  label,
-  focus,
-  children,
-  ...other
-}: LoaderOverlayProps) => {
-  const overlayRef = createRef<HTMLDivElement>();
+const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
+  (
+    {
+      className,
+      variant,
+      label,
+      children,
+      focus,
+      ...other
+    }: LoaderOverlayProps,
+    ref
+  ) => {
+    const fallbackFocus = ref || null;
+    const overlayRef = createRef<HTMLDivElement>();
 
-  useEffect(() => {
-    if (!!focus && overlayRef) {
-      setTimeout(() => {
-        return overlayRef.current?.focus();
-      });
-    }
-    return;
-  }, []);
+    useEffect(() => {
+      console.log(fallbackFocus);
+      console.log(overlayRef);
+      console.log(ref);
 
-  return (
-    <div
-      className={classNames(
-        'Loader__overlay',
-        className,
-        variant === 'large'
-          ? 'Loader__overlay--large'
-          : variant === 'small'
-          ? 'Loader__overlay--small'
-          : ''
-      )}
-      ref={overlayRef}
-      tabIndex={-1}
-      {...other}
-    >
-      <div className="Loader__overlay__loader">
-        <Loader variant={variant} />
-        <AxeLoader />
+      if ((!!focus && overlayRef) || (ref && fallbackFocus)) {
+        setTimeout(() => {
+          return overlayRef.current?.focus();
+        });
+      }
+      return;
+    }, []);
+
+    return (
+      <div
+        className={classNames(
+          'Loader__overlay',
+          className,
+          variant === 'large'
+            ? 'Loader__overlay--large'
+            : variant === 'small'
+            ? 'Loader__overlay--small'
+            : ''
+        )}
+        ref={overlayRef}
+        tabIndex={-1}
+        {...other}
+      >
+        <div className="Loader__overlay__loader">
+          <Loader variant={variant} />
+          <AxeLoader />
+        </div>
+        {label ? <span className="Loader__overlay__label">{label}</span> : null}
+        {children}
       </div>
-      {label ? <span className="Loader__overlay__label">{label}</span> : null}
-      {children}
-    </div>
-  );
-};
+    );
+  }
+);
 
 LoaderOverlay.propTypes = {
   className: PropTypes.string,

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -7,9 +7,8 @@ import AxeLoader from './axe-loader';
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
   label?: string;
-  focus?: boolean | null;
+  focus?: boolean;
   children?: React.ReactNode;
-  loaderRef?: HTMLDivElement;
 }
 
 const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
@@ -24,11 +23,10 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
     }: LoaderOverlayProps,
     ref
   ) => {
-    const fallbackFocus = ref || null;
     const overlayRef = createRef<HTMLDivElement>();
 
     useEffect(() => {
-      if ((!!focus && overlayRef) || (ref && fallbackFocus)) {
+      if ((!!focus && overlayRef) || ref) {
         setTimeout(() => {
           return overlayRef.current?.focus();
         });
@@ -47,7 +45,7 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
             ? 'Loader__overlay--small'
             : ''
         )}
-        ref={overlayRef}
+        ref={ref ? ref : overlayRef}
         tabIndex={-1}
         {...other}
       >

--- a/packages/react/src/components/Scrim/index.tsx
+++ b/packages/react/src/components/Scrim/index.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 export interface ScrimProps {
   show: boolean;
-  focus?: boolean;
 }
 
 interface ScrimState {
@@ -30,13 +29,10 @@ export default class Scrim extends React.Component<ScrimProps, ScrimState> {
   componentDidMount() {
     if (this.props.show) {
       this.fadeIn();
-      this.el?.focus();
     }
   }
 
   fadeIn() {
-    const { focus } = this.props;
-
     this.setState({ destroy: false }, () => {
       this.setState({
         animationClass: 'Scrim--show'
@@ -53,9 +49,6 @@ export default class Scrim extends React.Component<ScrimProps, ScrimState> {
         });
       });
     });
-    if (this.el && !!focus) {
-      this.el.focus();
-    }
   }
 
   fadeOut() {

--- a/packages/react/src/components/Scrim/index.tsx
+++ b/packages/react/src/components/Scrim/index.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 export interface ScrimProps {
   show: boolean;
+  focus?: boolean;
 }
 
 interface ScrimState {
@@ -29,10 +30,13 @@ export default class Scrim extends React.Component<ScrimProps, ScrimState> {
   componentDidMount() {
     if (this.props.show) {
       this.fadeIn();
+      this.el?.focus();
     }
   }
 
   fadeIn() {
+    const { focus } = this.props;
+
     this.setState({ destroy: false }, () => {
       this.setState({
         animationClass: 'Scrim--show'
@@ -49,6 +53,9 @@ export default class Scrim extends React.Component<ScrimProps, ScrimState> {
         });
       });
     });
+    if (this.el && !!focus) {
+      this.el.focus();
+    }
   }
 
   fadeOut() {


### PR DESCRIPTION
ref: https://github.com/dequelabs/walnut/issues/3039

Additional comments at above ref as well. 

## Purpose

To address moving focus to the loader, which was less of an issue with the component itself and more of an issue with its implementation in and need for handling focus outside of the component (e.g., via forwardRef).  

This solution addresses one part of the problem, with the second part needing to be addressed where the loader is being used without implementing some kind of focus (this PR will make it easier to fix that, however). 

See comments in https://github.com/dequelabs/walnut/issues/3039 and the diffs for additional information.
