### PR TITLE
fix(react): ensure check-circle icon meets color-constrast requirements

### DIFF
--- a/packages/react/src/components/Icon/icons/check-circle.svg
+++ b/packages/react/src/components/Icon/icons/check-circle.svg
@@ -1,1 +1,8 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" overflow="visible" preserveAspectRatio="none" viewBox="0 0 24 24" width="20" height="20"><g><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" vector-effect="non-scaling-stroke" fill="currentColor" /></g></svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" overflow="visible" preserveAspectRatio="none"
+	 viewBox="0 0 44 44" vector-effect="non-scaling-stroke" fill="currentColor">
+<style type="text/css">
+	.st1{fill:#FFFFFF;}
+</style>
+<circle id="body" cx="22" cy="22" r="18.3"/>
+<polygon id="check" class="st1" points="34.8,14.7 18.3,31.2 9.2,22 11.8,19.4 18.3,26 32.2,12.1"/>
+</svg>

--- a/packages/react/src/components/Icon/icons/check-circle.svg
+++ b/packages/react/src/components/Icon/icons/check-circle.svg
@@ -1,8 +1,1 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" overflow="visible" preserveAspectRatio="none"
-	 viewBox="0 0 44 44" vector-effect="non-scaling-stroke" fill="currentColor">
-<style type="text/css">
-	.st1{fill:#FFFFFF;}
-</style>
-<circle id="body" cx="22" cy="22" r="18.3"/>
-<polygon id="check" class="st1" points="34.8,14.7 18.3,31.2 9.2,22 11.8,19.4 18.3,26 32.2,12.1"/>
-</svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" overflow="visible" preserveAspectRatio="none" viewBox="0 0 24 24" width="20" height="20"><g><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" vector-effect="non-scaling-stroke" fill="currentColor" /></g></svg>

--- a/packages/styles/radio-card.css
+++ b/packages/styles/radio-card.css
@@ -43,7 +43,7 @@
   min-height: 44px;
 }
 .RadioCardGroup__Icon.Icon svg {
-  color: var(--accent-success-dark);
+  color: #4f990f;
   height: 44px;
   width: 44px;
 }

--- a/packages/styles/radio-card.css
+++ b/packages/styles/radio-card.css
@@ -43,6 +43,11 @@
   min-height: 44px;
 }
 .RadioCardGroup__Icon.Icon svg {
+  /** 
+   * this is edge case to pass color-contrast when the radio-card is selected,
+   * it is not a color we want to live in cauldron as a variable 
+   * @see https://github.com/dequelabs/cauldron/pull/736
+   */
   color: #4f990f;
   height: 44px;
   width: 44px;


### PR DESCRIPTION
ensure the check-circle background color defaults to white. to avoid color-contrast issues, currently when used with `RadioCardGroup` we do not meet the 3 : 1 requirements: 

<img width="603" alt="image" src="https://user-images.githubusercontent.com/41127686/184986576-bdac2dd8-f41e-4a55-bd23-90b4f3409fcd.png">


After: 
<img width="607" alt="image" src="https://user-images.githubusercontent.com/41127686/184986631-077a6aa2-120a-4e73-b4f9-12991b921738.png">

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/41127686/184986671-9c7a0087-c11d-4d15-93b4-ebe8a4557b75.png">
