### PR TITLE
fix: focusable Code component needs role and accessible name

### DIFF
--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -39,7 +39,7 @@ const Demo = props => {
       <h2>Component Description</h2>
       <p>{componentDescription}</p>
       <h2>Demo</h2>
-      <Code tabIndex={0}>
+      <Code focusable={true} aria-label="Import the component code snippet">
         {customImport ||
           `import { ${displayName} } from '@deque/cauldron-react'`}
       </Code>
@@ -65,7 +65,10 @@ const Demo = props => {
                 {DEMO_renderBefore}
                 <Component {...thinState} />
                 {DEMO_renderAfter}
-                <Code tabIndex={0}>
+                <Code
+                  focusable={true}
+                  aria-label={`Demo ${displayName} code snippet`}
+                >
                   {`${componentMarkup}${afterMarkup ? `\n${afterMarkup}` : ''}`}
                 </Code>
               </div>

--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -39,7 +39,7 @@ const Demo = props => {
       <h2>Component Description</h2>
       <p>{componentDescription}</p>
       <h2>Demo</h2>
-      <Code>
+      <Code tabIndex={0}>
         {customImport ||
           `import { ${displayName} } from '@deque/cauldron-react'`}
       </Code>
@@ -65,7 +65,7 @@ const Demo = props => {
                 {DEMO_renderBefore}
                 <Component {...thinState} />
                 {DEMO_renderAfter}
-                <Code role="region" tabIndex={0}>
+                <Code tabIndex={0}>
                   {`${componentMarkup}${afterMarkup ? `\n${afterMarkup}` : ''}`}
                 </Code>
               </div>

--- a/docs/patterns/components/Code/index.js
+++ b/docs/patterns/components/Code/index.js
@@ -4,7 +4,7 @@ import Demo from '../../../Demo';
 
 const CodeDemo = () => (
   <>
-    {/* <Demo
+    <Demo
       component={Code}
       componentDescription={
         'Displays text styled to indicate that it is computer code.'
@@ -67,19 +67,12 @@ div[class="foo"] {
         },
         ariaLabelledBy: {
           type: 'string',
-          description: 'Pass an id for an element to ariaLabelledBy instead of ariaLabel',
+          description:
+            'Pass an id for an element to ariaLabelledBy instead of ariaLabel',
           default: 'undefined'
         }
       }}
-    /> */}
-    <div>
-      <h1 id="heading">Javascript code snippet</h1>
-      <Code
-        language="javascript"
-        tabIndex={0}
-        ariaLabelledBy="heading"
-      >{`var some = "javascript"`}</Code>
-    </div>
+    />
   </>
 );
 

--- a/docs/patterns/components/Code/index.js
+++ b/docs/patterns/components/Code/index.js
@@ -47,7 +47,8 @@ div[class="foo"] {
         children: {
           type: 'string',
           description:
-            'code to be syntax highlighted and rendered in code block'
+            'code to be syntax highlighted and rendered in code block',
+          required: true
         },
         language: {
           type: 'string',
@@ -56,7 +57,13 @@ div[class="foo"] {
         tabIndex: {
           type: 'number',
           description:
-            "optional prop to set tabindex value on code block's <pre> wrapper"
+            "optional prop to set tabindex value on code block's <pre> wrapper",
+          default: 'undefined'
+        },
+        ariaLabel: {
+          type: 'string',
+          description: 'Label read by screen reader when tabindex is set to 0',
+          default: 'Code snippet'
         }
       }}
     />

--- a/docs/patterns/components/Code/index.js
+++ b/docs/patterns/components/Code/index.js
@@ -4,7 +4,7 @@ import Demo from '../../../Demo';
 
 const CodeDemo = () => (
   <>
-    <Demo
+    {/* <Demo
       component={Code}
       componentDescription={
         'Displays text styled to indicate that it is computer code.'
@@ -64,9 +64,22 @@ div[class="foo"] {
           type: 'string',
           description: 'Label read by screen reader when tabindex is set to 0',
           default: 'Code snippet'
+        },
+        ariaLabelledBy: {
+          type: 'string',
+          description: 'Pass an id for an element to ariaLabelledBy instead of ariaLabel',
+          default: 'undefined'
         }
       }}
-    />
+    /> */}
+    <div>
+      <h1 id="heading">Javascript code snippet</h1>
+      <Code
+        language="javascript"
+        tabIndex={0}
+        ariaLabelledBy="heading"
+      >{`var some = "javascript"`}</Code>
+    </div>
   </>
 );
 

--- a/docs/patterns/components/Code/index.js
+++ b/docs/patterns/components/Code/index.js
@@ -57,20 +57,7 @@ div[class="foo"] {
         focusable: {
           type: 'boolean',
           description:
-            "optional prop to set tabindex value on code block's <pre> wrapper",
-          default: false
-        },
-        'LabelProps.aria-label': {
-          type: 'string',
-          description:
-            'Add more descriptive aria-label to be read to screen readers when focusable is true.',
-          default: 'Code snippet'
-        },
-        'LabelProps.aria-labelledby': {
-          type: 'string',
-          description:
-            'Pass an id for an element to aria-labelledby instead of aria-label when focusable is true.',
-          default: 'undefined'
+            'When true, the code component will be focusable, have the landmark role region, and an aria-label or aria-labelledby will be required.'
         }
       }}
     />

--- a/docs/patterns/components/Code/index.js
+++ b/docs/patterns/components/Code/index.js
@@ -54,21 +54,22 @@ div[class="foo"] {
           type: 'string',
           description: '"javascript", "css" or "html"'
         },
-        tabIndex: {
-          type: 'number',
+        focusable: {
+          type: 'boolean',
           description:
             "optional prop to set tabindex value on code block's <pre> wrapper",
-          default: 'undefined'
+          default: false
         },
-        ariaLabel: {
-          type: 'string',
-          description: 'Label read by screen reader when tabindex is set to 0',
-          default: 'Code snippet'
-        },
-        ariaLabelledBy: {
+        'LabelProps.aria-label': {
           type: 'string',
           description:
-            'Pass an id for an element to ariaLabelledBy instead of ariaLabel',
+            'Add more descriptive aria-label to be read to screen readers when focusable is true.',
+          default: 'Code snippet'
+        },
+        'LabelProps.aria-labelledby': {
+          type: 'string',
+          description:
+            'Pass an id for an element to aria-labelledby instead of aria-label when focusable is true.',
           default: 'undefined'
         }
       }}

--- a/packages/react/__tests__/src/components/Code/index.js
+++ b/packages/react/__tests__/src/components/Code/index.js
@@ -27,42 +27,17 @@ test('should be focusable when tabIndex is set to 0', () => {
   expect(document.activeElement).toBe(pre);
 });
 
-test('should have region and accessible name when tabIndex is set to 0', () => {
-  const code = mount(
-    <Code language="javascript" tabIndex={0}>{`var some = "javascript"`}</Code>
-  );
-  const props = code.find('pre').props();
-  expect(props.role).toBe('region');
-  expect(props['aria-label']).toBe('Code snippet');
-});
-
-test('should be able to set an accessible name with ariaLabel', () => {
+test('should have role=region and tabIndex=0 when focusable is true', () => {
   const code = mount(
     <Code
       language="javascript"
-      tabIndex={0}
-      ariaLabel="Javascript code snippet"
+      focusable={true}
+      aria-label="label"
     >{`var some = "javascript"`}</Code>
   );
   const props = code.find('pre').props();
   expect(props.role).toBe('region');
-  expect(props['aria-label']).toBe('Javascript code snippet');
-});
-
-test('should be able to set an accessible name with ariaLabelledBy', () => {
-  const code = mount(
-    <div>
-      <h1 id="heading">Javascript code snippet</h1>
-      <Code
-        language="javascript"
-        tabIndex={0}
-        ariaLabelledBy="heading"
-      >{`var some = "javascript"`}</Code>
-    </div>
-  );
-  const props = code.find('pre').props();
-  expect(props.role).toBe('region');
-  expect(props['aria-labelledby']).toBe('heading');
+  expect(props.tabIndex).toBe(0);
 });
 
 test('should not be focusable when tabindex is not set', () => {

--- a/packages/react/__tests__/src/components/Code/index.js
+++ b/packages/react/__tests__/src/components/Code/index.js
@@ -36,7 +36,7 @@ test('should have region and accessible name when tabIndex is set to 0', () => {
   expect(props['aria-label']).toBe('Code snippet');
 });
 
-test('should be able to set an accessible name', () => {
+test('should be able to set an accessible name with ariaLabel', () => {
   const code = mount(
     <Code
       language="javascript"
@@ -47,6 +47,22 @@ test('should be able to set an accessible name', () => {
   const props = code.find('pre').props();
   expect(props.role).toBe('region');
   expect(props['aria-label']).toBe('Javascript code snippet');
+});
+
+test('should be able to set an accessible name with ariaLabelledBy', () => {
+  const code = mount(
+    <div>
+      <h1 id="heading">Javascript code snippet</h1>
+      <Code
+        language="javascript"
+        tabIndex={0}
+        ariaLabelledBy="heading"
+      >{`var some = "javascript"`}</Code>
+    </div>
+  );
+  const props = code.find('pre').props();
+  expect(props.role).toBe('region');
+  expect(props['aria-labelledby']).toBe('heading');
 });
 
 test('should not be focusable when tabindex is not set', () => {

--- a/packages/react/__tests__/src/components/Code/index.js
+++ b/packages/react/__tests__/src/components/Code/index.js
@@ -27,6 +27,28 @@ test('should be focusable when tabIndex is set to 0', () => {
   expect(document.activeElement).toBe(pre);
 });
 
+test('should have region and accessible name when tabIndex is set to 0', () => {
+  const code = mount(
+    <Code language="javascript" tabIndex={0}>{`var some = "javascript"`}</Code>
+  );
+  const props = code.find('pre').props();
+  expect(props.role).toBe('region');
+  expect(props['aria-label']).toBe('Code snippet');
+});
+
+test('should be able to set an accessible name', () => {
+  const code = mount(
+    <Code
+      language="javascript"
+      tabIndex={0}
+      ariaLabel="Javascript code snippet"
+    >{`var some = "javascript"`}</Code>
+  );
+  const props = code.find('pre').props();
+  expect(props.role).toBe('region');
+  expect(props['aria-label']).toBe('Javascript code snippet');
+});
+
 test('should not be focusable when tabindex is not set', () => {
   const code = mount(
     <Code language="javascript">{`var some = "javascript"`}</Code>

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -23,25 +23,32 @@ interface Props extends SyntaxHighlighterProps {
   language?: 'javascript' | 'css' | 'html' | 'yaml';
   className?: string;
   tabIndex?: number;
+  ariaLabel?: string;
 }
 
 const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
   children,
   className,
   tabIndex,
+  ariaLabel,
   ...props
-}) => (
-  <>
-    <Highlighter
-      {...props}
-      useInlineStyles={false}
-      className={classNames('Code', className)}
-      tabIndex={tabIndex}
-    >
-      {children}
-    </Highlighter>
-  </>
-);
+}) => {
+  if (!ariaLabel) ariaLabel = 'Code snippet';
+
+  return (
+    <>
+      <Highlighter
+        {...props}
+        useInlineStyles={false}
+        className={classNames('Code', className)}
+        tabIndex={tabIndex}
+        {...(tabIndex === 0 && { role: 'region', 'aria-label': ariaLabel })}
+      >
+        {children}
+      </Highlighter>
+    </>
+  );
+};
 
 Code.displayName = 'Code';
 

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -7,6 +7,7 @@ import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
 import css from 'react-syntax-highlighter/dist/esm/languages/hljs/css';
 import xml from 'react-syntax-highlighter/dist/esm/languages/hljs/xml';
 import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
+import { Cauldron } from '../../types';
 
 SyntaxHighlighter.registerLanguage('javascript', js);
 SyntaxHighlighter.registerLanguage('css', css);
@@ -23,18 +24,21 @@ interface Props extends SyntaxHighlighterProps {
   language?: 'javascript' | 'css' | 'html' | 'yaml';
   className?: string;
   tabIndex?: number;
-  ariaLabel?: string;
+  focusable: boolean;
+  LabelProps: Cauldron.LabelProps;
 }
 
-const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
+type AllProps = Props & React.AriaAttributes;
+
+const Code: React.ComponentType<React.PropsWithChildren<AllProps>> = ({
   children,
   className,
   tabIndex,
-  ariaLabel,
-  ariaLabelledBy,
+  focusable,
+  LabelProps,
   ...props
 }) => {
-  if (!ariaLabel) ariaLabel = 'Code snippet';
+  // how to add LabelProps?
 
   return (
     <>
@@ -42,14 +46,9 @@ const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
         {...props}
         useInlineStyles={false}
         className={classNames('Code', className)}
-        tabIndex={tabIndex}
-        {...(tabIndex === 0 &&
-          !ariaLabelledBy && { role: 'region', 'aria-label': ariaLabel })}
-        {...(tabIndex === 0 &&
-          ariaLabelledBy && {
-            role: 'region',
-            'aria-labelledby': ariaLabelledBy
-          })}
+        {...(focusable
+          ? { tabIndex: 0, role: 'region' }
+          : { tabIndex: tabIndex })}
       >
         {children}
       </Highlighter>

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { string } from 'prop-types';
 import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light';
 import classNames from 'classnames';
@@ -23,32 +23,26 @@ interface Props extends SyntaxHighlighterProps {
   children: string;
   language?: 'javascript' | 'css' | 'html' | 'yaml';
   className?: string;
-  tabIndex?: number;
-  focusable: boolean;
-  LabelProps: Cauldron.LabelProps;
+  focusable?: boolean;
 }
 
-type AllProps = Props & React.AriaAttributes;
+type CodeProps = Props &
+  React.HTMLAttributes<HTMLElement> &
+  Cauldron.LabelProps;
 
-const Code: React.ComponentType<React.PropsWithChildren<AllProps>> = ({
+const Code: React.ComponentType<React.PropsWithChildren<CodeProps>> = ({
   children,
   className,
-  tabIndex,
   focusable,
-  LabelProps,
   ...props
 }) => {
-  // how to add LabelProps?
-
   return (
     <>
       <Highlighter
         {...props}
         useInlineStyles={false}
         className={classNames('Code', className)}
-        {...(focusable
-          ? { tabIndex: 0, role: 'region' }
-          : { tabIndex: tabIndex })}
+        {...(focusable && { tabIndex: 0, role: 'region' })}
       >
         {children}
       </Highlighter>
@@ -62,7 +56,20 @@ Code.propTypes = {
   children: PropTypes.string.isRequired,
   language: PropTypes.oneOf(['javascript', 'css', 'html', 'yaml']),
   className: PropTypes.string,
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
+  hasLabel: (
+    props: { [key: string]: string },
+    propName: string,
+    componentName: string
+  ) => {
+    if (props.focusable && !props['aria-label'] && !props['aria-labelledby']) {
+      return new Error(
+        `${componentName} must have an "aria-label" or "aria-labelledby" prop if focusable is true.`
+      );
+    } else {
+      return null;
+    }
+  }
 };
 
 export default Code;

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes, { string } from 'prop-types';
+import PropTypes from 'prop-types';
 import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light';
 import classNames from 'classnames';

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -31,6 +31,7 @@ const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
   className,
   tabIndex,
   ariaLabel,
+  ariaLabelledBy,
   ...props
 }) => {
   if (!ariaLabel) ariaLabel = 'Code snippet';
@@ -42,7 +43,13 @@ const Code: React.ComponentType<React.PropsWithChildren<Props>> = ({
         useInlineStyles={false}
         className={classNames('Code', className)}
         tabIndex={tabIndex}
-        {...(tabIndex === 0 && { role: 'region', 'aria-label': ariaLabel })}
+        {...(tabIndex === 0 &&
+          !ariaLabelledBy && { role: 'region', 'aria-label': ariaLabel })}
+        {...(tabIndex === 0 &&
+          ariaLabelledBy && {
+            role: 'region',
+            'aria-labelledby': ariaLabelledBy
+          })}
       >
         {children}
       </Highlighter>


### PR DESCRIPTION
- add `focusable` prop
- when true, `tabIndex=0` and `role='region'` will be added. If an `aria-label` or `aria-labelledby` is not added, there will be a console error.
- borrowed the [hasLabel validator from RadioGroup](https://github.com/dequelabs/cauldron/blob/3e730f66df86cecedfa022fce6a00ede3c837ded/packages/react/src/components/RadioGroup/index.tsx#L154)
- added 2 tests

Issue #680

All tests pass

![Screen Shot 2022-10-27 at 3 51 32 PM](https://user-images.githubusercontent.com/99676396/198385185-2f6557a8-b27b-439b-b264-ae9befc50da3.png)
