### PR TITLE
fix(react): fix issue where ref property was getting clobberd on <Tab>

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -32,7 +32,6 @@ const Tabs = ({
 }: TabsProps): JSX.Element => {
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
   const tabsRef = useRef<HTMLDivElement>(null);
-  const tabsListRef = useRef<HTMLUListElement>(null);
 
   const tabs = React.Children.toArray(children).filter(
     child => (child as React.ReactElement<any>).type === Tab

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -131,7 +131,7 @@ const Tabs = ({
 
   useDidUpdate(() => {
     const activeTab = tabsRef.current?.querySelector(
-      '[role="tablist"] > [aria-selected="true"]'
+      ':scope > [role="tablist"] > [aria-selected="true"]'
     ) as HTMLLIElement;
     activeTab?.focus();
     if (typeof onChange === 'function') {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -32,7 +32,7 @@ const Tabs = ({
 }: TabsProps): JSX.Element => {
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
   const tabsRef = useRef<HTMLDivElement>(null);
-  const focusedTabRef = useRef<HTMLLIElement>(null);
+  const tabsListRef = useRef<HTMLUListElement>(null);
 
   const tabs = React.Children.toArray(children).filter(
     child => (child as React.ReactElement<any>).type === Tab
@@ -122,7 +122,6 @@ const Tabs = ({
       tabIndex: index === activeIndex ? 0 : -1,
       ['aria-controls']: target.current?.id,
       ['aria-selected']: selected,
-      ref: index === activeIndex ? focusedTabRef : null,
       onClick: () => handleClick(index),
       ...other
     };
@@ -131,9 +130,12 @@ const Tabs = ({
   });
 
   useDidUpdate(() => {
-    focusedTabRef.current?.focus();
+    const activeTab = tabsRef.current?.querySelector(
+      '[role="tablist"] > [aria-selected="true"]'
+    ) as HTMLLIElement;
+    activeTab?.focus();
     if (typeof onChange === 'function') {
-      onChange({ activeTabIndex: activeIndex, target: focusedTabRef.current });
+      onChange({ activeTabIndex: activeIndex, target: activeTab });
     }
   }, [activeIndex]);
 


### PR DESCRIPTION
This fixes an issue where `<Tab ref={tabRef}>` was always `null` because it was getting clobbered within `cloneElement`.