### PR TITLE
fix(typo): descending misspelled in table CSS

### DIFF
--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -72,7 +72,7 @@
 }
 
 .TableHeader--sort-ascending .TableHeader__sort-button,
-.TableHeader--sort-decscending .TableHeader__sort-button {
+.TableHeader--sort-descending .TableHeader__sort-button {
   color: var(--table-header-sorting-text-color);
 }
 


### PR DESCRIPTION
Update `.TableHeader--sort-decscending` to `.TableHeader--sort-descending`