### PR TITLE
feat(react): allow LoaderOverlay to be used as a focus trap

### DIFF
--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -52,6 +52,11 @@ const LoaderOverlayDemo = () => {
         loaderRef: {
           type: 'function',
           description: 'optional ref function'
+        },
+        focusTrap: {
+          type: 'boolean',
+          description: 'conditionally wrap the overlay in a focus trap',
+          defaultValue: 'false'
         }
       }}
     >
@@ -63,7 +68,7 @@ const LoaderOverlayDemo = () => {
               tabIndex={-1}
               label="Loading..."
               variant="large"
-              focusOnInitialRender
+              focusTrap
             >
               <p>
                 Explanatory secondary text goes here. Let them know what's

--- a/packages/react/__tests__/src/components/LoaderOverlay/index.js
+++ b/packages/react/__tests__/src/components/LoaderOverlay/index.js
@@ -80,6 +80,16 @@ test('handles being passed a ref', () => {
   });
 });
 
+test('traps focus', () => {
+  const loaderOverlay = shallow(
+    <LoaderOverlay className="baz" role="alert" label="loading" focusTrap>
+      Some text
+    </LoaderOverlay>
+  );
+
+  expect(loaderOverlay.find('FocusTrap').exists()).toBe(true);
+});
+
 test('returns no axe violations', async () => {
   const loaderOverlay = shallow(<LoaderOverlay>Hello world</LoaderOverlay>);
 

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useEffect } from 'react';
+import FocusTrap from 'focus-trap-react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Loader from '../Loader';
@@ -10,6 +11,7 @@ interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   label?: string;
   focusOnInitialRender?: boolean;
   children?: React.ReactNode;
+  focusTrap?: boolean;
 }
 
 const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
@@ -20,6 +22,7 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
       label,
       children,
       focusOnInitialRender,
+      focusTrap = false,
       ...other
     }: LoaderOverlayProps,
     ref
@@ -35,28 +38,41 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
       return;
     }, [overlayRef.current]);
 
+    const Wrapper = focusTrap ? FocusTrap : React.Fragment;
+    const wrapperProps = focusTrap
+      ? {
+          focusTrapOptions: {
+            fallbackFocus: '.Loader__overlay'
+          }
+        }
+      : {};
+
     return (
-      <div
-        className={classNames(
-          'Loader__overlay',
-          className,
-          variant === 'large'
-            ? 'Loader__overlay--large'
-            : variant === 'small'
-            ? 'Loader__overlay--small'
-            : ''
-        )}
-        ref={overlayRef}
-        tabIndex={-1}
-        {...other}
-      >
-        <div className="Loader__overlay__loader">
-          <Loader variant={variant} />
-          <AxeLoader />
+      <Wrapper {...wrapperProps}>
+        <div
+          className={classNames(
+            'Loader__overlay',
+            className,
+            variant === 'large'
+              ? 'Loader__overlay--large'
+              : variant === 'small'
+              ? 'Loader__overlay--small'
+              : ''
+          )}
+          ref={overlayRef}
+          tabIndex={-1}
+          {...other}
+        >
+          <div className="Loader__overlay__loader">
+            <Loader variant={variant} />
+            <AxeLoader />
+          </div>
+          {label ? (
+            <span className="Loader__overlay__label">{label}</span>
+          ) : null}
+          {children}
         </div>
-        {label ? <span className="Loader__overlay__label">{label}</span> : null}
-        {children}
-      </div>
+      </Wrapper>
     );
   }
 );


### PR DESCRIPTION
Sometimes, the `LoaderOverlay` component needs to also be a focus trap, since its potentially blocking active content behind the overlay while something is loading.