### PR TITLE
fix(docs): Ensures content doesn't get cutoff in prop docs tables

### DIFF
--- a/docs/Demo/index.css
+++ b/docs/Demo/index.css
@@ -7,6 +7,10 @@
   display: none;
 }
 
+.Demo-props .DescriptionList__details {
+  word-break: break-word;
+}
+
 @media (max-width: 730px) {
   .Demo-props .not-collapsed .DescriptionList {
     display: block;


### PR DESCRIPTION
Closes #774 

## Before

<img width="470" alt="Screen Shot 2022-09-15 at 10 34 57 PM" src="https://user-images.githubusercontent.com/3180185/190564724-d39e3d4e-4ddc-4910-9515-476b8c7010e1.png">

<img width="263" alt="Screen Shot 2022-09-15 at 10 36 11 PM" src="https://user-images.githubusercontent.com/3180185/190564742-cb497fd0-4777-48a7-bb41-68da0eae6d59.png">

## After

<img width="470" alt="Screen Shot 2022-09-15 at 10 35 13 PM" src="https://user-images.githubusercontent.com/3180185/190564815-9c280d5f-eb90-448e-a9b2-8b5c27bff59d.png">

<img width="263" alt="Screen Shot 2022-09-15 at 10 36 17 PM" src="https://user-images.githubusercontent.com/3180185/190564828-aa203cf4-dfa6-481b-8aed-c066aa1bdf0a.png">

