### PR TITLE
docs: props table for Modal component docs page

### DIFF
--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -169,7 +169,7 @@ class Demo extends Component {
               },
               portal: {
                 type: 'any',
-                description: 'The parent element to place the Modal in.',
+                description: 'The parent element to render the Modal within.',
                 default: 'document.body'
               },
               show: {
@@ -188,7 +188,8 @@ class Demo extends Component {
               },
               closeButtonText: {
                 type: 'string',
-                description: 'The desired accessible name of the modal's close button.',
+                description:
+                  "The desired accessible name of the modal's close button.",
                 default: 'Close'
               }
             }}

--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -6,6 +6,8 @@ import {
   ModalFooter,
   Code
 } from '@deque/cauldron-react';
+import PropDocs from '../../../Demo/PropDocs';
+import { children, className } from '../../../props';
 
 export default class Demo extends Component {
   constructor() {
@@ -144,6 +146,54 @@ class Demo extends Component {
 }
           `}
         </Code>
+        <div className="Demo-props">
+          <h2>Props</h2>
+          <PropDocs
+            docs={{
+              children,
+              className,
+              variant: {
+                type: 'string',
+                description: 'The style of Modal to display.',
+                default: 'default'
+              },
+              heading: {
+                type: 'React.ReactElement<any> or object',
+                description:
+                  'Displayed in the heading at the top of the Modal. Optional to pass heading level.',
+                required: true
+              },
+              onClose: {
+                type: 'function',
+                description: 'Function called when the Modal is closed'
+              },
+              portal: {
+                type: 'any',
+                description: 'The parent element to place the Modal in.',
+                default: 'document.body'
+              },
+              show: {
+                type: 'boolean',
+                description: 'Whether or not to show the Modal'
+              },
+              dialogRef: {
+                type: 'function or function.current',
+                description: 'Pass a ref to the Modal.'
+              },
+              forceAction: {
+                type: 'boolean',
+                description:
+                  'If true, user must interact with Modal content before closing it.',
+                default: 'false'
+              },
+              closeButtonText: {
+                type: 'string',
+                description: 'Text read to screen reader about close button.',
+                default: 'Close'
+              }
+            }}
+          />
+        </div>
       </div>
     );
   }

--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -188,7 +188,7 @@ class Demo extends Component {
               },
               closeButtonText: {
                 type: 'string',
-                description: 'Text read to screen reader about close button.',
+                description: 'The desired accessible name of the modal's close button.',
                 default: 'Close'
               }
             }}

--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -180,12 +180,6 @@ class Demo extends Component {
                 type: 'function or function.current',
                 description: 'Pass a ref to the Modal.'
               },
-              forceAction: {
-                type: 'boolean',
-                description:
-                  'If true, no close button will be rendered and the user must take action with Modal content.',
-                default: 'false'
-              },
               closeButtonText: {
                 type: 'string',
                 description:

--- a/docs/patterns/components/Modal/index.js
+++ b/docs/patterns/components/Modal/index.js
@@ -183,7 +183,7 @@ class Demo extends Component {
               forceAction: {
                 type: 'boolean',
                 description:
-                  'If true, user must interact with Modal content before closing it.',
+                  'If true, no close button will be rendered and the user must take action with Modal content.',
                 default: 'false'
               },
               closeButtonText: {

--- a/docs/patterns/components/Tooltip/index.js
+++ b/docs/patterns/components/Tooltip/index.js
@@ -57,7 +57,7 @@ const DemoTooltip = () => {
           },
           portal: {
             type: 'Ref | HTMLElement',
-            description: 'The parent element to place the Tooltip in.',
+            description: 'The parent element to render the Tooltip within.',
             required: false,
             defaultValue: 'document.body'
           }

--- a/docs/patterns/components/TooltipTabstop/index.js
+++ b/docs/patterns/components/TooltipTabstop/index.js
@@ -44,7 +44,7 @@ const DemoTooltipTabstop = () => {
           },
           portal: {
             type: 'Ref | HTMLElement',
-            description: 'The parent element to place the tooltip in.',
+            description: 'The parent element to render the tooltip within.',
             required: false,
             defaultValue: 'document.body'
           }


### PR DESCRIPTION
Add PropDocs component with Modal props to Modal docs page.

![Screen Shot 2022-10-20 at 9 51 49 AM](https://user-images.githubusercontent.com/99676396/196967712-a4719283-b7bf-4bf9-8644-1c013c03c992.png)

Closes: #803