### PR TITLE
fix(react): fixes incorrect PropType and TypeScript interfaces

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -111,7 +111,9 @@ Accordion.propTypes = {
 
 AccordionTrigger.propTypes = {
   children: PropTypes.node,
-  heading: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', undefined])
+  heading: PropTypes.shape({
+    level: PropTypes.number
+  })
 };
 
 AccordionContent.propTypes = {

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 
 export interface AccordionTriggerProps
   extends React.HTMLAttributes<HTMLButtonElement> {
-  children: React.ReactElement;
+  children: React.ReactNode;
   heading?:
     | React.ReactElement
     | {

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -49,7 +49,9 @@ const Accordion = ({ children }: AccordionProps) => {
   const childrenArray = React.Children.toArray(children);
 
   const trigger = childrenArray.find(
-    child => (child as React.ReactElement<any>).type === AccordionTrigger
+    child =>
+      typeof child === 'string' ||
+      (child as React.ReactElement<any>).type === AccordionTrigger
   );
 
   const panelElement = childrenArray.find(

--- a/packages/react/src/components/ExpandCollapsePanel/ExpandCollapsePanel.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/ExpandCollapsePanel.tsx
@@ -13,7 +13,7 @@ export interface ExpandCollapsePanelProps
   open?: boolean;
   children: React.ReactNode;
   animationTiming?: number | boolean;
-  onToggle: (e: React.MouseEvent<HTMLButtonElement>) => void | undefined;
+  onToggle?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 interface ExpandCollapsePanelState {
@@ -51,7 +51,7 @@ export default class ExpandCollapsePanel extends React.Component<
   private styleTag: HTMLStyleElement;
 
   handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const { onToggle } = this.props;
+    const { onToggle = () => {} } = this.props;
     const { isOpen, controlled } = this.state;
     onToggle(e);
     if (!controlled) {

--- a/packages/react/src/components/ExpandCollapsePanel/ExpandCollapsePanel.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/ExpandCollapsePanel.tsx
@@ -13,7 +13,7 @@ export interface ExpandCollapsePanelProps
   open?: boolean;
   children: React.ReactNode;
   animationTiming?: number | boolean;
-  onToggle: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onToggle: (e: React.MouseEvent<HTMLButtonElement>) => void | undefined;
 }
 
 interface ExpandCollapsePanelState {

--- a/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
+++ b/packages/react/src/components/ExpandCollapsePanel/PanelTrigger.tsx
@@ -61,7 +61,9 @@ PanelTrigger.propTypes = {
   open: PropTypes.bool,
   iconExpanded: PropTypes.string,
   iconCollapsed: PropTypes.string,
-  heading: PropTypes.number
+  heading: PropTypes.shape({
+    level: PropTypes.number
+  })
 };
 
 PanelTrigger.displayName = 'PanelTrigger';


### PR DESCRIPTION
This is to fix some issues that I noticed the other day as I was using it, as well as some TypeScript errors being thrown that needed to be fixed (the underlying functionality was fine, this just fixes PropType/TypeScript issues). 