### PR TITLE
fix(styles): clean up table sort button styles

### DIFF
--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -2,7 +2,6 @@
   --table-header-text-color: var(--gray-90);
   --table-header-background-color: var(--gray-20);
   --table-header-sorting-background-color: #caddec;
-  --table-header-sorting-text-color: var(--gray-90);
   --table-header-background-color-hover: #dddddd;
   --table-cell-text-color: var(--gray-60);
   --table-cell-background-color: var(--white);
@@ -16,7 +15,6 @@
   --table-header-text-color: var(--white);
   --table-header-background-color: var(--accent-dark);
   --table-header-sorting-background-color: #53636e;
-  --table-header-sorting-text-color: var(--white);
   --table-header-background-color-hover: #53636e;
   --table-cell-text-color: var(--accent-light);
   --table-cell-background-color: var(--accent-medium);
@@ -70,11 +68,6 @@
 .TableHeader--sort-descending {
   background: var(--table-header-sorting-background-color);
   border-bottom: 3px solid var(--table-header-sorting-border-color);
-}
-
-.TableHeader--sort-ascending .TableHeader__sort-button,
-.TableHeader--sort-decscending .TableHeader__sort-button {
-  color: var(--table-header-sorting-text-color);
 }
 
 /* compensate the gap in height between TableHeader and Icon */

--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -3,6 +3,8 @@
   --table-header-background-color: var(--gray-20);
   --table-header-sorting-background-color: #caddec;
   --table-header-background-color-hover: #dddddd;
+  /* --table-header-sorting-text-color will be deprecated */
+  --table-header-sorting-text-color: var(--gray-90);
   --table-cell-text-color: var(--gray-60);
   --table-cell-background-color: var(--white);
   --table-row-border-color: var(--gray-40);
@@ -14,6 +16,8 @@
 .cauldron--theme-dark {
   --table-header-text-color: var(--white);
   --table-header-background-color: var(--accent-dark);
+  /* --table-header-sorting-text-color will be deprecated */
+  --table-header-sorting-text-color: var(--white);
   --table-header-sorting-background-color: #53636e;
   --table-header-background-color-hover: #53636e;
   --table-cell-text-color: var(--accent-light);
@@ -68,6 +72,12 @@
 .TableHeader--sort-descending {
   background: var(--table-header-sorting-background-color);
   border-bottom: 3px solid var(--table-header-sorting-border-color);
+}
+
+/* These styles are not applying and will be deprecated */
+.TableHeader--sort-ascending .TableHeader__sort-button,
+.TableHeader--sort-decscending .TableHeader__sort-button {
+  color: var(--table-header-sorting-text-color);
 }
 
 /* compensate the gap in height between TableHeader and Icon */


### PR DESCRIPTION
BREAKING CHANGE: The TableHeader sort button text colors do not change when ascending or descending, per the UX Pin. The removed styles were overriding with the same hex value for light or dark mode.

https://preview.uxpin.com/4052c8b6f05ce03e28813f28deb3a682950c2ac6#/pages/140808126/simulate/sitemap

https://cauldron.dequelabs.com/components/Table

<img width="1517" alt="sort-button" src="https://user-images.githubusercontent.com/3081483/193894787-d67f260a-8cbb-47ce-8417-cc048ba4ef69.png">

