### PR TITLE
fix: correct top bar padding

### DIFF
--- a/packages/styles/navbar.css
+++ b/packages/styles/navbar.css
@@ -75,7 +75,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 var(--space-medium);
+  padding: 0 var(--space-small);
   /* clicking anywhere in the "item" should activate the anchor */
   height: 100%;
   width: 100%;

--- a/packages/styles/top-bar.css
+++ b/packages/styles/top-bar.css
@@ -57,7 +57,7 @@
 }
 
 .TopBar > ul > li:not(.TopBar__menu-trigger) {
-  padding: 0 var(--space-medium);
+  padding: 0 var(--space-small);
   font-size: var(--text-size-small);
   height: var(--top-bar-height);
   display: flex;


### PR DESCRIPTION
In meeting with @awpearlm, the padding on top bar and nav items should be 16px--not 18px.