### PR TITLE
fix(styles): fix accordion background colors

### DIFF
--- a/packages/styles/accordion.css
+++ b/packages/styles/accordion.css
@@ -29,8 +29,9 @@
   all: unset;
 }
 
-.Accordion__trigger {
-  background: var(--accordion-trigger-background-color);
+.Accordion__trigger,
+button.Accordion__trigger {
+  background-color: var(--accordion-trigger-background-color);
   padding: calc(var(--space-small) - var(--space-half));
   width: 100%;
   display: flex;


### PR DESCRIPTION
kudos to @tbusillo for noticing this

The recent cleanup with #723 missed that buttons needed a more specific selector because they also inherit from `.ExpandCollapsePanel__trigger`. Including the fallback selector will create a higher specificity while allowing the existing classname to be extended.