### PR TITLE
fix: updated details to wrap text at smaller widths (#907)

### DIFF
--- a/packages/styles/description-list.css
+++ b/packages/styles/description-list.css
@@ -85,6 +85,7 @@
   color: var(--data-list-value-text-color);
   background-color: var(--data-list-value-background-color);
   font-weight: var(--font-weight-normal);
+  word-break: break-word;
 }
 
 .DescriptionList__term,


### PR DESCRIPTION
Closes #907 

Wraps the side of the description, however, it does not wrap the term. This is intentional because if the term was too long it would lead to other issues but I am open to including the terms too!