### PR TITLE
fix(react): only allow a single options menu to be open at one time

### DIFF
--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -69,7 +69,6 @@ export default class OptionsMenu extends Component<
 
   toggleMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     this.setState(({ show }) => ({ show: !show }));
-    event.preventDefault();
   };
 
   handleClose = () => {

--- a/packages/react/src/components/OptionsMenu/OptionsMenuList.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenuList.tsx
@@ -165,10 +165,19 @@ export default class OptionsMenuList extends React.Component<
       });
     });
 
+    // This allows the ClickOutsideListener to only be activated when the menu is
+    // currently open. This prevents an obscure behavior where the activation of a
+    // different menu would cause all menus to close
+    const clickOutsideEventActive = !show ? false : undefined;
+
     // Key event is being handled in componentDidMount
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     return (
-      <ClickOutsideListener onClickOutside={this.handleClickOutside}>
+      <ClickOutsideListener
+        onClickOutside={this.handleClickOutside}
+        mouseEvent={clickOutsideEventActive}
+        touchEvent={clickOutsideEventActive}
+      >
         <ul
           {...other}
           className={classnames('OptionsMenu__list', className)}


### PR DESCRIPTION
This fixes an obscure behavior where multiple options menus could be opened at the same time. With this change, options menus are now only open exclusively one at a time.