### PR TITLE
feat: allow a node to be passed in as an IconButton label

### DIFF
--- a/docs/patterns/components/IconButton/index.js
+++ b/docs/patterns/components/IconButton/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { IconButton } from '@deque/cauldron-react/';
+import { IconButton, Offscreen } from '@deque/cauldron-react/';
 
 const IconButtonDemo = () => (
   <div>
@@ -9,6 +9,16 @@ const IconButtonDemo = () => (
       states={[
         { icon: 'pencil', label: 'Edit' },
         { icon: 'pencil', label: 'Edit', variant: 'primary' },
+        {
+          icon: 'pencil',
+          label: (
+            <>
+              Edit User
+              <Offscreen>Steve</Offscreen>
+            </>
+          ),
+          variant: 'primary'
+        },
         {
           icon: 'pencil',
           label: 'Edit',
@@ -41,7 +51,7 @@ const IconButtonDemo = () => (
           default: 'button'
         },
         label: {
-          type: 'string',
+          type: 'node',
           required: true
         },
         icon: {

--- a/docs/patterns/components/IconButton/index.js
+++ b/docs/patterns/components/IconButton/index.js
@@ -23,16 +23,14 @@ const IconButtonDemo = () => (
           icon: 'pencil',
           label: 'Edit',
           variant: 'primary',
-          disabled: true,
-          'aria-label': 'Edit'
+          disabled: true
         },
         { icon: 'pencil', label: 'Edit', variant: 'secondary' },
         {
           icon: 'pencil',
           label: 'Edit',
           variant: 'secondary',
-          disabled: true,
-          'aria-label': 'Edit'
+          disabled: true
         },
         { icon: 'pencil', label: 'Edit', variant: 'error' },
         { icon: 'trash', label: 'Delete', tooltipPlacement: 'bottom' },

--- a/packages/react/__tests__/src/components/IconButton/index.js
+++ b/packages/react/__tests__/src/components/IconButton/index.js
@@ -19,6 +19,7 @@ test('should render button by default', async () => {
   expect(button.prop('type')).toBe('button');
   expect(button.prop('tabIndex')).toBe(0);
   expect(button.prop('role')).toBeUndefined();
+  expect(button.text()).toBe('Edit');
 });
 
 test('should render a "as" an anchor', async () => {
@@ -37,13 +38,6 @@ test('adds aria-disabled when disabled is passed in for something other than a b
   const a = wrapper.find('a');
   expect(a.exists()).toBe(true);
   expect(a.prop('aria-disabled')).toBe(true);
-});
-
-test('renders the label offscreen when disabled', async () => {
-  const wrapper = mount(<IconButton icon="pencil" label="Edit" disabled />);
-
-  await update(wrapper);
-  expect(wrapper.find('Offscreen').text()).toBe('Edit');
 });
 
 test('should add button role when the component is not a link or a button', async () => {

--- a/packages/react/__tests__/src/components/IconButton/index.js
+++ b/packages/react/__tests__/src/components/IconButton/index.js
@@ -39,11 +39,11 @@ test('adds aria-disabled when disabled is passed in for something other than a b
   expect(a.prop('aria-disabled')).toBe(true);
 });
 
-test('adds aria-label when disabled is passed in', async () => {
+test('renders the label offscreen when disabled', async () => {
   const wrapper = mount(<IconButton icon="pencil" label="Edit" disabled />);
 
   await update(wrapper);
-  expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('Edit');
+  expect(wrapper.find('Offscreen').text()).toBe('Edit');
 });
 
 test('should add button role when the component is not a link or a button', async () => {

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -10,15 +10,13 @@ import React, {
   forwardRef,
   useImperativeHandle,
   MutableRefObject,
-  HTMLProps,
-  useEffect
+  HTMLProps
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import * as Polymorphic from '../../utils/polymorphic-type';
 import Icon, { IconType } from '../Icon';
 import Tooltip, { TooltipProps } from '../Tooltip';
-import { useId } from 'react-id-generator';
 import Offscreen from '../Offscreen';
 
 export interface IconButtonOwnProps {

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -21,7 +21,7 @@ import Tooltip, { TooltipProps } from '../Tooltip';
 
 export interface IconButtonOwnProps {
   icon: IconType;
-  label: string;
+  label: React.ReactNode;
   tooltipPlacement?: TooltipProps['placement'];
   tooltipVariant?: TooltipProps['variant'];
   tooltipPortal?: TooltipProps['portal'];
@@ -121,7 +121,7 @@ IconButton.propTypes = {
   as: PropTypes.elementType,
   // @ts-expect-error
   icon: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,
   // @ts-expect-error

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -93,8 +93,7 @@ const IconButton = forwardRef(
           {...other}
         >
           <Icon type={icon} />
-          {// When not disabled, the button is labelled by the tooltip
-          disabled && <Offscreen>{label}</Offscreen>}
+          <Offscreen>{label}</Offscreen>
         </Component>
         {!disabled && (
           <Tooltip

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -18,6 +18,8 @@ import classnames from 'classnames';
 import * as Polymorphic from '../../utils/polymorphic-type';
 import Icon, { IconType } from '../Icon';
 import Tooltip, { TooltipProps } from '../Tooltip';
+import { useId } from 'react-id-generator';
+import Offscreen from '../Offscreen';
 
 export interface IconButtonOwnProps {
   icon: IconType;
@@ -75,13 +77,6 @@ const IconButton = forwardRef(
       }
     }
 
-    useEffect(() => {
-      if (!disabled) {
-        return;
-      }
-      internalRef.current?.setAttribute('aria-label', label);
-    }, [disabled]);
-
     return (
       <React.Fragment>
         <Component
@@ -98,6 +93,8 @@ const IconButton = forwardRef(
           {...other}
         >
           <Icon type={icon} />
+          {// When not disabled, the button is labelled by the tooltip
+          disabled && <Offscreen>{label}</Offscreen>}
         </Component>
         {!disabled && (
           <Tooltip


### PR DESCRIPTION
This allows a node to be passed in as the label for an IconButton. Allowing a node to be passed in allows consumers to include things like screen reader-only content. (see the docs example in this PR)
