### PR TITLE
fix(app): ensure tooltips are not displayed behind a dialog

### DIFF
--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -101,7 +101,7 @@
   --content-max-width: 1000px;
 
   /* z-index */
-  --z-index-tooltip: 9;
+  --z-index-tooltip: 22;
   --z-index-loader: 8;
   --z-index-scrim: 7;
   --z-index-dialog: 21;


### PR DESCRIPTION

<img width="599" alt="image" src="https://user-images.githubusercontent.com/41127686/184423366-b63700ab-180d-4e82-b33e-e8ec47188990.png">


ref: https://github.com/dequelabs/cauldron/issues/715