### PR TITLE
fix: remove base TableHeader from sort styles

### DIFF
--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -66,7 +66,6 @@
   outline-offset: unset;
 }
 
-.TableHeader,
 .TableHeader--sort-ascending,
 .TableHeader--sort-descending {
   background: var(--table-header-sorting-background-color);


### PR DESCRIPTION
This PR fixes a bug that was causing the table header to use `--table-header-sorting-background-color` by default even when the table header wasn't sorted.

[UXPin - Tables](https://preview.uxpin.com/68df515d0023cc4b79f25d43f7663e24e363b1b9#/pages/141465418/simulate/sitemap?mode=i)
Screenshot from UXPin Light Theme
<img width="347" alt="Screen Shot 2023-02-02 at 5 46 57 PM" src="https://user-images.githubusercontent.com/3081483/216483865-7ef5944c-0d2a-4143-8b9e-c964cfa46f6f.png">

Screenshot from UXPin Dark Theme
<img width="376" alt="Screen Shot 2023-02-02 at 5 47 34 PM" src="https://user-images.githubusercontent.com/3081483/216484000-d017687e-cb6b-4ec4-a4ba-f6fa461d5e26.png">

This change is fixing a breaking change in 5.0.0. Would that mean that the version bumps to 5.0.1?

## Verification steps

### Reproduce the bug
- [ ] Go to https://cauldron.dequelabs.com/components/Table
- [ ] See that the table headers are using `--table-header-sorting-background-color` by default for the light and dark theme
<img width="727" alt="Screen Shot 2023-02-02 at 5 46 32 PM" src="https://user-images.githubusercontent.com/3081483/216483804-fd35d997-1173-4e61-a545-9b0885e01072.png">
<img width="784" alt="Screen Shot 2023-02-02 at 5 55 27 PM" src="https://user-images.githubusercontent.com/3081483/216485346-8912af92-0deb-4e24-a800-d0e1455a350c.png">


## Verify the fix
- [ ] Go to https://fix--table-header-css.d1gko6en628vir.amplifyapp.com/
- [ ] Scroll down to the Sortable Table and verify the headers are set to `--table-header-background-color` for the light and dark theme
<img width="1656" alt="Screen Shot 2023-02-02 at 5 40 42 PM" src="https://user-images.githubusercontent.com/3081483/216483051-08d88eff-494a-4aa1-bf22-f0bef954a57d.png">
<img width="787" alt="Screen Shot 2023-02-02 at 5 53 57 PM" src="https://user-images.githubusercontent.com/3081483/216485031-915c8da4-f0fe-43ef-b140-c3630ca5e40b.png">

