### PR TITLE
chore: release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.2.1](https://github.com/dequelabs/cauldron/compare/v4.2.0...v4.2.1) (2022-03-31)
+
+### Bug Fixes
+
+- **styles:** fix thin buttons being too large ([#613](https://github.com/dequelabs/cauldron/issues/613)) ([a5ffb23](https://github.com/dequelabs/cauldron/commit/a5ffb233b64f9aca3971ca47ed795185b224d155))
+
 ## [4.2.0](https://github.com/dequelabs/cauldron/compare/v4.1.0...v4.2.0) (2022-03-31)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cauldron",
   "private": true,
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MPL-2.0",
   "scripts": {
     "build": "concurrently \"yarn build:styles\" \"yarn build:react\" \"yarn build:docs\"",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-react",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Fully accessible react components library for Deque Cauldron",
   "publishConfig": {
     "access": "public"

--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -164,7 +164,7 @@ button.Link {
 }
 
 .Button--thin {
-  height: var(--button-thin-height);
+  min-height: var(--button-thin-height);
   min-width: 100px;
   font-size: var(--text-size-smallest);
   line-height: var(--text-size-smallest);

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-styles",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MPL-2.0",
   "description": "deque cauldron pattern library styles",
   "repository": "https://github.com/dequelabs/cauldron",


### PR DESCRIPTION
### [4.2.1](https://github.com/dequelabs/cauldron/compare/v4.2.0...v4.2.1) (2022-03-31)

### Bug Fixes

- **styles:** fix thin buttons being too large ([#613](https://github.com/dequelabs/cauldron/issues/613)) ([a5ffb23](https://github.com/dequelabs/cauldron/commit/a5ffb233b64f9aca3971ca47ed795185b224d155))