### PR TITLE
feat(styles): add axe-core issue impact colors

### DIFF
--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -35,6 +35,10 @@
   --accent-secondary-active: var(--gray-30);
   --focus-light: #c11bde;
   --focus-dark: #eb94ff;
+  --axe-issue-critical: #ed5959;
+  --axe-issue-serious: #f3826b;
+  --axe-issue-moderatee: #ffdd76;
+  --axe-issue-minor: #d3dde0;
 
   /* text colours */
   --text-color-base: var(--gray-60);

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -35,10 +35,10 @@
   --accent-secondary-active: var(--gray-30);
   --focus-light: #c11bde;
   --focus-dark: #eb94ff;
-  --axe-issue-critical: #ed5959;
-  --axe-issue-serious: #f3826b;
-  --axe-issue-moderatee: #ffdd76;
-  --axe-issue-minor: #d3dde0;
+  --issue-critical: #ed5959;
+  --issue-serious: #f3826b;
+  --issue-moderatee: #ffdd76;
+  --issue-minor: #d3dde0;
 
   /* text colours */
   --text-color-base: var(--gray-60);


### PR DESCRIPTION
Required for https://github.com/dequelabs/walnut/pull/3320.
Colors taken from https://github.com/dequelabs/walnut/blob/develop/app/src/modules/app/components/RuleHelp.css#L95-L119