### PR TITLE
fix(react): change div element to span in Icon component

### DIFF
--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -51,10 +51,10 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
     };
 
     return (
-      <div ref={ref} {...data}>
+      <span ref={ref} {...data}>
         {label && <Offscreen>{label}</Offscreen>}
         {IconSVG && <IconSVG />}
-      </div>
+      </span>
     );
   }
 );


### PR DESCRIPTION
fix(react): change div element to span in Icon component for better semantics.

When Icon component is used inside p tag it is not valid HTML, because Icon component uses div element. Replace div element with span, so the Icon can be used inside p tags and it is considered valid HTML.

Closes #668