### PR TITLE
fix: correct default sort announcement

### DIFF
--- a/docs/patterns/components/Table/index.js
+++ b/docs/patterns/components/Table/index.js
@@ -305,6 +305,20 @@ const SortableTable = () => {
               required: false,
               default: 'none'
             },
+            sortAscendingAnnouncement: {
+              type: 'string',
+              description:
+                'The message read to screen readers when the header changes to ascending',
+              required: false,
+              default: 'sorted ascending'
+            },
+            sortDescendingAnnouncement: {
+              type: 'string',
+              description:
+                'The message read to screen readers when the header changes to descending',
+              required: false,
+              default: 'sorted descending'
+            },
             onSort: {
               type: 'function',
               description:

--- a/packages/react/__tests__/src/components/Table/index.js
+++ b/packages/react/__tests__/src/components/Table/index.js
@@ -129,6 +129,7 @@ describe('Table components', () => {
 
       expect(wrapper.find('button').exists()).toBe(true);
       expect(wrapper.find('.Icon--sort-triangle').exists()).toBe(true);
+      expect(wrapper.find('Offscreen').text()).toBe('');
     });
 
     test('render className TableHeader--sorting when a TableHeader is actively sorting', () => {
@@ -147,12 +148,16 @@ describe('Table components', () => {
       expect(wrapper.find('.TableHeader--sort-ascending').exists()).toBe(true);
     });
 
-    test('renders triangle up Icon when sortDirection is ascending', () => {
+    test('renders triangle up Icon and ascending message when sortDirection is ascending', () => {
       const wrapper = mount(
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeader sortDirection={'ascending'} onSort={() => null}>
+              <TableHeader
+                sortDirection={'ascending'}
+                sortAscendingAnnouncement={'up and away'}
+                onSort={() => null}
+              >
                 Sortable Header
               </TableHeader>
             </TableRow>
@@ -160,15 +165,20 @@ describe('Table components', () => {
         </Table>
       );
 
+      expect(wrapper.find('Offscreen').text()).toBe('up and away');
       expect(wrapper.find('.Icon--triangle-up').exists()).toBe(true);
     });
 
-    test('renders triangle down Icon when sortDirection is descending', () => {
+    test('renders triangle down Icon and descending message when sortDirection is descending', () => {
       const wrapper = mount(
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeader sortDirection={'descending'} onSort={() => null}>
+              <TableHeader
+                sortDirection={'descending'}
+                sortDescendingAnnouncement={'down below'}
+                onSort={() => null}
+              >
                 Sortable Header
               </TableHeader>
             </TableRow>
@@ -176,6 +186,7 @@ describe('Table components', () => {
         </Table>
       );
 
+      expect(wrapper.find('Offscreen').text()).toBe('down below');
       expect(wrapper.find('.Icon--triangle-down').exists()).toBe(true);
     });
 

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -78,7 +78,9 @@ TableHeader.propTypes = {
   children: PropTypes.node.isRequired,
   sortDirection: PropTypes.string,
   onSort: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  sortAscendingAnnouncement: PropTypes.string,
+  sortDescendingAnnouncement: PropTypes.string
 };
 
 export default TableHeader;

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ThHTMLAttributes, useState, useEffect } from 'react';
+import React, { ThHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Offscreen from '../Offscreen';
@@ -13,7 +13,7 @@ interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   onSort?: () => void;
   className?: string;
   sortAscendingAnnouncement?: string;
-  sortDescendingAnnouncemen?: string;
+  sortDescendingAnnouncement?: string;
 }
 
 const TableHeader = ({
@@ -22,22 +22,19 @@ const TableHeader = ({
   onSort,
   className,
   sortAscendingAnnouncement = 'sorted ascending',
-  sortDescendingAnnouncemen = 'sorted descending',
+  sortDescendingAnnouncement = 'sorted descending',
   ...other
 }: TableHeaderProps) => {
   // When the sort direction changes, we want to announce the change in a live region
   // because changes to the sort value is not widely supported yet
   // see: https://a11ysupport.io/tech/aria/aria-sort_attribute
-  const [announcement, setAnnouncement] = useState('');
-  useEffect(() => {
-    if (sortDirection !== 'none') {
-      setAnnouncement(
-        sortDirection === 'ascending'
-          ? sortAscendingAnnouncement
-          : sortDescendingAnnouncemen
-      );
-    }
-  }, [sortDirection]);
+  const announcement =
+    sortDirection === 'ascending'
+      ? sortAscendingAnnouncement
+      : sortDirection === 'descending'
+      ? sortDescendingAnnouncement
+      : '';
+
   return (
     <th
       aria-sort={sortDirection}


### PR DESCRIPTION
Ref: https://github.com/dequelabs/walnut/issues/3098

The issue was we were defaulting the sort message to `sortDescendingAnnouncemen`

Note: I also corrected the spelling of the `sortDescendingAnnouncemen` prop to be `sortDescendingAnnouncement`. This prop was undocumented, so I don't think we need a new major release. I also added documentation.