### PR TITLE
fix(styles): fix issue which prevents navigation/tabstop in NVDA/Chrome on Checkboxes/Radios

### DIFF
--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -321,7 +321,6 @@ textarea.Field--has-error:focus:hover,
   top: 8px;
   left: 8px;
   appearance: none;
-  border: 0;
 }
 
 .Checkbox__overlay.Checkbox__overlay--focused,
@@ -350,8 +349,6 @@ textarea.Field--has-error:focus:hover,
   top: 8px;
   left: 8px;
   appearance: none;
-  width: 2px;
-  border: 0;
 }
 
 .Checkbox__overlay.Icon--checkbox-checked {


### PR DESCRIPTION
closes #585 
closes #590
closes #584 

I tested with Voiceover, JAWS 2021, and NVDA with the included changes and everyone read out radios/checkboxes both as tabstops and with navigation keys.