### PR TITLE
feat(PanelTrigger): add icon override

### DIFF
--- a/docs/patterns/components/ExpandCollapsePanel/index.js
+++ b/docs/patterns/components/ExpandCollapsePanel/index.js
@@ -4,6 +4,8 @@ import {
   PanelTrigger,
   Code
 } from '@deque/cauldron-react/';
+import PropDocs from '../../../Demo/PropDocs';
+import { children, className } from '../../../props';
 
 const ControlledExpandCollapse = () => {
   const [open, setOpen] = useState(false);
@@ -86,6 +88,71 @@ const Demo = () => {
   <ControlledExpandCollapsePanel />
 };
         `}</Code>
+        <div className="Demo-props">
+          <h2>Props</h2>
+          <h3>
+            <code>ExpandCollapsePanel</code>
+          </h3>
+
+          <PropDocs
+            docs={{
+              className,
+              children,
+              open: {
+                type: 'boolean',
+                description: 'Initial collapsed state of ExpandCollapsePanel',
+                default: 'false'
+              },
+              animationTiming: {
+                type: 'number | boolean',
+                description:
+                  'Animation time of expand/collapse in ms. Animation disabled when set to false.',
+                default: 250
+              },
+              onToggle: {
+                type: '(e: React.MouseEvent<HTMLButtonElement>) => void',
+                description:
+                  'onToggle handler for the panel. The original event object will be passed.',
+                default: 'function () {}'
+              }
+            }}
+          />
+
+          <h3>
+            <code>PanelTrigger</code>
+          </h3>
+          <PropDocs
+            docs={{
+              children,
+              className,
+              open: {
+                type: 'boolean',
+                description: 'Initial collapsed state of PanelTrigger',
+                default: 'false'
+              },
+              fullWidth: {
+                type: 'string',
+                description:
+                  'When set to "fullWidth" this component will stretch to the full width of its parent.'
+              },
+              onClick: {
+                type: '(e: React.MouseEvent<HTMLButtonElement>)',
+                description:
+                  'onClick handler for PanelTrigger. The original event object will be passed.'
+              },
+              iconExpanded: {
+                type: 'string',
+                description: 'The Icon to use when open=true.',
+                default: 'chevron-down'
+              },
+              iconCollapsed: {
+                type: 'string',
+                description: 'The Icon to use when open=false.',
+                default: 'chevron-right'
+              }
+            }}
+          />
+        </div>
       </div>
     );
   }

--- a/packages/react/__tests__/src/components/ExpandCollapsePanel/PanelTrigger.js
+++ b/packages/react/__tests__/src/components/ExpandCollapsePanel/PanelTrigger.js
@@ -45,7 +45,7 @@ test('should render default trigger icons', () => {
 
 test('should render custom trigger icons', () => {
   const wrapper = shallow(
-    <PanelTrigger expandedIcon="triangle-down" collapsedIcon="triangle-right" />
+    <PanelTrigger iconExpanded="triangle-down" iconCollapsed="triangle-right" />
   );
   expect(wrapper.find('Icon').props('type')).toEqual({
     type: 'triangle-right'

--- a/packages/react/__tests__/src/components/ExpandCollapsePanel/PanelTrigger.js
+++ b/packages/react/__tests__/src/components/ExpandCollapsePanel/PanelTrigger.js
@@ -31,3 +31,27 @@ test('should handle onclick', () => {
   wrapper.simulate('click');
   expect(handleClick).toBeCalled();
 });
+
+test('should render default trigger icons', () => {
+  const wrapper = shallow(<PanelTrigger />);
+  expect(wrapper.find('Icon').props('type')).toEqual({
+    type: 'chevron-right'
+  });
+  wrapper.setProps({ open: true });
+  expect(wrapper.find('Icon').props('type')).toEqual({
+    type: 'chevron-down'
+  });
+});
+
+test('should render custom trigger icons', () => {
+  const wrapper = shallow(
+    <PanelTrigger expandedIcon="triangle-down" collapsedIcon="triangle-right" />
+  );
+  expect(wrapper.find('Icon').props('type')).toEqual({
+    type: 'triangle-right'
+  });
+  wrapper.setProps({ open: true });
+  expect(wrapper.find('Icon').props('type')).toEqual({
+    type: 'triangle-down'
+  });
+});

--- a/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
@@ -9,8 +9,8 @@ export interface PanelTriggerProps
   open?: boolean;
   fullWidth?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  expandedIcon?: IconType;
-  collapsedIcon?: IconType;
+  iconExpanded?: IconType;
+  iconCollapsed?: IconType;
 }
 
 function PanelTrigger({
@@ -19,8 +19,8 @@ function PanelTrigger({
   open,
   fullWidth,
   onClick,
-  expandedIcon = 'chevron-down',
-  collapsedIcon = 'chevron-right',
+  iconExpanded = 'chevron-down',
+  iconCollapsed = 'chevron-right',
   ...other
 }: PanelTriggerProps) {
   return (
@@ -38,7 +38,7 @@ function PanelTrigger({
       <div className="ExpandCollapse__trigger-title">
         {typeof children === 'function' ? children({ open: !!open }) : children}
       </div>
-      <Icon type={open ? expandedIcon : collapsedIcon} />
+      <Icon type={open ? iconExpanded : iconCollapsed} />
     </button>
   );
 }
@@ -48,8 +48,8 @@ PanelTrigger.propTypes = {
   open: PropTypes.bool,
   onClick: PropTypes.func,
   className: PropTypes.string,
-  expandedIcon: PropTypes.string,
-  collapsedIcon: PropTypes.string
+  iconExpanded: PropTypes.string,
+  iconCollapsed: PropTypes.string
 };
 
 export default React.memo(PanelTrigger);

--- a/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Icon from '../Icon';
+import Icon, { IconType } from '../Icon';
 
 export interface PanelTriggerProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -9,6 +9,8 @@ export interface PanelTriggerProps
   open?: boolean;
   fullWidth?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  expandedIcon?: IconType;
+  collapsedIcon?: IconType;
 }
 
 function PanelTrigger({
@@ -17,6 +19,8 @@ function PanelTrigger({
   open,
   fullWidth,
   onClick,
+  expandedIcon = 'chevron-down',
+  collapsedIcon = 'chevron-right',
   ...other
 }: PanelTriggerProps) {
   return (
@@ -34,7 +38,7 @@ function PanelTrigger({
       <div className="ExpandCollapse__trigger-title">
         {typeof children === 'function' ? children({ open: !!open }) : children}
       </div>
-      <Icon type={open ? 'chevron-down' : 'chevron-right'} />
+      <Icon type={open ? expandedIcon : collapsedIcon} />
     </button>
   );
 }
@@ -43,7 +47,9 @@ PanelTrigger.propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   open: PropTypes.bool,
   onClick: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  expandIcon: PropTypes.string,
+  collapseIcon: PropTypes.string
 };
 
 export default React.memo(PanelTrigger);

--- a/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
@@ -48,8 +48,8 @@ PanelTrigger.propTypes = {
   open: PropTypes.bool,
   onClick: PropTypes.func,
   className: PropTypes.string,
-  expandIcon: PropTypes.string,
-  collapseIcon: PropTypes.string
+  expandedIcon: PropTypes.string,
+  collapsedIcon: PropTypes.string
 };
 
 export default React.memo(PanelTrigger);


### PR DESCRIPTION
Adds 2 new optional props:
- `expandedIcon`
- `collapsedIcon`

This enables devs to use alternatives to the `chevron-right` and `chevron-down` icons.

Closes: #633 