### PR TITLE
fix(styles): allow button text to wrap to prevent text from being cut off

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -32,7 +32,7 @@
   position: relative;
   text-align: center;
   text-transform: uppercase;
-  height: 36px;
+  min-height: 36px;
   min-width: 100px;
   display: inline-grid;
   grid-auto-flow: column;


### PR DESCRIPTION
closes #567 