### PR TITLE
fix(RadioCardGroup): use `flex-end` instead of `end` for checked card

### DIFF
--- a/packages/styles/radio-card.css
+++ b/packages/styles/radio-card.css
@@ -39,7 +39,7 @@
 
 .RadioCardGroup__Checked {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   min-height: 44px;
 }
 .RadioCardGroup__Icon.Icon svg {


### PR DESCRIPTION
Error: `autoprefixer end value has mixed support consider using flex-end instead`