### PR TITLE
chore(release): 4.5.0

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
             set -e
 
-            Title="${{ github.event.pull_request.title }}"
+            Title='${{ github.event.pull_request.title }}'
             CommitTypes="feat fix perf style docs refactor test build ci chore Merge Revert"
 
             echo "Validating PR title: \"$Title\""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.5.0](https://github.com/dequelabs/cauldron/compare/v4.4.0...v4.5.0) (2022-05-17)
+
+### Features
+
+- **react:** Add `ref` support to `<Loader/>` ([#651](https://github.com/dequelabs/cauldron/issues/651)) ([f8ca4e9](https://github.com/dequelabs/cauldron/commit/f8ca4e9b0465f085394206878ceff0d4c39fb290))
+- add ref forwarding to Panel component ([#649](https://github.com/dequelabs/cauldron/issues/649)) ([77fc218](https://github.com/dequelabs/cauldron/commit/77fc21838a462f7403013c8c121ea2db7f1f1071))
+
+### Bug Fixes
+
+- **react:** ensure that sibling elements get correctly hidden when setting focusTrap on overlay loader ([#656](https://github.com/dequelabs/cauldron/issues/656)) ([2f777a4](https://github.com/dequelabs/cauldron/commit/2f777a4317d0aa51db0e66c1749a9f5488b9eed4))
+
 ## [4.4.0](https://github.com/dequelabs/cauldron/compare/v4.3.0...v4.4.0) (2022-05-09)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cauldron",
   "private": true,
-  "version": "4.4.0",
+  "version": "4.5.0",
   "license": "MPL-2.0",
   "scripts": {
     "build": "concurrently \"yarn build:styles\" \"yarn build:react\" \"yarn build:docs\"",

--- a/packages/react/__tests__/src/components/Loader/index.js
+++ b/packages/react/__tests__/src/components/Loader/index.js
@@ -42,3 +42,9 @@ test('returns no axe violations', async () => {
   expect(await axe(withLabel.html())).toHaveNoViolations();
   expect(await axe(withoutLabel.html())).toHaveNoViolations();
 });
+
+test('supports ref={React.createRef()}', () => {
+  const ref = React.createRef();
+  mount(<Loader ref={ref} />);
+  expect(ref.current).toBeTruthy();
+});

--- a/packages/react/__tests__/src/components/Panel/index.js
+++ b/packages/react/__tests__/src/components/Panel/index.js
@@ -73,4 +73,15 @@ describe('Panel', () => {
 
     expect(panel.find('section').hasClass('Panel--collapsed')).toBe(true);
   });
+
+  test('forwards a ref', () => {
+    const ref = jest.fn();
+    mount(
+      <Panel ref={ref} heading={{ text: 'Title' }}>
+        Content
+      </Panel>
+    );
+
+    expect(ref).toHaveBeenCalled();
+  });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-react",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Fully accessible react components library for Deque Cauldron",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/Loader/index.tsx
+++ b/packages/react/src/components/Loader/index.tsx
@@ -1,4 +1,3 @@
-import { Cauldron } from '../../types';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Offscreen from '../Offscreen';
@@ -9,37 +8,34 @@ export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
 }
 
-export default function Loader({
-  className,
-  variant = 'small',
-  label,
-  ...props
-}: LoaderProps) {
-  if (label?.length) {
-    props['role'] = 'alert';
-    props.children = <Offscreen>{label}</Offscreen>;
-  } else {
-    props['aria-hidden'] = true;
-  }
+const Loader = React.forwardRef<HTMLDivElement, LoaderProps>(
+  ({ className, variant = 'small', label, ...props }: LoaderProps, ref) => {
+    if (label?.length) {
+      props['role'] = 'alert';
+      props.children = <Offscreen>{label}</Offscreen>;
+    } else {
+      props['aria-hidden'] = true;
+    }
 
-  return (
-    <div
-      className={classNames(
-        'Loader',
-        className,
-        variant === 'large'
-          ? 'Loader--large'
-          : variant === 'small'
-          ? 'Loader--small'
-          : ''
-      )}
-      {...props}
-    />
-  );
-}
+    return (
+      <div
+        ref={ref}
+        className={classNames(
+          'Loader',
+          className,
+          variant === 'large' && 'Loader--large',
+          variant === 'small' && 'Loader--small'
+        )}
+        {...props}
+      />
+    );
+  }
+);
 
 Loader.propTypes = {
   className: PropTypes.string
 };
 
 Loader.displayName = 'Loader';
+
+export default Loader;

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Loader from '../Loader';
 import AxeLoader from './axe-loader';
+import AriaIsolate from '../../utils/aria-isolate';
 import useSharedRef from '../../utils/useSharedRef';
 
 interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -28,6 +29,20 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
     ref
   ) => {
     const overlayRef = useSharedRef<HTMLDivElement>(ref);
+
+    useEffect(() => {
+      const isolator = overlayRef.current
+        ? new AriaIsolate(overlayRef.current)
+        : null;
+
+      if (isolator) {
+        focusTrap ? isolator.activate() : isolator.deactivate();
+      }
+
+      return () => {
+        isolator?.deactivate();
+      };
+    }, [focusTrap, overlayRef.current]);
 
     useEffect(() => {
       if (!!focusOnInitialRender && overlayRef.current) {

--- a/packages/react/src/components/Panel/index.tsx
+++ b/packages/react/src/components/Panel/index.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
+import React, { HTMLAttributes, ReactNode, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import rndid from '../../utils/rndid';
@@ -6,62 +6,62 @@ import rndid from '../../utils/rndid';
 interface PanelProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
   heading?:
-    | ReactElement<any>
+    | ReactNode
     | {
         id?: string;
-        text: ReactElement<any>;
+        text: ReactNode;
         level: number | undefined;
       };
   collapsed?: boolean;
   className?: string;
 }
 
-const Panel = ({
-  children,
-  collapsed,
-  className,
-  heading,
-  ...other
-}: PanelProps) => {
-  const headingId = !heading
-    ? undefined
-    : typeof heading === 'object' && 'id' in heading
-    ? heading.id
-    : rndid();
+const Panel = forwardRef<HTMLElement, PanelProps>(
+  ({ children, collapsed, className, heading, ...other }: PanelProps, ref) => {
+    const headingId = !heading
+      ? undefined
+      : typeof heading === 'object' && 'id' in heading
+      ? heading.id
+      : rndid();
 
-  const Heading = () => {
-    if (!headingId) {
-      return null;
-    }
+    const Heading = () => {
+      if (!headingId) {
+        return null;
+      }
 
-    const HeadingComponent = `h${
-      typeof heading === 'object' && 'level' in heading && !!heading.level
-        ? heading.level
-        : 2
-    }` as 'h1';
+      const HeadingComponent = `h${
+        heading &&
+        typeof heading === 'object' &&
+        'level' in heading &&
+        !!heading.level
+          ? heading.level
+          : 2
+      }` as 'h1';
+
+      return (
+        <HeadingComponent id={headingId} className="Panel__Heading">
+          {heading && typeof heading === 'object' && 'text' in heading
+            ? heading.text
+            : heading}
+        </HeadingComponent>
+      );
+    };
 
     return (
-      <HeadingComponent id={headingId} className="Panel__Heading">
-        {typeof heading === 'object' && 'text' in heading
-          ? heading.text
-          : heading}
-      </HeadingComponent>
+      <section
+        aria-labelledby={headingId}
+        className={classNames('Panel', className, {
+          ['Panel--collapsed']: collapsed
+        })}
+        ref={ref}
+        {...other}
+      >
+        <Heading />
+        {children}
+      </section>
     );
-  };
-
-  return (
-    <section
-      aria-labelledby={headingId}
-      className={classNames('Panel', className, {
-        ['Panel--collapsed']: collapsed
-      })}
-      {...other}
-    >
-      <Heading />
-      {children}
-    </section>
-  );
-};
+  }
+);
 
 Panel.displayName = 'Panel';
 Panel.propTypes = {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deque/cauldron-styles",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "license": "MPL-2.0",
   "description": "deque cauldron pattern library styles",
   "repository": "https://github.com/dequelabs/cauldron",


### PR DESCRIPTION
## [4.5.0](https://github.com/dequelabs/cauldron/compare/v4.4.0...v4.5.0) (2022-05-17)

### Features

- **react:** Add `ref` support to `<Loader/>` ([#651](https://github.com/dequelabs/cauldron/issues/651)) ([f8ca4e9](https://github.com/dequelabs/cauldron/commit/f8ca4e9b0465f085394206878ceff0d4c39fb290))
- add ref forwarding to Panel component ([#649](https://github.com/dequelabs/cauldron/issues/649)) ([77fc218](https://github.com/dequelabs/cauldron/commit/77fc21838a462f7403013c8c121ea2db7f1f1071))

### Bug Fixes

- **react:** ensure that sibling elements get correctly hidden when setting focusTrap on overlay loader ([#656](https://github.com/dequelabs/cauldron/issues/656)) ([2f777a4](https://github.com/dequelabs/cauldron/commit/2f777a4317d0aa51db0e66c1749a9f5488b9eed4))