### PR TITLE
fix(react): add types to Pagination onClick props

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -15,10 +15,18 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   previousPageLabel?: string;
   nextPageLabel?: string;
   lastPageLabel?: string;
-  onNextPageClick?: () => void;
-  onPreviousPageClick?: () => void;
-  onFirstPageClick?: () => void;
-  onLastPageClick?: () => void;
+  onNextPageClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  onPreviousPageClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  onFirstPageClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  onLastPageClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
   tooltipPlacement?: Placement;
   thin?: boolean;
   className?: string;

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -16,16 +16,16 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   nextPageLabel?: string;
   lastPageLabel?: string;
   onNextPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement>
   ) => void;
   onPreviousPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement>
   ) => void;
   onFirstPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement>
   ) => void;
   onLastPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement>
   ) => void;
   tooltipPlacement?: Placement;
   thin?: boolean;


### PR DESCRIPTION
Assign types to the `onClick` props otherwise TS will shout: 

```
Type '(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void' is not assignable to type '() => void'.ts(2322)
```