### PR TITLE
build: Change dev server port to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ yarn build
 $ yarn dev
 ```
 
-navigate browser to http://localhost:8000
+navigate browser to http://localhost:8003/
 
 ### run tests
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ const config = {
     }
   },
   devServer: {
-    port: 8000,
+    port: 8003,
     historyApiFallback: true
   }
 };


### PR DESCRIPTION
When running the axe server's dependencies locally (`dc.sh up -d`), `:8000` is already taken by DynamoDB. This patch changes the Cauldron dev server's port to 8003 to avoid this conflict.