### PR TITLE
fix(styles): use css variables for big tooltip font size and padding

### DIFF
--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -132,7 +132,6 @@
 
 .TooltipContent {
   background: #fff;
-  font-size: var(--font-size-smaller);
   text-align: left;
 }
 

--- a/packages/styles/tooltip.css
+++ b/packages/styles/tooltip.css
@@ -124,9 +124,9 @@
 
 .TooltipHead {
   background: var(--gray-20);
-  font-size: 16px;
+  font-size: var(--text-size-small);
   color: var(--gray-90);
-  padding: 16px 28px;
+  padding: var(--space-small) var(--space-large);
   text-align: center;
 }
 


### PR DESCRIPTION
Closes: #707 

I also removed the `font-size` property for `.TooltipContent` because it was using a css variable that didn't exist.