### PR TITLE
fix(OptionsMenu): add spacing between focus outline and border

### DIFF
--- a/packages/styles/options-menu.css
+++ b/packages/styles/options-menu.css
@@ -82,7 +82,8 @@
 }
 
 .OptionsMenu__list-item:focus {
-  box-shadow: inset 0 0 0 2px var(--focus);
+  box-shadow: inset 0 0 0 1px var(--options-menu-hover-background-color),
+    inset 0 0 0 3px var(--focus);
 }
 
 .OptionsMenu__list-item[aria-disabled='true'] {


### PR DESCRIPTION
Adds spacing between purple outline and the border of the focused options menu item to address an a11y color contrast issue.

fixes: #877 