### PR TITLE
fix(styles): updated breadcrumbs to wrap at low content consistently

### DIFF
--- a/packages/styles/breadcrumb.css
+++ b/packages/styles/breadcrumb.css
@@ -4,6 +4,7 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
+  flex-wrap: wrap;
 }
 
 .Breadcrumb__Separator {
@@ -19,4 +20,6 @@
 .Breadcrumb__Item {
   font-weight: 500;
   color: var(--link-text-color);
+  display: flex;
+  flex-wrap: nowrap;
 }


### PR DESCRIPTION
Updated the breadcrumbs so the separators will stay inline, while also still wrapping for the cases where there is a large number of breadcrumbs. 

Closes: #850 

Below is an example where it is still multiple columns and one where it is shrunk down to one column due to screen width.

<img width="134" alt="breadcrumbs where it is not fully one column due to small screen width" src="https://user-images.githubusercontent.com/13560664/219223493-3d067515-57a3-4b02-9fc2-c30aeaedeac4.png">
<img width="64" alt="breadcrumbs where it is one column due to small screen width" src="https://user-images.githubusercontent.com/13560664/219223645-cc163b23-4cc0-4873-bdc1-c0e2cdeef6b5.png">
