### PR TITLE
fix: use a span instead of div for offscreen text

### DIFF
--- a/packages/react/src/components/Offscreen/index.tsx
+++ b/packages/react/src/components/Offscreen/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export interface OffscreenProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 const Offscreen = (props: OffscreenProps) => (
-  <div className="Offscreen" {...props} />
+  <span className="Offscreen" {...props} />
 );
 
 export default Offscreen;


### PR DESCRIPTION
`div` elements are not allowed as a child of `button` or `span` elements.

Issue #834 

## Validation steps
- [ ] Pull down this branch `fix--icon-html`
- [ ] Run `yarn dev`
- [ ] Modify an `Icon` in `docs/Home/Footer.js` to include a `label="some text goes here"`
- [ ] Open DevTools and copy the HTML for the `Icon` you modified
<img width="950" alt="Screen Shot 2023-02-14 at 2 25 45 PM" src="https://user-images.githubusercontent.com/3081483/218866718-b0ab496c-9e33-4b77-a79e-5c2276b8c866.png">

- [ ] Paste this HTML in the [W3 HTML Validator](https://validator.w3.org/#validate_by_input) and verify it passes
```
<!doctype html>
<html lang="en">
<title>Test</title>

<!-- PASTE OUTER HTML HERE -->

</html>
```