### PR TITLE
fix(styles): contrast ratio of light theme focus indicator

### DIFF
--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -37,7 +37,7 @@
   --accent-primary-active: #316091;
   --accent-secondary: var(--gray-20);
   --accent-secondary-active: var(--gray-30);
-  --focus-light: #b51ad1;
+  --focus-light: #9215a8;
   --focus-dark: #eb94ff;
   --issue-critical: var(--accent-danger);
   --issue-serious: var(--accent-warning);


### PR DESCRIPTION
- darkens the focus indicator color on the light theme to maintain a passing color contrast ratio for highlighted option menu items

Testing:

1. `yarn dev` and navigate to components/OptionsMenu.
2. Select the light theme and open the OptionMenu component
3. Confirm the new color shows on focus and that it has [sufficient contrast with a highlighted option](https://webaim.org/resources/contrastchecker/)

<img width="795" alt="failing color contrast check" src="https://user-images.githubusercontent.com/6422248/219729809-a54e4e20-9c37-4808-9fa5-b0f7b29f5007.png">

<img width="756" alt="passing color contrast check" src="https://user-images.githubusercontent.com/6422248/219729241-e146b096-5106-4849-a3c4-fce10ecf1c7c.png">
