### PR TITLE
fix(react): ensure that other elements get correctly hidden when setting focusTrap on overlay loader

### DIFF
--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -35,8 +35,8 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
         ? new AriaIsolate(overlayRef.current)
         : null;
 
-      if (focusTrap && isolator) {
-        isolator.activate();
+      if (isolator) {
+        focusTrap ? isolator.activate() : isolator.deactivate();
       }
 
       return () => {

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Loader from '../Loader';
 import AxeLoader from './axe-loader';
+import AriaIsolate from '../../utils/aria-isolate';
 import useSharedRef from '../../utils/useSharedRef';
 
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -28,6 +29,20 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
     ref
   ) => {
     const overlayRef = useSharedRef<HTMLDivElement>(ref);
+
+    useEffect(() => {
+      const isolator = overlayRef.current
+        ? new AriaIsolate(overlayRef.current)
+        : null;
+
+      if (focusTrap && isolator) {
+        isolator.activate();
+      }
+
+      return () => {
+        isolator?.deactivate();
+      };
+    }, [focusTrap, overlayRef.current]);
 
     useEffect(() => {
       if (!!focusOnInitialRender && overlayRef.current) {


### PR DESCRIPTION
This fixes an issue where focus-trap handles keyboard trapping only and does not isolate the trapped component for SR users.