### PR TITLE
fix(react): Support React 18 types

### DIFF
--- a/packages/react/__tests__/src/components/Dialog/index.js
+++ b/packages/react/__tests__/src/components/Dialog/index.js
@@ -15,7 +15,7 @@ test('returns null if passed a falsey "show" prop', () => {
 test('focuses heading when mounted with a truthy "show" prop', done => {
   const dialog = mount(
     <Dialog {...defaults} show={true}>
-      {'hello'}
+      hello
     </Dialog>
   );
 
@@ -115,7 +115,11 @@ test('supports heading from text', async () => {
 
 test('supports heading from options', async () => {
   const dialog = mount(
-    <Dialog {...defaults} heading={{ text: 'hello title', level: 3 }} show={true}>
+    <Dialog
+      {...defaults}
+      heading={{ text: 'hello title', level: 3 }}
+      show={true}
+    >
       {'body'}
     </Dialog>
   );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,14 +23,14 @@
   "dependencies": {
     "@popperjs/core": "^2.5.4",
     "classnames": "^2.2.6",
-    "focus-trap-react": "^8.9.0",
+    "focus-trap-react": "^9.0.0",
     "focusable": "^2.3.0",
     "keyname": "^0.1.0",
     "prop-types": "^15.6.0",
     "react-id-generator": "^3.0.1",
     "react-popper": "^2.2.4",
-    "react-syntax-highlighter": "^15.4.3",
-    "tslib": "^2.0.0"
+    "react-syntax-highlighter": "^15.5.0",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -47,10 +47,11 @@
     "@rollup/plugin-typescript": "^5.0.2",
     "@svgr/rollup": "^6.1.2",
     "@types/classnames": "^2.2.10",
+    "@types/node": "^17.0.42",
     "@types/prop-types": "^15.7.3",
-    "@types/react": "^16.9.34",
-    "@types/react-dom": "^16.9.7",
-    "@types/react-syntax-highlighter": "^13.5.2",
+    "@types/react": "^18.0.12",
+    "@types/react-dom": "^18.0.5",
+    "@types/react-syntax-highlighter": "^15.5.2",
     "autoprefixer": "^9.7.6",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
@@ -79,8 +80,8 @@
     "react-router-dom": "^5.1.2",
     "rollup": "^2.23.0",
     "sinon": "^10.0.0",
-    "ts-node": "^8.9.1",
-    "typescript": "^3.9.7"
+    "ts-node": "^10.8.1",
+    "typescript": "^4.7.3"
   },
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@popperjs/core": "^2.5.4",
     "classnames": "^2.2.6",
-    "focus-trap-react": "^9.0.0",
+    "focus-trap-react": "8",
     "focusable": "^2.3.0",
     "keyname": "^0.1.0",
     "prop-types": "^15.6.0",

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -13,27 +13,34 @@ SyntaxHighlighter.registerLanguage('css', css);
 SyntaxHighlighter.registerLanguage('html', xml);
 SyntaxHighlighter.registerLanguage('yaml', yaml);
 
+// HACK: This is a workaround for a bug in react-syntax-highlighter's types.
+const Highlighter = SyntaxHighlighter as React.ComponentType<
+  SyntaxHighlighterProps
+>;
+
 interface Props extends SyntaxHighlighterProps {
-  children: React.ReactNode;
+  children: string;
   language?: 'javascript' | 'css' | 'html' | 'yaml';
   className?: string;
   tabIndex?: number;
 }
 
-const Code: React.ComponentType<Props> = ({
+const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
   children,
   className,
   tabIndex,
   ...props
 }) => (
-  <SyntaxHighlighter
-    {...props}
-    useInlineStyles={false}
-    className={classNames('Code', className)}
-    tabIndex={tabIndex}
-  >
-    {children}
-  </SyntaxHighlighter>
+  <>
+    <Highlighter
+      {...props}
+      useInlineStyles={false}
+      className={classNames('Code', className)}
+      tabIndex={tabIndex}
+    >
+      {children}
+    </Highlighter>
+  </>
 );
 
 Code.displayName = 'Code';
@@ -41,7 +48,8 @@ Code.displayName = 'Code';
 Code.propTypes = {
   children: PropTypes.string.isRequired,
   language: PropTypes.oneOf(['javascript', 'css', 'html', 'yaml']),
-  className: PropTypes.string
+  className: PropTypes.string,
+  tabIndex: PropTypes.number
 };
 
 export default Code;

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -166,7 +166,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
     return createPortal(
       Dialog,
       ('current' in portal ? portal.current : portal) || document.body
-    );
+    ) as JSX.Element;
   }
 
   close() {

--- a/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import Icon, { IconType } from '../Icon';
 
 export interface PanelTriggerProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   children?: ((props: { open: boolean }) => React.ReactNode) | React.ReactNode;
   open?: boolean;
   fullWidth?: string;

--- a/packages/react/src/components/FieldWrap/index.tsx
+++ b/packages/react/src/components/FieldWrap/index.tsx
@@ -17,6 +17,7 @@ const FieldWrap = React.forwardRef<HTMLElement, Props>(
 
 FieldWrap.displayName = 'FieldWrap';
 FieldWrap.propTypes = {
+  // @ts-expect-error
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   as: PropTypes.string

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -115,6 +115,7 @@ IconButton.propTypes = {
   as: PropTypes.elementType,
   // @ts-expect-error
   icon: PropTypes.string.isRequired,
+  // @ts-expect-error
   label: PropTypes.node.isRequired,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,

--- a/packages/react/src/components/IssuePanel/index.tsx
+++ b/packages/react/src/components/IssuePanel/index.tsx
@@ -18,7 +18,11 @@ const IssuePanel = ({
     <div className={classNames('IssuePanel', className)}>
       <div className="IssuePanel__Header">
         {title && <div className="IssuePanel__Header-title">{title}</div>}
-        {actions && <div className="IssuePanel__Header-actions">{actions}</div>}
+        {actions && (
+          <div className="IssuePanel__Header-actions">
+            {actions as React.ReactNode}
+          </div>
+        )}
       </div>
       <div className="IssuePanel__Content">{children}</div>
     </div>

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -97,6 +97,7 @@ LoaderOverlay.propTypes = {
   variant: PropTypes.oneOf(['large', 'small']),
   label: PropTypes.string,
   focusOnInitialRender: PropTypes.bool,
+  // @ts-expect-error
   children: PropTypes.node
 };
 

--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -25,6 +25,7 @@ export interface OptionsMenuProps extends OptionsMenuAlignmentProps {
   onSelect: (e: React.MouseEvent<HTMLElement>) => void;
   closeOnSelect?: boolean;
   show?: boolean;
+  children: React.ReactNode;
 }
 
 interface OptionsMenuState {

--- a/packages/react/src/components/Panel/index.tsx
+++ b/packages/react/src/components/Panel/index.tsx
@@ -65,7 +65,9 @@ const Panel = forwardRef<HTMLElement, PanelProps>(
 
 Panel.displayName = 'Panel';
 Panel.propTypes = {
+  // @ts-expect-error
   children: PropTypes.node.isRequired,
+  // @ts-expect-error
   heading: PropTypes.oneOfType([PropTypes.object, PropTypes.node]),
   className: PropTypes.string
 };

--- a/packages/react/src/components/Pointout/index.tsx
+++ b/packages/react/src/components/Pointout/index.tsx
@@ -463,7 +463,7 @@ export default class Pointout extends React.Component<
 
     if (target && portal && !disableOffscreenPointout) {
       return (
-        <React.Fragment>
+        <>
           <div
             className="Offscreen"
             role="region"
@@ -503,7 +503,7 @@ export default class Pointout extends React.Component<
             )}
           </div>
           {createPortal(FTPO, portal as HTMLElement)}
-        </React.Fragment>
+        </>
       );
     }
 

--- a/packages/react/src/components/SideBar/SideBarItem.tsx
+++ b/packages/react/src/components/SideBar/SideBarItem.tsx
@@ -7,11 +7,9 @@ export interface SideBarItemProps extends React.HTMLAttributes<HTMLLIElement> {
   autoClickLink?: boolean;
 }
 
-const SideBarItem: React.ComponentType<SideBarItemProps> = ({
-  children,
-  autoClickLink,
-  ...other
-}) => {
+const SideBarItem: React.ComponentType<React.PropsWithChildren<
+  SideBarItemProps
+>> = ({ children, autoClickLink, ...other }) => {
   const onClick = (e: React.MouseEvent<HTMLLIElement>) => {
     if (!autoClickLink) {
       return;
@@ -33,6 +31,7 @@ SideBarItem.defaultProps = {
   autoClickLink: true
 };
 SideBarItem.propTypes = {
+  // @ts-expect-error
   children: PropTypes.node.isRequired,
   autoClickLink: PropTypes.bool
 };

--- a/packages/react/src/components/Tabs/Tab.tsx
+++ b/packages/react/src/components/Tabs/Tab.tsx
@@ -21,6 +21,7 @@ Tab.displayName = 'Tab';
 Tab.propTypes = {
   target: PropTypes.any.isRequired,
   id: PropTypes.string,
+  // @ts-expect-error
   children: PropTypes.node
 };
 

--- a/packages/react/src/components/Tabs/TabPanel.tsx
+++ b/packages/react/src/components/Tabs/TabPanel.tsx
@@ -29,6 +29,7 @@ const TabPanel = forwardRef<HTMLDivElement, TabPanelProps>(
 TabPanel.displayName = 'TabPanel';
 TabPanel.propTypes = {
   id: PropTypes.string,
+  // @ts-expect-error
   children: PropTypes.node,
   className: PropTypes.string
 };

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -68,7 +68,7 @@ export default class TextField extends React.Component<
     this.state = {
       value:
         typeof this.props.value !== 'undefined'
-          ? this.props.value
+          ? (this.props.value as string)
           : this.props.defaultValue || ''
     };
     this.onChange = this.onChange.bind(this);

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -12,6 +12,7 @@ export interface ToastProps {
   toastRef: React.Ref<HTMLDivElement>;
   focus?: boolean;
   show?: boolean;
+  children: React.ReactNode;
 }
 
 interface ToastState {

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -49,7 +49,7 @@ export default function Tooltip({
   hideElementOnHidden = false,
   className,
   ...props
-}: TooltipProps) {
+}: TooltipProps): JSX.Element {
   const [id] = propId ? [propId] : useId(1, 'tooltip');
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showTooltip, setShowTooltip] = useState(!!initialShow);
@@ -178,34 +178,43 @@ export default function Tooltip({
     }
   }, [targetElement, id]);
 
-  return (showTooltip || hideElementOnHidden) && isBrowser()
-    ? createPortal(
-        <div
-          id={id}
-          className={classnames('Tooltip', `Tooltip--${placement}`, className, {
-            TooltipInfo: variant === 'info',
-            'Tooltip--hidden': !showTooltip && hideElementOnHidden,
-            'Tooltip--big': variant === 'big'
-          })}
-          ref={setTooltipElement}
-          role="tooltip"
-          style={styles.popper}
-          {...attributes.popper}
-          {...props}
-        >
-          {variant !== 'big' && (
+  return (
+    <>
+      {(showTooltip || hideElementOnHidden) && isBrowser()
+        ? createPortal(
             <div
-              className="TooltipArrow"
-              ref={setArrowElement}
-              style={styles.arrow}
-            />
-          )}
-          {children}
-        </div>,
-        (portal && 'current' in portal ? portal.current : portal) ||
-          document.body
-      )
-    : null;
+              id={id}
+              className={classnames(
+                'Tooltip',
+                `Tooltip--${placement}`,
+                className,
+                {
+                  TooltipInfo: variant === 'info',
+                  'Tooltip--hidden': !showTooltip && hideElementOnHidden,
+                  'Tooltip--big': variant === 'big'
+                }
+              )}
+              ref={setTooltipElement}
+              role="tooltip"
+              style={styles.popper}
+              {...attributes.popper}
+              {...props}
+            >
+              {variant !== 'big' && (
+                <div
+                  className="TooltipArrow"
+                  ref={setArrowElement}
+                  style={styles.arrow}
+                />
+              )}
+              {children}
+            </div>,
+            (portal && 'current' in portal ? portal.current : portal) ||
+              document.body
+          )
+        : null}
+    </>
+  );
 }
 
 Tooltip.displayName = 'Tooltip';

--- a/packages/react/src/components/TopBar/TopBarTrigger.tsx
+++ b/packages/react/src/components/TopBar/TopBarTrigger.tsx
@@ -7,11 +7,9 @@ interface TopBarTriggerProps extends React.HTMLAttributes<HTMLLIElement> {
   children: React.ReactNode;
 }
 
-const TopBarTrigger: React.ComponentType<TopBarTriggerProps> = ({
-  children,
-  className,
-  ...other
-}) => (
+const TopBarTrigger: React.ComponentType<React.PropsWithChildren<
+  TopBarTriggerProps
+>> = ({ children, className, ...other }) => (
   <MenuItem
     aria-haspopup="true"
     className={classNames('TopBar__menu-trigger', className)}
@@ -22,6 +20,7 @@ const TopBarTrigger: React.ComponentType<TopBarTriggerProps> = ({
 );
 TopBarTrigger.displayName = 'TopBarTrigger';
 TopBarTrigger.propTypes = {
+  // @ts-expect-error
   children: PropTypes.node.isRequired,
   className: PropTypes.string
 };

--- a/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.tsx
+++ b/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.tsx
@@ -40,6 +40,15 @@ const TwoColumnPanel = forwardRef<HTMLDivElement, TwoColumnPanelProps>(
     const [isCollapsed, setCollapsed] = useState(initialCollapsed);
     const [isFocusTrap, setIsFocusTrap] = useState(false);
     const [showPanel, setShowPanel] = useState(!initialCollapsed);
+    const toggleButtonRef = useRef<HTMLButtonElement>(null);
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+    const columnLeftRef = useRef<HTMLDivElement>(null);
+    const columnRightRef = useRef<HTMLDivElement>(null);
+
+    const columnLeft = React.Children.toArray(children).find(
+      child => (child as React.ReactElement<any>).type === ColumnLeft
+    );
+
     const togglePanel = () => {
       if (isCollapsed) {
         setShowPanel(true);
@@ -55,14 +64,6 @@ const TwoColumnPanel = forwardRef<HTMLDivElement, TwoColumnPanelProps>(
         }
       });
     };
-    const toggleButtonRef = useRef<HTMLButtonElement>(null);
-    const closeButtonRef = useRef<HTMLButtonElement>(null);
-    const columnLeftRef = useRef<HTMLDivElement>(null);
-    const columnRightRef = useRef<HTMLDivElement>(null);
-
-    const columnLeft = React.Children.toArray(children).find(
-      child => (child as React.ReactElement<any>).type === ColumnLeft
-    );
 
     // The ColumnLeftComponent will end up being a focus trap when < 720px
     // This component also gets unmounted when not visible meaning that any
@@ -231,22 +232,24 @@ const TwoColumnPanel = forwardRef<HTMLDivElement, TwoColumnPanelProps>(
         {...props}
         ref={ref}
       >
-        <FocusTrap
-          active={!isCollapsed && isFocusTrap}
-          focusTrapOptions={{
-            escapeDeactivates: true,
-            allowOutsideClick: true,
-            fallbackFocus: columnLeftRef.current as HTMLElement
-          }}
-          containerElements={[columnLeftRef.current as HTMLElement]}
-        />
-        <ClickOutsideListener
-          onClickOutside={handleClickOutside}
-          target={columnLeftRef.current as HTMLElement}
-        />
-        {isCollapsed ? null : skipLink}
-        {showPanel ? ColumnLeftComponent : null}
-        {ColumnRightComponent}
+        <>
+          <FocusTrap
+            active={!isCollapsed && isFocusTrap}
+            focusTrapOptions={{
+              escapeDeactivates: true,
+              allowOutsideClick: true,
+              fallbackFocus: columnLeftRef.current as HTMLElement
+            }}
+            containerElements={[columnLeftRef.current as HTMLElement]}
+          />
+          <ClickOutsideListener
+            onClickOutside={handleClickOutside}
+            target={columnLeftRef.current as HTMLElement}
+          />
+          {isCollapsed ? null : skipLink}
+          {showPanel ? ColumnLeftComponent : null}
+          {ColumnRightComponent}
+        </>
       </div>
     );
   }

--- a/packages/react/src/utils/polymorphic-type/index.ts
+++ b/packages/react/src/utils/polymorphic-type/index.ts
@@ -51,7 +51,7 @@ interface ForwardRefComponent<
   <As = IntrinsicElementString>(
     props: As extends ''
       ? { as: keyof JSX.IntrinsicElements }
-      : As extends React.ComponentType<infer P>
+      : As extends React.ComponentType<React.PropsWithChildren<infer P>>
       ? Merge<P, OwnProps & { as: As }>
       : As extends keyof JSX.IntrinsicElements
       ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>

--- a/packages/react/src/utils/polymorphic-type/index.ts
+++ b/packages/react/src/utils/polymorphic-type/index.ts
@@ -51,7 +51,7 @@ interface ForwardRefComponent<
   <As = IntrinsicElementString>(
     props: As extends ''
       ? { as: keyof JSX.IntrinsicElements }
-      : As extends React.ComponentType<React.PropsWithChildren<infer P>>
+      : As extends React.ComponentType<infer P>
       ? Merge<P, OwnProps & { as: As }>
       : As extends keyof JSX.IntrinsicElements
       ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -1858,6 +1858,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -2030,6 +2037,24 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz#30cd49820a962aff48c8fffc5cd760151fca61fe"
+  integrity sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
+  integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -2243,6 +2268,26 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.10.tgz#10fecee4a3be17357ce99b370bd81874044d8dbd"
+  integrity sha512-N+srakvPaYMGkwjNDx3ASx65Zl3QG8dJgVtIB+YMOkucU+zctlv/hdP5250VKdDHSDoW9PFZoCqbqNcAPjCjXA==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.2.tgz#b09c08de2eb319ca2acab17a1b8028af110b24b3"
+  integrity sha512-YwrUA5ysDXHFYfL0Xed9x3sNS4P+aKlCOnnbqUa2E5HdQshHFleCJVrj1PlGTb4GgFUCDyte1v3JWLy2sz8Oqg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
 "@types/babel__core@^7.1.0":
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
@@ -2328,6 +2373,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
   integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
+"@types/node@^17.0.42":
+  version "17.0.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.42.tgz#d7e8f22700efc94d125103075c074396b5f41f9b"
+  integrity sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -2338,27 +2388,41 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-dom@^16.9.7":
-  version "16.9.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.7.tgz#60844d48ce252d7b2dccf0c7bb937130e27c0cd2"
-  integrity sha512-GHTYhM8/OwUCf254WO5xqR/aqD3gC9kSTLpopWGpQLpnw23jk44RvMHsyUSEplvRJZdHxhJGMMLF0kCPYHPhQA==
+"@types/react-dom@^18.0.5":
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
+  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@^13.5.2":
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-13.5.2.tgz#357cc03581dc434c57c3b31f70e0eecdbf7b3ab0"
-  integrity sha512-sRZoKZBGKaE7CzMvTTgz+0x/aVR58ZYUTfB7HN76vC+yQnvo1FWtzNARBt0fGqcLGEVakEzMu/CtPzssmanu8Q==
+"@types/react-syntax-highlighter@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.2.tgz#b3450851c11b8526a27edf51d00769b69d8fbf20"
+  integrity sha512-cJJvwU8lQv/efGSo/LmPoaOqWi/B0AG4CNKKCn7HPUL25SqiPn1Vl+fV1JiUigJv97ruTZ8mo08+b8/0zoYufA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.34":
+"@types/react@*":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^18.0.12":
+  version "18.0.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.12.tgz#cdaa209d0a542b3fcf69cf31a03976ec4cdd8840"
+  integrity sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2425,6 +2489,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -2439,6 +2508,11 @@ acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
+acorn@^8.4.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -3346,6 +3420,11 @@ cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3440,6 +3519,11 @@ csstype@^2.2.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.6"
@@ -4298,19 +4382,19 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-focus-trap-react@^8.9.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.9.0.tgz#28bd4c9c117de6cb72bad4773ee58345b785117f"
-  integrity sha512-zxV5b0sRn9IeDYvDbApfZUdH5vrWBqHoltB+HbSZCAgDML58vft6qTjgiEO3ROVKjX2wbNF1A1Rv1An1uhJI6A==
+focus-trap-react@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-9.0.0.tgz#4ce24e80e702fbefea7d75ac82a81b8420bc437e"
+  integrity sha512-LvS2NXFf8elJcEnkGXOKCt26g9LOHEePYUGSgM4FLNCV2Oa6UWHShM/YYz7hYyBWoYhl9IPG6b6okc3dUG7WbQ==
   dependencies:
-    focus-trap "^6.7.1"
+    focus-trap "^6.9.4"
 
-focus-trap@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.1.tgz#d474f86dbaf3c7fbf0d53cf0b12295f4f4068d10"
-  integrity sha512-a6czHbT9twVpy2RpkWQA9vIgwQgB9Nx1PIxNNUxQT4nugG/3QibwxO+tWTh9i+zSY2SFiX4pnYhTaFaQF/6ZAg==
+focus-trap@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.4.tgz#436da1a1d935c48b97da63cd8f361c6f3aa16444"
+  integrity sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==
   dependencies:
-    tabbable "^5.2.1"
+    tabbable "^5.3.3"
 
 focusable@^2.3.0:
   version "2.3.0"
@@ -6810,15 +6894,15 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.22.0:
+prismjs@^1.27.0:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.28.0.tgz#0d8f561fa0f7cf6ebca901747828b149147044b6"
-  integrity "sha1-DY9WH6D3z268qQF0eCixSRRwRLY= sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
+  integrity sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==
 
-prismjs@~1.24.0:
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
-  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 private@^0.1.8:
   version "0.1.8"
@@ -7017,16 +7101,16 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
   integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
-react-syntax-highlighter@^15.4.3:
-  version "15.4.3"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz#fffe3286677ac470b963b364916d16374996f3a6"
-  integrity sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==
+react-syntax-highlighter@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"
+  integrity sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "^10.4.1"
     lowlight "^1.17.0"
-    prismjs "^1.22.0"
-    refractor "^3.2.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"
@@ -7130,14 +7214,14 @@ reflect.ownkeys@^0.2.0:
   resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
   integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
-refractor@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.4.0.tgz#62bd274b06c942041f390c371b676eb67cb0a678"
-  integrity sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
   dependencies:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
-    prismjs "~1.24.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -7686,7 +7770,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6:
+source-map-support@^0.5.16, source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -7992,10 +8076,10 @@ symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
+tabbable@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
+  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
 table@^5.2.3:
   version "5.4.6"
@@ -8136,15 +8220,23 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-ts-node@^8.9.1:
-  version "8.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
-  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+ts-node@^10.8.1:
+  version "10.8.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
+  integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tslib@^1.9.0:
@@ -8152,10 +8244,10 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
-  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -8198,10 +8290,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -8313,6 +8405,11 @@ uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -4382,10 +4382,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-focus-trap-react@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-9.0.0.tgz#4ce24e80e702fbefea7d75ac82a81b8420bc437e"
-  integrity sha512-LvS2NXFf8elJcEnkGXOKCt26g9LOHEePYUGSgM4FLNCV2Oa6UWHShM/YYz7hYyBWoYhl9IPG6b6okc3dUG7WbQ==
+focus-trap-react@8:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.11.3.tgz#aa0ba3b17676abf8faf78c5e51d8cd8df83eec41"
+  integrity sha512-y126gMYuB1aVYiEZSP6/v9bAfVmAIUVixanhcoMelkz7bOh+l0c3h05CEHC8S63ztxdRI2AAPS9AsTat6jlDeQ==
   dependencies:
     focus-trap "^6.9.4"
 


### PR DESCRIPTION
This patch updates `@deque/cauldron-react` to play nicely with [React v18 types](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions).

Part of https://github.com/dequelabs/walnut/issues/3349