### PR TITLE
chore: remove unused imports on doc pages

### DIFF
--- a/docs/patterns/components/Accordion/index.js
+++ b/docs/patterns/components/Accordion/index.js
@@ -5,7 +5,7 @@ import {
   AccordionContent,
   Code,
   Link
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import './index.css';
 import PropDocs from '../../../Demo/PropDocs';
 import { children, className } from '../../../props';
@@ -69,7 +69,7 @@ const AccordionDemo = () => {
   Accordion,
   AccordionTrigger,
   AccordionContent,
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 const ControlledAccordion = ({ label, open: initialOpen = false }) => {
   const [open, setIsOpen] = useState(initialOpen);

--- a/docs/patterns/components/Address/index.js
+++ b/docs/patterns/components/Address/index.js
@@ -5,7 +5,7 @@ import {
   Address,
   AddressLine,
   AddressCityStateZip
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const addressComponentNames = ['Address', 'AddressLine', 'AddressCityStateZip'];

--- a/docs/patterns/components/Alert/index.js
+++ b/docs/patterns/components/Alert/index.js
@@ -5,7 +5,7 @@ import {
   AlertContent,
   AlertActions,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 export default class Demo extends Component {
   constructor() {

--- a/docs/patterns/components/Breadcrumb/index.js
+++ b/docs/patterns/components/Breadcrumb/index.js
@@ -6,7 +6,7 @@ import {
   BreadcrumbLink,
   Icon,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const BreadcrumbDemo = () => (

--- a/docs/patterns/components/Button/index.js
+++ b/docs/patterns/components/Button/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Button, Icon } from '@deque/cauldron-react/';
+import { Button, Icon } from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const ButtonDemo = () => (

--- a/docs/patterns/components/Button/index.js
+++ b/docs/patterns/components/Button/index.js
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React from 'react';
 import Demo from '../../../Demo';
 import { Button, Icon } from '@deque/cauldron-react/';
 import { children, className } from '../../../props';

--- a/docs/patterns/components/Card/index.js
+++ b/docs/patterns/components/Card/index.js
@@ -5,7 +5,7 @@ import {
   CardHeader,
   CardContent,
   CardFooter
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import './index.css';
 
 const dataListComponentNames = [

--- a/docs/patterns/components/Checkbox/index.js
+++ b/docs/patterns/components/Checkbox/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Demo from '../../../Demo';
 import { className } from '../../../props';
-import { Checkbox, FieldWrap } from '@deque/cauldron-react/';
+import { Checkbox, FieldWrap } from '@deque/cauldron-react';
 import FieldWrapNotice from '../../../FieldWrapNotice';
 
 export default class CheckboxDemo extends Component {

--- a/docs/patterns/components/ClickOutsideListener/index.js
+++ b/docs/patterns/components/ClickOutsideListener/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ClickOutsideListener, Code, Button } from '@deque/cauldron-react/';
+import { ClickOutsideListener, Code, Button } from '@deque/cauldron-react';
 import PropDocs from '../../../Demo/PropDocs';
 
 const Demo = () => (

--- a/docs/patterns/components/DescriptionList/index.js
+++ b/docs/patterns/components/DescriptionList/index.js
@@ -7,7 +7,7 @@ import {
   DescriptionListItem,
   DescriptionTerm,
   DescriptionDetails
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 import './index.css';
 

--- a/docs/patterns/components/ExpandCollapsePanel/index.js
+++ b/docs/patterns/components/ExpandCollapsePanel/index.js
@@ -1,9 +1,5 @@
 import React, { Component, useState } from 'react';
-import {
-  ExpandCollapsePanel,
-  PanelTrigger,
-  Code
-} from '@deque/cauldron-react/';
+import { ExpandCollapsePanel, PanelTrigger, Code } from '@deque/cauldron-react';
 import PropDocs from '../../../Demo/PropDocs';
 import { children, className } from '../../../props';
 

--- a/docs/patterns/components/Icon/index.js
+++ b/docs/patterns/components/Icon/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Demo from '../../../Demo';
-import { Icon, iconTypes } from '@deque/cauldron-react/';
+import { Icon, iconTypes } from '@deque/cauldron-react';
 import { className } from '../../../props';
 
 export default class IconDemo extends Component {

--- a/docs/patterns/components/IconButton/index.js
+++ b/docs/patterns/components/IconButton/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { IconButton, Offscreen } from '@deque/cauldron-react/';
+import { IconButton, Offscreen } from '@deque/cauldron-react';
 
 const IconButtonDemo = () => (
   <div>

--- a/docs/patterns/components/IssuePanel/index.js
+++ b/docs/patterns/components/IssuePanel/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { IssuePanel, IconButton } from '@deque/cauldron-react/';
+import { IssuePanel, IconButton } from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const IssuePanelDemo = () => {

--- a/docs/patterns/components/Layout/index.js
+++ b/docs/patterns/components/Layout/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Code } from '@deque/cauldron-react/';
+import { Code } from '@deque/cauldron-react';
 
 export default function Layout() {
   return (

--- a/docs/patterns/components/Line/index.js
+++ b/docs/patterns/components/Line/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Line } from '@deque/cauldron-react/';
+import { Line } from '@deque/cauldron-react';
 import { className } from '../../../props';
 
 const LineDemo = () => (

--- a/docs/patterns/components/Line/index.js
+++ b/docs/patterns/components/Line/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Demo from '../../../Demo';
 import { Line } from '@deque/cauldron-react/';
 import { className } from '../../../props';

--- a/docs/patterns/components/Link/index.js
+++ b/docs/patterns/components/Link/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Demo from '../../../Demo';
-import { Link, Code } from '@deque/cauldron-react/';
+import { Link, Code } from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 export default class LinkDemo extends Component {

--- a/docs/patterns/components/Loader/index.js
+++ b/docs/patterns/components/Loader/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Loader } from '@deque/cauldron-react/';
+import { Loader } from '@deque/cauldron-react';
 import { className } from '../../../props';
 
 const LoaderDemo = () => (

--- a/docs/patterns/components/LoaderOverlay/index.js
+++ b/docs/patterns/components/LoaderOverlay/index.js
@@ -6,7 +6,7 @@ import {
   Button,
   Scrim,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { className, children } from '../../../props';
 
 const LOADING_DURATION = 5000;

--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -5,7 +5,7 @@ import {
   ModalContent,
   ModalFooter,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 export default class Demo extends Component {
   constructor() {

--- a/docs/patterns/components/OptionsMenu/index.js
+++ b/docs/patterns/components/OptionsMenu/index.js
@@ -5,7 +5,7 @@ import {
   OptionsMenuTrigger,
   Icon,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 export default class Demo extends Component {
   render() {

--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Demo from '../../../Demo';
 import { Pagination, usePagination } from '@deque/cauldron-react/';
 import { Code } from '@deque/cauldron-react';
 import PropDocs from '../../../Demo/PropDocs';
-import { children, className } from '../../../props';
 
 const PaginationDemo = () => {
   const totalItems = 111;

--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Pagination, usePagination } from '@deque/cauldron-react/';
-import { Code } from '@deque/cauldron-react';
+import { Pagination, usePagination, Code } from '@deque/cauldron-react';
 import PropDocs from '../../../Demo/PropDocs';
 
 const PaginationDemo = () => {

--- a/docs/patterns/components/Panel/index.js
+++ b/docs/patterns/components/Panel/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { Panel } from '@deque/cauldron-react/';
+import { Panel } from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const PanelDemo = () => {

--- a/docs/patterns/components/RadioGroup/index.js
+++ b/docs/patterns/components/RadioGroup/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Demo from '../../../Demo';
-import { RadioGroup, FieldWrap } from '@deque/cauldron-react/';
+import { RadioGroup, FieldWrap } from '@deque/cauldron-react';
 import FieldWrapNotice from '../../../FieldWrapNotice';
 
 const labelDescription =

--- a/docs/patterns/components/Select/index.js
+++ b/docs/patterns/components/Select/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, FieldWrap } from '@deque/cauldron-react/';
+import { Select, FieldWrap } from '@deque/cauldron-react';
 import './index.css';
 import Demo from '../../../Demo';
 import FieldWrapNotice from '../../../FieldWrapNotice';

--- a/docs/patterns/components/Stepper/index.js
+++ b/docs/patterns/components/Stepper/index.js
@@ -10,7 +10,7 @@ import {
   TableRow,
   TableCell,
   TableBody
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 import './index.css';
 

--- a/docs/patterns/components/Table/index.js
+++ b/docs/patterns/components/Table/index.js
@@ -9,7 +9,7 @@ import {
   TableRow,
   Code,
   IconButton
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 const sampleData = [
@@ -108,7 +108,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 const BasicTable = () => (
   <Table>
@@ -199,7 +199,7 @@ import {
   TableHead,
   TableHeader,
   TableRow
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 
 const sampleData = [
   {

--- a/docs/patterns/components/Tag/index.js
+++ b/docs/patterns/components/Tag/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Demo from '../../../Demo';
-import { Tag, TagLabel } from '@deque/cauldron-react/';
+import { Tag, TagLabel } from '@deque/cauldron-react';
 import { children, className } from '../../../props';
 
 export default class TagDemo extends Component {

--- a/docs/patterns/components/TextField/index.js
+++ b/docs/patterns/components/TextField/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextField, FieldWrap } from '@deque/cauldron-react/';
+import { TextField, FieldWrap } from '@deque/cauldron-react';
 import { className } from '../../../props';
 import Demo from '../../../Demo';
 import FieldWrapNotice from '../../../FieldWrapNotice';

--- a/docs/patterns/components/Toast/index.js
+++ b/docs/patterns/components/Toast/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Toast, Link } from '@deque/cauldron-react/';
+import { Button, Toast, Link } from '@deque/cauldron-react';
 import DemoComponent from '../../../Demo';
 import { children } from '../../../props';
 

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -8,7 +8,7 @@ import {
   Code,
   TextField,
   Line
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import './index.css';
 
 const DemoTooltip = () => {

--- a/docs/patterns/components/TooltipTabstop/index.js
+++ b/docs/patterns/components/TooltipTabstop/index.js
@@ -1,5 +1,4 @@
-import React, { useRef } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
 import Demo from '../../../Demo';
 import { TooltipTabstop, Code } from '@deque/cauldron-react/';
 import './index.css';

--- a/docs/patterns/components/TooltipTabstop/index.js
+++ b/docs/patterns/components/TooltipTabstop/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Demo from '../../../Demo';
-import { TooltipTabstop, Code } from '@deque/cauldron-react/';
+import { TooltipTabstop, Code } from '@deque/cauldron-react';
 import './index.css';
 
 const DemoTooltipTabstop = () => {

--- a/docs/patterns/components/TopBar/index.js
+++ b/docs/patterns/components/TopBar/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Code } from '@deque/cauldron-react/';
+import { Code } from '@deque/cauldron-react';
 
 const Demo = () => {
   return (
@@ -8,8 +8,8 @@ const Demo = () => {
       <h2>Component Description</h2>
       <p>
         A bar at the top of the page. Typically contains information about the
-        page, a navigation menu, and other actions a user can take relating to the
-        whole website.
+        page, a navigation menu, and other actions a user can take relating to
+        the whole website.
       </p>
       <h2>Demo</h2>
       <p>The TopBar is located at the top of the page.</p>

--- a/docs/patterns/components/TopBarMenu/index.js
+++ b/docs/patterns/components/TopBarMenu/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Code } from '@deque/cauldron-react/';
+import { Button, Code } from '@deque/cauldron-react';
 
 class TopBarMenuDemo extends React.Component {
   buttonRef = React.createRef();

--- a/docs/patterns/components/TwoColumnPanel/index.js
+++ b/docs/patterns/components/TwoColumnPanel/index.js
@@ -10,7 +10,7 @@ import {
   BreadcrumbLink,
   BreadcrumbItem,
   Code
-} from '@deque/cauldron-react/';
+} from '@deque/cauldron-react';
 import PropDocs from '../../../Demo/PropDocs';
 import { children, className } from '../../../props';
 

--- a/docs/patterns/components/TwoColumnPanel/index.js
+++ b/docs/patterns/components/TwoColumnPanel/index.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import {
   TwoColumnPanel,
   ColumnLeft,


### PR DESCRIPTION
This PR removes several unused imports from the docs pages for various components.

Component doc pages to validate:
- [x] Button
- [x] Line
- [x] Pagination
- [x] TooltipTabStop
- [x] TwoColumnPanel