### PR TITLE
feat(Pagination): add overload of statusLabel prop to take in function exposing totalItems, itemStart, itemEnd

### DIFF
--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -56,9 +56,9 @@ const PaginationDemo = () => {
             default: 1
           },
           statusLabel: {
-            type: 'ReactNode',
+            type: 'ReactNode | function',
             description:
-              'The "x of y" status label (rendered as text in the middle of the pagination controls).',
+              'The "x of y" status label (rendered as text in the middle of the pagination controls). As a ReactNode, this property is simply the representation of this label. As a function, it is a callback exposing totalItems, itemStart, and itemEnd and returning a ReactNode; this can be useful in cases like internationalization.',
             required: false,
             default: `<span>
                 Showing <strong>{itemStart}</strong> to{' '}

--- a/packages/react/__tests__/src/components/Pagination/index.js
+++ b/packages/react/__tests__/src/components/Pagination/index.js
@@ -131,6 +131,21 @@ describe('Pagination', () => {
       expect(wrapper.find('#foo').exists()).toBe(true);
     });
 
+    test('supports custom status label formatter', () => {
+      const wrapper = mount(
+        <Pagination
+          totalItems={18}
+          statusLabel={(totalItems, itemStart, itemEnd) => (
+            <div id="foo">{`There are ${totalItems} items. You are seeing ${itemStart} through ${itemEnd}`}</div>
+          )}
+        />
+      );
+
+      expect(wrapper.find('#foo').text()).toBe(
+        'There are 18 items. You are seeing 1 through 10'
+      );
+    });
+
     test('calls on{Next,Previous,First,Last}Click as expected', () => {
       const onNextPageClick = sinon.spy();
       const onPreviousPageClick = sinon.spy();

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -6,27 +6,25 @@ import IconButton from '../IconButton';
 import TooltipTabstop from '../TooltipTabstop';
 import Icon from '../Icon';
 
+export type StatusLabeller = (
+  totalItems: number,
+  itemStart: number,
+  itemEnd: number
+) => React.ReactNode;
+
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   totalItems: number;
   itemsPerPage?: number;
   currentPage?: number;
-  statusLabel?: React.ReactNode;
+  statusLabel?: React.ReactNode | StatusLabeller;
   firstPageLabel?: string;
   previousPageLabel?: string;
   nextPageLabel?: string;
   lastPageLabel?: string;
-  onNextPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onPreviousPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onFirstPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onLastPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
+  onNextPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onPreviousPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onFirstPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onLastPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   tooltipPlacement?: Placement;
   thin?: boolean;
   className?: string;
@@ -58,7 +56,6 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
     const itemEnd = Math.min(itemStart + itemsPerPage - 1, totalItems);
     const isLastPage = itemEnd === totalItems;
     const isFirstPage = currentPage === 1;
-
     return (
       <div
         ref={ref}
@@ -112,7 +109,13 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
 
           <li>
             <span role="log" aria-atomic="true">
-              {statusLabel || (
+              {statusLabel ? (
+                typeof statusLabel === 'function' ? (
+                  statusLabel(totalItems, itemStart, itemEnd)
+                ) : (
+                  statusLabel
+                )
+              ) : (
                 <span>
                   Showing <strong>{itemStart}</strong> to{' '}
                   <strong>{itemEnd}</strong> of <strong>{totalItems}</strong>
@@ -173,7 +176,7 @@ Pagination.propTypes = {
   totalItems: PropTypes.number.isRequired,
   itemsPerPage: PropTypes.number,
   currentPage: PropTypes.number,
-  statusLabel: PropTypes.element,
+  statusLabel: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   firstPageLabel: PropTypes.string,
   previousPageLabel: PropTypes.string,
   nextPageLabel: PropTypes.string,


### PR DESCRIPTION
closes: #733 