### PR TITLE
fix(styles): updated links within paragraphs to use dynamic link color

### DIFF
--- a/packages/styles/link.css
+++ b/packages/styles/link.css
@@ -33,6 +33,6 @@ p .Link {
   margin: 0 2px;
   display: inline;
   text-decoration: underline;
-  color: var(--gray-90);
+  color: var(--link-text-color);
   font-weight: var(--font-weight-normal);
 }


### PR DESCRIPTION
Updated the color used for links within paragraphs to use the recommended styling for dynamic color changes.

Closes #884 