### PR TITLE
feat(react): include setCurrentPage for pageStatus with usePagination hook

### DIFF
--- a/packages/react/__tests__/src/components/Pagination/index.js
+++ b/packages/react/__tests__/src/components/Pagination/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import Pagination, {
@@ -202,6 +202,58 @@ describe('Pagination', () => {
   });
 
   describe('with hook', () => {
+    test('initializes and handles pagesize change as expected', () => {
+      let testPagination1;
+      let testPageStatus1;
+
+      const PaginationWithHook1 = () => {
+        const [pageSize, setPageSize] = useState(10);
+        const { pagination, pageStatus } = usePagination({
+          totalItems: 500,
+          initialPage: 3,
+          initialPageSize: pageSize
+        });
+        testPagination1 = pagination;
+        testPageStatus1 = pageStatus;
+
+        function onPageSizeChange() {
+          setPageSize(25);
+          pageStatus.setCurrentPage(1);
+        }
+        return (
+          <div>
+            <button onClick={onPageSizeChange}>25</button>
+            <Pagination {...pagination} />
+          </div>
+        );
+      };
+      const wrapper = mount(<PaginationWithHook1 />);
+      expect(testPagination1.totalItems).toBe(500);
+      expect(testPagination1.currentPage).toBe(3);
+      expect(testPagination1.itemsPerPage).toBe(10);
+      expect(testPageStatus1.currentPage).toStrictEqual(3);
+      expect(testPageStatus1.pageStart).toStrictEqual(21);
+      expect(testPageStatus1.pageEnd).toStrictEqual(30);
+      // click the next page button
+      wrapper
+        .find('button')
+        .at(3)
+        .simulate('click');
+      expect(testPageStatus1.currentPage).toStrictEqual(4);
+      expect(testPageStatus1.pageStart).toStrictEqual(31);
+      expect(testPageStatus1.pageEnd).toStrictEqual(40);
+      //change the itemsPerPage
+      wrapper
+        .find('button')
+        .at(0)
+        .simulate('click');
+      expect(testPagination1.itemsPerPage).toBe(25);
+      expect(testPagination1.currentPage).toBe(1);
+      expect(testPageStatus1.currentPage).toStrictEqual(1);
+      expect(testPageStatus1.pageStart).toStrictEqual(1);
+      expect(testPageStatus1.pageEnd).toStrictEqual(25);
+    });
+
     test('initializes and calls on{Next,Previous,First,Last}Click as expected', () => {
       let testPagination;
       let testPageStatus;
@@ -223,55 +275,45 @@ describe('Pagination', () => {
       expect(testPagination.totalItems).toBe(500);
       expect(testPagination.currentPage).toBe(3);
       expect(testPagination.itemsPerPage).toBe(10);
-      expect(testPageStatus).toStrictEqual({
-        currentPage: 3,
-        pageStart: 21,
-        pageEnd: 30
-      });
+      expect(testPageStatus.currentPage).toStrictEqual(3);
+      expect(testPageStatus.pageStart).toStrictEqual(21);
+      expect(testPageStatus.pageEnd).toStrictEqual(30);
 
       // click the prev page button
       wrapper
         .find('button')
         .at(1)
         .simulate('click');
-      expect(testPageStatus).toStrictEqual({
-        currentPage: 2,
-        pageStart: 11,
-        pageEnd: 20
-      });
+      expect(testPageStatus.currentPage).toStrictEqual(2);
+      expect(testPageStatus.pageStart).toStrictEqual(11);
+      expect(testPageStatus.pageEnd).toStrictEqual(20);
 
       // click the next page button
       wrapper
         .find('button')
         .at(2)
         .simulate('click');
-      expect(testPageStatus).toStrictEqual({
-        currentPage: 3,
-        pageStart: 21,
-        pageEnd: 30
-      });
+      expect(testPageStatus.currentPage).toStrictEqual(3);
+      expect(testPageStatus.pageStart).toStrictEqual(21);
+      expect(testPageStatus.pageEnd).toStrictEqual(30);
 
       // click the first page button
       wrapper
         .find('button')
         .at(0)
         .simulate('click');
-      expect(testPageStatus).toStrictEqual({
-        currentPage: 1,
-        pageStart: 1,
-        pageEnd: 10
-      });
+      expect(testPageStatus.currentPage).toStrictEqual(1);
+      expect(testPageStatus.pageStart).toStrictEqual(1);
+      expect(testPageStatus.pageEnd).toStrictEqual(10);
 
       // click the last page button
       wrapper
         .find('button')
         .at(3)
         .simulate('click');
-      expect(testPageStatus).toStrictEqual({
-        currentPage: 50,
-        pageStart: 491,
-        pageEnd: 500
-      });
+      expect(testPageStatus.currentPage).toStrictEqual(50);
+      expect(testPageStatus.pageStart).toStrictEqual(491);
+      expect(testPageStatus.pageEnd).toStrictEqual(500);
     });
   });
 });

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -19,7 +19,6 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   onPreviousPageClick?: () => void;
   onFirstPageClick?: () => void;
   onLastPageClick?: () => void;
-  onPageSizeChange?: () => void;
   tooltipPlacement?: Placement;
   thin?: boolean;
   className?: string;
@@ -41,7 +40,6 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
       onPreviousPageClick,
       onFirstPageClick,
       onLastPageClick,
-      onPageSizeChange,
       className,
       thin = false,
       ...other
@@ -176,7 +174,6 @@ Pagination.propTypes = {
   onPreviousPageClick: PropTypes.func,
   onFirstPageClick: PropTypes.func,
   onLastPageClick: PropTypes.func,
-  onPageSizeChange: PropTypes.func,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,
   className: PropTypes.string

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -19,6 +19,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   onPreviousPageClick?: () => void;
   onFirstPageClick?: () => void;
   onLastPageClick?: () => void;
+  onPageSizeChange?: () => void;
   tooltipPlacement?: Placement;
   thin?: boolean;
   className?: string;
@@ -40,6 +41,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
       onPreviousPageClick,
       onFirstPageClick,
       onLastPageClick,
+      onPageSizeChange,
       className,
       thin = false,
       ...other
@@ -174,6 +176,7 @@ Pagination.propTypes = {
   onPreviousPageClick: PropTypes.func,
   onFirstPageClick: PropTypes.func,
   onLastPageClick: PropTypes.func,
+  onPageSizeChange: PropTypes.func,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,
   className: PropTypes.string

--- a/packages/react/src/components/Pagination/usePagination.tsx
+++ b/packages/react/src/components/Pagination/usePagination.tsx
@@ -14,7 +14,6 @@ interface PaginationResults {
   onPreviousPageClick: () => void;
   onFirstPageClick: () => void;
   onLastPageClick: () => void;
-  setCurrentPage: (page:number) => void;
 }
 
 // PageStatus has some built-in redundancy to prevent a user from
@@ -23,12 +22,13 @@ interface PageStatus {
   currentPage: number;
   pageStart: number;
   pageEnd: number;
+  setCurrentPage: (page: number) => void;
 }
 
 export const usePagination = ({
   totalItems,
   initialPageSize = 10,
-  initialPage = 1,
+  initialPage = 1
 }: Options): {
   pagination: PaginationResults;
   pageStatus: PageStatus;
@@ -50,16 +50,15 @@ export const usePagination = ({
     onFirstPageClick,
     onPreviousPageClick,
     onNextPageClick,
-    onLastPageClick,
-    setCurrentPage
+    onLastPageClick
   };
 
   const pageStatus: PageStatus = {
     currentPage,
     pageStart,
-    pageEnd
+    pageEnd,
+    setCurrentPage
   };
-
 
   return { pagination, pageStatus };
 };

--- a/packages/react/src/components/Pagination/usePagination.tsx
+++ b/packages/react/src/components/Pagination/usePagination.tsx
@@ -14,6 +14,7 @@ interface PaginationResults {
   onPreviousPageClick: () => void;
   onFirstPageClick: () => void;
   onLastPageClick: () => void;
+  setCurrentPage: (page:number) => void;
 }
 
 // PageStatus has some built-in redundancy to prevent a user from
@@ -27,7 +28,7 @@ interface PageStatus {
 export const usePagination = ({
   totalItems,
   initialPageSize = 10,
-  initialPage = 1
+  initialPage = 1,
 }: Options): {
   pagination: PaginationResults;
   pageStatus: PageStatus;
@@ -36,7 +37,6 @@ export const usePagination = ({
 
   const pageStart = currentPage * initialPageSize - initialPageSize + 1;
   const pageEnd = Math.min(pageStart + initialPageSize - 1, totalItems);
-
   const onFirstPageClick = () => setCurrentPage(1);
   const onPreviousPageClick = () => setCurrentPage(currentPage - 1);
   const onNextPageClick = () => setCurrentPage(currentPage + 1);
@@ -50,7 +50,8 @@ export const usePagination = ({
     onFirstPageClick,
     onPreviousPageClick,
     onNextPageClick,
-    onLastPageClick
+    onLastPageClick,
+    setCurrentPage
   };
 
   const pageStatus: PageStatus = {
@@ -58,6 +59,7 @@ export const usePagination = ({
     pageStart,
     pageEnd
   };
+
 
   return { pagination, pageStatus };
 };


### PR DESCRIPTION
- Expose setCurrentPage from usePagination Hook, allowing developers to manage pagination in certain cases.
- Add a test to make sure that pagination handles the call to setCurrentPage correctly. 