### PR TITLE
Revert "fix(typo): descending misspelled (#782)"

### DIFF
--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -72,7 +72,7 @@
 }
 
 .TableHeader--sort-ascending .TableHeader__sort-button,
-.TableHeader--sort-descending .TableHeader__sort-button {
+.TableHeader--sort-decscending .TableHeader__sort-button {
   color: var(--table-header-sorting-text-color);
 }
 


### PR DESCRIPTION
This reverts commit 87de5e625038316bcc501d848398be03d642ca08.

About two weeks ago in our #pattern-library channel, we discussed that this change should be labeled as "breaking" so that is why we are reverting it.