### PR TITLE
feat(react): announce changes to sort on sortable TableHeaders

### DIFF
--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -13,7 +13,7 @@ interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   onSort?: () => void;
   className?: string;
   sortAscendingAnnouncement?: string;
-  sortDescendingAnnoucnement?: string;
+  sortDescendingAnnouncemen?: string;
 }
 
 const TableHeader = ({
@@ -22,7 +22,7 @@ const TableHeader = ({
   onSort,
   className,
   sortAscendingAnnouncement = 'sorted ascending',
-  sortDescendingAnnoucnement = 'sorted descending',
+  sortDescendingAnnouncemen = 'sorted descending',
   ...other
 }: TableHeaderProps) => {
   // When the sort direction changes, we want to announce the change in a live region
@@ -34,7 +34,7 @@ const TableHeader = ({
       setAnnouncement(
         sortDirection === 'ascending'
           ? sortAscendingAnnouncement
-          : sortDescendingAnnoucnement
+          : sortDescendingAnnouncemen
       );
     }
   }, [sortDirection]);

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,6 +1,7 @@
-import React, { ThHTMLAttributes } from 'react';
+import React, { ThHTMLAttributes, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Offscreen from '../Offscreen';
 import Icon from '../Icon';
 
 // these match aria-sort's values
@@ -11,6 +12,8 @@ interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   sortDirection?: SortDirection;
   onSort?: () => void;
   className?: string;
+  sortAscendingAnnouncement?: string;
+  sortDescendingAnnoucnement?: string;
 }
 
 const TableHeader = ({
@@ -18,38 +21,60 @@ const TableHeader = ({
   sortDirection,
   onSort,
   className,
+  sortAscendingAnnouncement = 'sorted ascending',
+  sortDescendingAnnoucnement = 'sorted descending',
   ...other
-}: TableHeaderProps) => (
-  <th
-    aria-sort={sortDirection}
-    className={classNames('TableHeader', className, {
-      'TableHeader--sort-ascending': sortDirection === 'ascending',
-      'TableHeader--sort-descending': sortDirection === 'descending'
-    })}
-    {...other}
-  >
-    {!!onSort && !!sortDirection ? (
-      <button
-        onClick={onSort}
-        className="TableHeader__sort-button"
-        type="button"
-      >
-        {children}
-        <span aria-hidden="true">
-          {sortDirection === 'none' ? (
-            <Icon type="sort-triangle" />
-          ) : sortDirection === 'ascending' ? (
-            <Icon type="triangle-up" />
-          ) : (
-            <Icon type="triangle-down" />
-          )}
-        </span>
-      </button>
-    ) : (
-      children
-    )}
-  </th>
-);
+}: TableHeaderProps) => {
+  // When the sort direction changes, we want to announce the change in a live region
+  // because changes to the sort value is not widely supported yet
+  // see: https://a11ysupport.io/tech/aria/aria-sort_attribute
+  const [announcement, setAnnouncement] = useState('');
+  useEffect(() => {
+    if (sortDirection !== 'none') {
+      setAnnouncement(
+        sortDirection === 'ascending'
+          ? sortAscendingAnnouncement
+          : sortDescendingAnnoucnement
+      );
+    }
+  }, [sortDirection]);
+  return (
+    <th
+      aria-sort={sortDirection}
+      className={classNames('TableHeader', className, {
+        'TableHeader--sort-ascending': sortDirection === 'ascending',
+        'TableHeader--sort-descending': sortDirection === 'descending'
+      })}
+      {...other}
+    >
+      {!!onSort && !!sortDirection ? (
+        <button
+          onClick={onSort}
+          className="TableHeader__sort-button"
+          type="button"
+        >
+          {children}
+          <span aria-hidden="true">
+            {sortDirection === 'none' ? (
+              <Icon type="sort-triangle" />
+            ) : sortDirection === 'ascending' ? (
+              <Icon type="triangle-up" />
+            ) : (
+              <Icon type="triangle-down" />
+            )}
+          </span>
+          <Offscreen>
+            <span role="alert" aria-live="polite">
+              {announcement}
+            </span>
+          </Offscreen>
+        </button>
+      ) : (
+        children
+      )}
+    </th>
+  );
+};
 
 TableHeader.displayName = 'TableHeader';
 TableHeader.propTypes = {

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -64,7 +64,7 @@ const TableHeader = ({
             )}
           </span>
           <Offscreen>
-            <span role="alert" aria-live="polite">
+            <span role="status" aria-live="polite">
               {announcement}
             </span>
           </Offscreen>


### PR DESCRIPTION
Changes to the `aria-sort` attribute on table column cells is not yet [widely supported](https://a11ysupport.io/tech/aria/aria-sort_attribute) and is only currently announced in Firefox/JAWS.

This does mean that anyone using Firefox/JAWS will get a _very verbose_ announcement for sorting changes - but every other SR combination will at least have a polite announcement of the sort change.