### PR TITLE
chore(pagination): use goToPage instead of four different functions

### DIFF
--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -7,13 +7,8 @@ const PaginationDemo = () => {
   const totalItems = 111;
   const itemsPerPage = 25;
   const [currentPage, setCurrentPage] = useState(3);
-  const itemStart = currentPage * itemsPerPage - itemsPerPage + 1;
-  const itemEnd = Math.min(itemStart + itemsPerPage - 1, totalItems);
-
-  const onNextPageClick = () => setCurrentPage(currentPage + 1);
-  const onFirstPageClick = () => setCurrentPage(1);
-  const onPreviousPageClick = () => setCurrentPage(currentPage - 1);
-  const onLastPageClick = () => setCurrentPage(5);
+  const itemStart = currentPage * itemsPerPage + 1;
+  const itemEnd = Math.min((currentPage + 1) * itemsPerPage, totalItems);
 
   return (
     <div>
@@ -35,10 +30,7 @@ const PaginationDemo = () => {
             nextPageLabel: 'NEXT PAGE!!',
             previousPageLabel: 'PREV PAGE!!',
             lastPageLabel: 'JIMMY PAGE!!',
-            onNextPageClick,
-            onFirstPageClick,
-            onPreviousPageClick,
-            onLastPageClick
+            goToPage: setCurrentPage
           }
         ]}
         propDocs={{
@@ -57,8 +49,14 @@ const PaginationDemo = () => {
           currentPage: {
             type: 'number',
             description: 'The (1-based) number of the current page.',
-            required: false,
+            required: true,
             default: 1
+          },
+          goToPage: {
+            type: 'function',
+            description:
+              'Function to be called when a page navigation button is clicked',
+            required: true
           },
           statusLabel: {
             type: 'ReactNode',
@@ -97,30 +95,6 @@ const PaginationDemo = () => {
               'The label text for the last page button (to be rendered as a tooltip).',
             required: false,
             default: 'Last page'
-          },
-          onNextPageClick: {
-            type: 'function',
-            description:
-              'Function to be called when next page button is clicked',
-            required: false
-          },
-          onPreviousPageClick: {
-            type: 'function',
-            description:
-              'Function to be called when previous page button is clicked',
-            required: false
-          },
-          onFirstPageClick: {
-            type: 'function',
-            description:
-              'Function to be called when first page button is clicked',
-            required: false
-          },
-          onLastPageClick: {
-            type: 'function',
-            description:
-              'Function to be called when last page button is clicked',
-            required: false
           },
           tooltipPlacement: {
             type: 'string',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-router-dom": "^5.3.2",
     "@types/react-syntax-highlighter": "^11.0.4",
+    "@types/sinon": "^10.0.11",
     "@types/webpack-dev-server": "^3.10.1",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",

--- a/packages/react/__tests__/src/components/Pagination/index.js
+++ b/packages/react/__tests__/src/components/Pagination/index.js
@@ -5,15 +5,9 @@ import Pagination from '../../../../src/components/Pagination';
 
 describe('on the first page', () => {
   test('Disables first/prev page buttons', () => {
-    const onFirstPageClick = sinon.spy();
-    const onPreviousPageClick = sinon.spy();
+    const goToPage = sinon.spy();
     const wrapper = mount(
-      <Pagination
-        totalItems={18}
-        currentPage={1}
-        onFirstPageClick={onFirstPageClick}
-        onPreviousPageClick={onPreviousPageClick}
-      />
+      <Pagination totalItems={18} currentPage={0} goToPage={goToPage} />
     );
     expect(
       wrapper
@@ -52,22 +46,15 @@ describe('on the first page', () => {
       .at(1)
       .simulate('click');
 
-    expect(onFirstPageClick.callCount).toBe(0);
-    expect(onPreviousPageClick.callCount).toBe(0);
+    expect(goToPage.callCount).toBe(0);
   });
 });
 
 describe('on the last page', () => {
   test('Disables last/next page buttons', () => {
-    const onNextPageClick = sinon.spy();
-    const onLastPageClick = sinon.spy();
+    const goToPage = sinon.spy();
     const wrapper = mount(
-      <Pagination
-        totalItems={18}
-        currentPage={2}
-        onNextPageClick={onNextPageClick}
-        onLastPageClick={onLastPageClick}
-      />
+      <Pagination totalItems={18} currentPage={2} goToPage={goToPage} />
     );
     expect(
       wrapper
@@ -106,8 +93,7 @@ describe('on the last page', () => {
       .at(3)
       .simulate('click');
 
-    expect(onNextPageClick.callCount).toBe(0);
-    expect(onLastPageClick.callCount).toBe(0);
+    expect(goToPage.callCount).toBe(0);
   });
 });
 
@@ -120,20 +106,14 @@ test('supports custom status label text', () => {
 });
 
 test('calls on{Next,Previous,First,Last}Click as expected', () => {
-  const onNextPageClick = sinon.spy();
-  const onPreviousPageClick = sinon.spy();
-  const onFirstPageClick = sinon.spy();
-  const onLastPageClick = sinon.spy();
+  const goToPage = sinon.spy();
 
   const wrapper = mount(
     <Pagination
       totalItems={500}
       currentPage={3}
       itemsPerPage={10}
-      onNextPageClick={onNextPageClick}
-      onPreviousPageClick={onPreviousPageClick}
-      onFirstPageClick={onFirstPageClick}
-      onLastPageClick={onLastPageClick}
+      goToPage={goToPage}
     />
   );
 
@@ -142,45 +122,33 @@ test('calls on{Next,Previous,First,Last}Click as expected', () => {
     .find('button')
     .at(0)
     .simulate('click');
-  expect(onFirstPageClick.callCount).toBe(1);
-  expect(onPreviousPageClick.callCount).toBe(0);
-  expect(onNextPageClick.callCount).toBe(0);
-  expect(onLastPageClick.callCount).toBe(0);
+  expect(goToPage.args).toStrictEqual([[0]]);
 
   // click the prev page button
   wrapper
     .find('button')
     .at(1)
     .simulate('click');
-  expect(onFirstPageClick.callCount).toBe(1);
-  expect(onPreviousPageClick.callCount).toBe(1);
-  expect(onNextPageClick.callCount).toBe(0);
-  expect(onLastPageClick.callCount).toBe(0);
+  expect(goToPage.args).toStrictEqual([[0], [2]]);
 
   // click the next page button
   wrapper
     .find('button')
     .at(2)
     .simulate('click');
-  expect(onFirstPageClick.callCount).toBe(1);
-  expect(onPreviousPageClick.callCount).toBe(1);
-  expect(onNextPageClick.callCount).toBe(1);
-  expect(onLastPageClick.callCount).toBe(0);
+  expect(goToPage.args).toStrictEqual([[0], [2], [4]]);
 
   // click the last page button
   wrapper
     .find('button')
     .at(3)
     .simulate('click');
-  expect(onFirstPageClick.callCount).toBe(1);
-  expect(onPreviousPageClick.callCount).toBe(1);
-  expect(onNextPageClick.callCount).toBe(1);
-  expect(onLastPageClick.callCount).toBe(1);
+  expect(goToPage.args).toStrictEqual([[0], [2], [4], [49]]);
 });
 
 test('renders the expected default status label', () => {
   const wrapper = mount(
-    <Pagination totalItems={500} currentPage={3} itemsPerPage={17} />
+    <Pagination totalItems={500} currentPage={2} itemsPerPage={17} />
   );
 
   expect(wrapper.find('[role="log"]').text()).toBe('Showing 35 to 51 of 500');

--- a/packages/react/src/components/Pagination/index.tsx
+++ b/packages/react/src/components/Pagination/index.tsx
@@ -9,16 +9,13 @@ import Icon from '../Icon';
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   totalItems: number;
   itemsPerPage?: number;
-  currentPage?: number;
+  currentPage: number;
+  goToPage: (page: number) => void;
   statusLabel?: React.ReactNode;
   firstPageLabel?: string;
   previousPageLabel?: string;
   nextPageLabel?: string;
   lastPageLabel?: string;
-  onNextPageClick?: () => void;
-  onPreviousPageClick?: () => void;
-  onFirstPageClick?: () => void;
-  onLastPageClick?: () => void;
   tooltipPlacement?: Placement;
   className?: string;
 }
@@ -28,26 +25,23 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
     {
       totalItems,
       itemsPerPage = 10,
-      currentPage = 1,
+      currentPage,
       statusLabel,
       firstPageLabel = 'First page',
       previousPageLabel = 'Previous page',
       nextPageLabel = 'Next page',
       lastPageLabel = 'Last page',
       tooltipPlacement = 'bottom',
-      onNextPageClick,
-      onPreviousPageClick,
-      onFirstPageClick,
-      onLastPageClick,
+      goToPage,
       className,
       ...other
     },
     ref
   ) => {
-    const itemStart = currentPage * itemsPerPage - itemsPerPage + 1;
-    const itemEnd = Math.min(itemStart + itemsPerPage - 1, totalItems);
+    const itemStart = currentPage * itemsPerPage + 1;
+    const itemEnd = Math.min((currentPage + 1) * itemsPerPage, totalItems);
     const isLastPage = itemEnd === totalItems;
-    const isFirstPage = currentPage === 1;
+    const isFirstPage = currentPage === 0;
 
     return (
       <div ref={ref} className={classNames('Pagination', className)} {...other}>
@@ -67,7 +61,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
                 icon="chevron-double-left"
                 tooltipPlacement={tooltipPlacement}
                 label={firstPageLabel}
-                onClick={onFirstPageClick}
+                onClick={() => goToPage(0)}
               />
             )}
           </li>
@@ -87,7 +81,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
                 icon="chevron-left"
                 tooltipPlacement={tooltipPlacement}
                 label={previousPageLabel}
-                onClick={onPreviousPageClick}
+                onClick={() => goToPage(currentPage - 1)}
               />
             )}
           </li>
@@ -118,7 +112,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
                 icon="chevron-right"
                 tooltipPlacement={tooltipPlacement}
                 label={nextPageLabel}
-                onClick={onNextPageClick}
+                onClick={() => goToPage(currentPage + 1)}
               />
             )}
           </li>
@@ -138,7 +132,9 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
                 icon="chevron-double-right"
                 tooltipPlacement={tooltipPlacement}
                 label={lastPageLabel}
-                onClick={onLastPageClick}
+                onClick={() =>
+                  goToPage(Math.ceil(totalItems / itemsPerPage) - 1)
+                }
               />
             )}
           </li>
@@ -152,16 +148,13 @@ Pagination.displayName = 'Pagination';
 Pagination.propTypes = {
   totalItems: PropTypes.number.isRequired,
   itemsPerPage: PropTypes.number,
-  currentPage: PropTypes.number,
+  currentPage: PropTypes.number.isRequired,
+  goToPage: PropTypes.func.isRequired,
   statusLabel: PropTypes.element,
   firstPageLabel: PropTypes.string,
   previousPageLabel: PropTypes.string,
   nextPageLabel: PropTypes.string,
   lastPageLabel: PropTypes.string,
-  onNextPageClick: PropTypes.func,
-  onPreviousPageClick: PropTypes.func,
-  onFirstPageClick: PropTypes.func,
-  onLastPageClick: PropTypes.func,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,
   className: PropTypes.string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,6 +1182,18 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/sinon@^10.0.11":
+  version "10.0.11"
+  resolved "https://agora.dequecloud.com:443/artifactory/api/npm/dequelabs/@types/sinon/-/sinon-10.0.11.tgz#8245827b05d3fc57a6601bd35aee1f7ad330fc42"
+  integrity sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.2"
+  resolved "https://agora.dequecloud.com:443/artifactory/api/npm/dequelabs/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
+  integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"


### PR DESCRIPTION
closes: #629

- Replaces the four `onPageChange` functions with `goToPage` to remove redundancy
- Makes props that are necessary for the component to function "required"
- Adds types for `sinon`
- Uses zero-indexed paging
- Cleans up paging logic