### PR TITLE
fix(styles): allow buttons to wrap

### DIFF
--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -63,7 +63,6 @@ button,
   display: inline-block;
   zoom: 1;
   line-height: normal;
-  white-space: nowrap;
   vertical-align: middle;
   text-align: center;
   user-select: none;


### PR DESCRIPTION
Adds an additional fix for: https://github.com/dequelabs/cauldron/issues/567

Allows text in buttons to wrap to prevent content from being cut off at 320px