### PR TITLE
chore(release): 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.3.0](https://github.com/dequelabs/cauldron/compare/v4.2.1...v4.3.0) (2022-04-06)
+
+### Features
+
+- **icons:** add minus ([#611](https://github.com/dequelabs/cauldron/issues/611)) ([abded4e](https://github.com/dequelabs/cauldron/commit/abded4e2c730f6716abab598eccbc2a066b97cbf))
+- **react:** announce changes to sort on sortable TableHeaders ([#622](https://github.com/dequelabs/cauldron/issues/622)) ([01c786a](https://github.com/dequelabs/cauldron/commit/01c786aea73440a6aedc9b79af2944b974d23b1d))
+
+### Bug Fixes
+
+- **react:** create useSharedRef util to share refs on forwardRef functional components ([#597](https://github.com/dequelabs/cauldron/issues/597)) ([d153945](https://github.com/dequelabs/cauldron/commit/d15394566685da7ff50bb70924be80d316834bc4))
+- **skip-link:** fix skip-link styles with new design ([#607](https://github.com/dequelabs/cauldron/issues/607)) ([f766f9d](https://github.com/dequelabs/cauldron/commit/f766f9dd496d75b7649bfe79b81bae853e0d9e47))
+- **styles:** fix thin buttons being too large ([#613](https://github.com/dequelabs/cauldron/issues/613)) ([62c9172](https://github.com/dequelabs/cauldron/commit/62c917271fd30df2e4e65c8eb421578ae20f373c))
+
 ### [4.2.1](https://github.com/dequelabs/cauldron/compare/v4.2.0...v4.2.1) (2022-03-31)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cauldron",
   "private": true,
-  "version": "4.2.1",
+  "version": "4.3.0",
   "license": "MPL-2.0",
   "scripts": {
     "build": "concurrently \"yarn build:styles\" \"yarn build:react\" \"yarn build:docs\"",

--- a/packages/react/__tests__/src/components/SkipLink/index.js
+++ b/packages/react/__tests__/src/components/SkipLink/index.js
@@ -60,16 +60,3 @@ test('passes props through to the nav element', () => {
       .getAttribute('aria-label')
   ).toBe('Skip to my lou');
 });
-
-test('includes space (&nbsp;) between skipText and targetText', () => {
-  const skipLink = mount(
-    <SkipLink
-      target="#skip-target"
-      skipText="Skip to"
-      targetText="Main Content"
-    />
-  );
-  expect(skipLink.find('nav a').getDOMNode().textContent).toBe(
-    'Skip to\xa0Main Content'
-  );
-});

--- a/packages/react/__tests__/src/utils/useSharedRef.js
+++ b/packages/react/__tests__/src/utils/useSharedRef.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { spy } from 'sinon';
+import useSharedRef from 'src/utils/useSharedRef';
+
+// eslint-disable-next-line react/display-name,react/prop-types
+const ComponentWithSharedRef = React.forwardRef(({ callback }, ref) => {
+  const sharedRef = useSharedRef(ref);
+  callback(sharedRef);
+  return <span ref={sharedRef}></span>;
+});
+
+test('it supports external functional refs', () => {
+  let refEl = null;
+  const internalRefCallback = spy();
+  act(() => {
+    const wrapper = mount(
+      <ComponentWithSharedRef
+        ref={el => (refEl = el)}
+        callback={internalRefCallback}
+      />
+    );
+    wrapper.update();
+  });
+  expect(refEl?.tagName.toLowerCase()).toEqual('span');
+  expect(
+    internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
+  ).toEqual('span');
+});
+
+test('it supports mutable refs', () => {
+  const fakeRef = { current: null };
+  const internalRefCallback = spy();
+  act(() => {
+    const wrapper = mount(
+      <ComponentWithSharedRef ref={fakeRef} callback={internalRefCallback} />
+    );
+    wrapper.update();
+  });
+  expect(fakeRef.current?.tagName.toLowerCase()).toEqual('span');
+  expect(
+    internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
+  ).toEqual('span');
+});
+
+test('it supports undefined parent ref', () => {
+  const internalRefCallback = spy();
+  act(() => {
+    const wrapper = mount(
+      <ComponentWithSharedRef callback={internalRefCallback} />
+    );
+    wrapper.update();
+  });
+  expect(
+    internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
+  ).toEqual('span');
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-react",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Fully accessible react components library for Deque Cauldron",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/Icon/icons/minus.svg
+++ b/packages/react/src/components/Icon/icons/minus.svg
@@ -1,0 +1,1 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" overflow="visible" preserveAspectRatio="none" viewBox="0 0 24 24" width="19" height="19"><path d="M19 13H5v-2h14v2z" vector-effect="non-scaling-stroke" fill="currentColor"/></svg>

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -1,8 +1,9 @@
-import React, { createRef, useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Loader from '../Loader';
 import AxeLoader from './axe-loader';
+import useSharedRef from '../../utils/useSharedRef';
 
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
@@ -11,7 +12,7 @@ interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
-const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
+const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
   (
     {
       className,
@@ -23,8 +24,7 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
     }: LoaderOverlayProps,
     ref
   ) => {
-    const overlayRef =
-      typeof ref === 'function' || !ref ? createRef<HTMLDivElement>() : ref;
+    const overlayRef = useSharedRef<HTMLDivElement>(ref);
 
     useEffect(() => {
       if (!!focusOnInitialRender && overlayRef.current) {
@@ -34,12 +34,6 @@ const LoaderOverlay = React.forwardRef<HTMLDivElement, LoaderOverlayProps>(
       }
       return;
     }, [overlayRef.current]);
-
-    useEffect(() => {
-      if (typeof ref === 'function') {
-        ref(overlayRef.current);
-      }
-    }, [ref]);
 
     return (
       <div

--- a/packages/react/src/components/SkipLink/index.tsx
+++ b/packages/react/src/components/SkipLink/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Icon from '../Icon';
 import { isBrowser } from '../../utils/is-browser';
 
 export interface SkipLinkProps {
@@ -66,8 +67,11 @@ export default class SkipLink extends React.Component<
           onFocus={this.onFocus}
           onBlur={this.onBlur}
         >
-          <span className="SkipLink__item--first">{skipText}</span>&nbsp;
-          <span className="SkipLink__item--second">{targetText}</span>
+          <span className="SkipLink__item--first">{skipText}</span>
+          <span className="SkipLink__item--second">
+            <Icon type="triangle-right" />
+            {targetText}
+          </span>
         </a>
       </nav>
     );

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,6 +1,7 @@
-import React, { ThHTMLAttributes } from 'react';
+import React, { ThHTMLAttributes, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Offscreen from '../Offscreen';
 import Icon from '../Icon';
 
 // these match aria-sort's values
@@ -11,6 +12,8 @@ interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   sortDirection?: SortDirection;
   onSort?: () => void;
   className?: string;
+  sortAscendingAnnouncement?: string;
+  sortDescendingAnnouncemen?: string;
 }
 
 const TableHeader = ({
@@ -18,38 +21,60 @@ const TableHeader = ({
   sortDirection,
   onSort,
   className,
+  sortAscendingAnnouncement = 'sorted ascending',
+  sortDescendingAnnouncemen = 'sorted descending',
   ...other
-}: TableHeaderProps) => (
-  <th
-    aria-sort={sortDirection}
-    className={classNames('TableHeader', className, {
-      'TableHeader--sort-ascending': sortDirection === 'ascending',
-      'TableHeader--sort-descending': sortDirection === 'descending'
-    })}
-    {...other}
-  >
-    {!!onSort && !!sortDirection ? (
-      <button
-        onClick={onSort}
-        className="TableHeader__sort-button"
-        type="button"
-      >
-        {children}
-        <span aria-hidden="true">
-          {sortDirection === 'none' ? (
-            <Icon type="sort-triangle" />
-          ) : sortDirection === 'ascending' ? (
-            <Icon type="triangle-up" />
-          ) : (
-            <Icon type="triangle-down" />
-          )}
-        </span>
-      </button>
-    ) : (
-      children
-    )}
-  </th>
-);
+}: TableHeaderProps) => {
+  // When the sort direction changes, we want to announce the change in a live region
+  // because changes to the sort value is not widely supported yet
+  // see: https://a11ysupport.io/tech/aria/aria-sort_attribute
+  const [announcement, setAnnouncement] = useState('');
+  useEffect(() => {
+    if (sortDirection !== 'none') {
+      setAnnouncement(
+        sortDirection === 'ascending'
+          ? sortAscendingAnnouncement
+          : sortDescendingAnnouncemen
+      );
+    }
+  }, [sortDirection]);
+  return (
+    <th
+      aria-sort={sortDirection}
+      className={classNames('TableHeader', className, {
+        'TableHeader--sort-ascending': sortDirection === 'ascending',
+        'TableHeader--sort-descending': sortDirection === 'descending'
+      })}
+      {...other}
+    >
+      {!!onSort && !!sortDirection ? (
+        <button
+          onClick={onSort}
+          className="TableHeader__sort-button"
+          type="button"
+        >
+          {children}
+          <span aria-hidden="true">
+            {sortDirection === 'none' ? (
+              <Icon type="sort-triangle" />
+            ) : sortDirection === 'ascending' ? (
+              <Icon type="triangle-up" />
+            ) : (
+              <Icon type="triangle-down" />
+            )}
+          </span>
+          <Offscreen>
+            <span role="status" aria-live="polite">
+              {announcement}
+            </span>
+          </Offscreen>
+        </button>
+      ) : (
+        children
+      )}
+    </th>
+  );
+};
 
 TableHeader.displayName = 'TableHeader';
 TableHeader.propTypes = {

--- a/packages/react/src/utils/useSharedRef.ts
+++ b/packages/react/src/utils/useSharedRef.ts
@@ -1,0 +1,24 @@
+import { MutableRefObject, Ref, useRef, useEffect } from 'react';
+import setRef from './setRef';
+
+/**
+ * When a component needs to track an internal ref on a component that has a
+ * forwarded ref, useSharedRef will return a MutableRefObject<T> that will
+ * correctly invoke the parent ref as well providing an internal ref.
+ *
+ * @example
+ * React.forwardRef(function Component({ children }, ref) {
+ *   const internalRef = useSharedRef<HTMLElement>(ref)
+ *   if (internalRef.current) {
+ *     // do something with the internal ref...
+ *   }
+ *   return (<div ref={internalRef}>...</div>)
+ * })
+ */
+export default function useSharedRef<T>(ref: Ref<T>): MutableRefObject<T> {
+  const internalRef = useRef<T>();
+  useEffect(() => {
+    setRef(ref, internalRef.current);
+  }, [ref]);
+  return internalRef as MutableRefObject<T>;
+}

--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -164,7 +164,7 @@ button.Link {
 }
 
 .Button--thin {
-  height: var(--button-thin-height);
+  min-height: var(--button-thin-height);
   min-width: 100px;
   font-size: var(--text-size-smallest);
   line-height: var(--text-size-smallest);

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-styles",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "license": "MPL-2.0",
   "description": "deque cauldron pattern library styles",
   "repository": "https://github.com/dequelabs/cauldron",

--- a/packages/styles/skip-link.css
+++ b/packages/styles/skip-link.css
@@ -1,19 +1,17 @@
 :root {
-  --skip-link-background-color: rgba(11, 14, 17, 0.9);
+  --skip-link-background-color: rgba(255, 255, 255, 0.95);
+  --skip-link-focus-color: var(--focus-light);
+  --skip-link-text-color: var(--text-color-base);
 }
 
 .SkipLink {
-  min-width: 173px;
-  height: 58px;
-  background-color: var(--skip-link-background-color);
   position: absolute;
   box-sizing: border-box;
-  padding: var(--space-half);
+  padding: var(--space-smallest);
   top: -999px;
   left: 11px;
   opacity: 0;
   transition: 250ms opacity;
-  border-radius: 2px;
   z-index: var(--z-index-skip-container);
 }
 
@@ -27,10 +25,13 @@
 }
 
 .SkipLink a {
+  min-width: 13rem;
+  background-color: var(--skip-link-background-color);
   display: block;
-  color: var(--text-color-light);
+  color: var(--skip-link-text-color);
   text-decoration: none;
-  padding: var(--space-three-quarters);
+  padding: 12px;
+  border-radius: 2px;
 }
 
 .SkipLink span {
@@ -40,13 +41,16 @@
 .SkipLink .SkipLink__item--first {
   font-size: var(--text-size-small);
   font-weight: var(--font-weight-light);
-  color: var(--text-color-light);
+  margin-bottom: var(--space-three-quarters);
 }
 
 .SkipLink .SkipLink__item--second {
   font-size: var(--text-size-normal);
   font-weight: var(--font-weight-medium);
-  color: var(--text-color-light);
+}
+
+.SkipLink .Icon--triangle-right {
+  color: var(--skip-link-focus-color);
 }
 
 .SkipLink ul {
@@ -91,4 +95,11 @@
 .SkipLink ul li a:focus:before,
 .SkipLink ul li a:focus:after {
   color: var(--text-color-light);
+}
+
+/* Dark Theme */
+.cauldron--theme-dark {
+  --skip-link-background-color: rgba(11, 14, 17, 0.95);
+  --skip-link-focus-color: var(--focus-dark);
+  --skip-link-text-color: var(--text-color-light);
 }


### PR DESCRIPTION
## [4.3.0](https://github.com/dequelabs/cauldron/compare/v4.2.1...v4.3.0) (2022-04-06)

### Features

- **icons:** add minus ([#611](https://github.com/dequelabs/cauldron/issues/611)) ([abded4e](https://github.com/dequelabs/cauldron/commit/abded4e2c730f6716abab598eccbc2a066b97cbf))
- **react:** announce changes to sort on sortable TableHeaders ([#622](https://github.com/dequelabs/cauldron/issues/622)) ([01c786a](https://github.com/dequelabs/cauldron/commit/01c786aea73440a6aedc9b79af2944b974d23b1d))

### Bug Fixes

- **react:** create useSharedRef util to share refs on forwardRef functional components ([#597](https://github.com/dequelabs/cauldron/issues/597)) ([d153945](https://github.com/dequelabs/cauldron/commit/d15394566685da7ff50bb70924be80d316834bc4))
- **skip-link:** fix skip-link styles with new design ([#607](https://github.com/dequelabs/cauldron/issues/607)) ([f766f9d](https://github.com/dequelabs/cauldron/commit/f766f9dd496d75b7649bfe79b81bae853e0d9e47))
- **styles:** fix thin buttons being too large ([#613](https://github.com/dequelabs/cauldron/issues/613)) ([62c9172](https://github.com/dequelabs/cauldron/commit/62c917271fd30df2e4e65c8eb421578ae20f373c))