### PR TITLE
fix(styles): remove right margin from right most pagination button

### DIFF
--- a/packages/styles/pagination.css
+++ b/packages/styles/pagination.css
@@ -19,7 +19,7 @@
   font-size: var(--text-size-small);
 }
 
-.Pagination > ul > li {
+.Pagination > ul > li:not(:last-child) {
   margin-right: var(--space-smallest);
 }
 


### PR DESCRIPTION
When the pagination controls are right aligned, this removes the right most margin preventing the pagination controls from being aligned to the right border of the containing element.