### PR TITLE
fix(LoaderOverlay): export LoaderOverlayProps interface

### DIFF
--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -7,7 +7,8 @@ import AxeLoader from './axe-loader';
 import AriaIsolate from '../../utils/aria-isolate';
 import useSharedRef from '../../utils/useSharedRef';
 
-interface LoaderOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface LoaderOverlayProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'large' | 'small';
   label?: string;
   focusOnInitialRender?: boolean;


### PR DESCRIPTION
Add missing export so users can extend the `LoaderOverlay` component.