### PR TITLE
fix(BreadcrumbLink): TS would not allow href attribute on component

### DIFF
--- a/packages/react/src/components/Breadcrumb/BreadcrumbLink.tsx
+++ b/packages/react/src/components/Breadcrumb/BreadcrumbLink.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react';
 import classnames from 'classnames';
-import { Cauldron } from '../../types';
 
-interface BreadcrumbLinkProps extends React.HTMLAttributes<HTMLLinkElement> {
+interface BreadcrumbLinkProps
+  extends Omit<React.LinkHTMLAttributes<HTMLLinkElement>, 'as'> {
   as?: React.ElementType;
 }
 
@@ -26,4 +26,5 @@ const BreadcrumbLink = forwardRef<HTMLElement, BreadcrumbLinkProps>(
   )
 );
 
+BreadcrumbLink.displayName = 'BreadcrumbLink';
 export default BreadcrumbLink;


### PR DESCRIPTION
Having the props extend only `HTMLAttributes<HTMLLinkElement>` did not include things like `href`. Extending `LinkHTMLAttributes<HTMLLinkElement>` brings in some Link specific attributes and extends `HTMLAttributes<HTMLLinkElement>`.