### PR TITLE
chore(table): clean up interfaces and use native types

### DIFF
--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { TableHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-const Table = ({ children, className, ...other }: TableProps) => (
+const Table = ({
+  children,
+  className,
+  ...other
+}: TableHTMLAttributes<HTMLTableElement>) => (
   <table className={classNames('Table', className)} {...other}>
     {children}
   </table>

--- a/packages/react/src/components/Table/TableBody.tsx
+++ b/packages/react/src/components/Table/TableBody.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableBodyProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-const TableBody = ({ children, className, ...other }: TableBodyProps) => (
+const TableBody = ({
+  children,
+  className,
+  ...other
+}: HTMLAttributes<HTMLTableSectionElement>) => (
   <tbody className={classNames('TableBody', className)} {...other}>
     {children}
   </tbody>

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -2,12 +2,11 @@ import React, { TdHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
-  children: React.ReactNode;
-  className?: string;
-}
-
-const TableCell = ({ children, className, ...other }: TableCellProps) => (
+const TableCell = ({
+  children,
+  className,
+  ...other
+}: TdHTMLAttributes<HTMLTableCellElement>) => (
   <td className={classNames('TableCell', className)} {...other}>
     {children}
   </td>

--- a/packages/react/src/components/Table/TableHead.tsx
+++ b/packages/react/src/components/Table/TableHead.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableHeadProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-const TableHead = ({ children, className, ...other }: TableHeadProps) => (
+const TableHead = ({
+  children,
+  className,
+  ...other
+}: HTMLAttributes<HTMLTableSectionElement>) => (
   <thead className={classNames('TableHead', className)} {...other}>
     {children}
   </thead>

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -8,10 +8,8 @@ import Icon from '../Icon';
 type SortDirection = 'ascending' | 'descending' | 'none';
 
 interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
-  children: React.ReactNode;
   sortDirection?: SortDirection;
   onSort?: () => void;
-  className?: string;
   sortAscendingAnnouncement?: string;
   sortDescendingAnnouncemen?: string;
 }

--- a/packages/react/src/components/Table/TableRow.tsx
+++ b/packages/react/src/components/Table/TableRow.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface TableRowProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-const TableRow = ({ children, className, ...other }: TableRowProps) => (
+const TableRow = ({
+  children,
+  className,
+  ...other
+}: HTMLAttributes<HTMLTableRowElement>) => (
   <tr className={classNames('TableRow', className)} {...other}>
     {children}
   </tr>


### PR DESCRIPTION
`children` and `classNames` are already a part of the default props. Also added native table prop types for elements missing them.