### PR TITLE
feat(styles): expose panel padding through a --panel-padding variable

### DIFF
--- a/packages/styles/panel.css
+++ b/packages/styles/panel.css
@@ -2,10 +2,11 @@
   --panel-border-color: var(--gray-40);
   --panel-background-color: var(--white);
   --panel-heading-color: var(--gray-90);
+  --panel-padding: var(--space-small);
 }
 
 .Panel {
-  padding: var(--space-small);
+  padding: var(--panel-padding);
   border: 1px solid var(--panel-border-color);
   border-radius: 3px;
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.15);
@@ -33,7 +34,7 @@ fieldset.Panel {
 }
 
 .Panel--collapsed {
-  padding: 12px;
+  --panel-padding: 12px;
 }
 
 .Panel--collapsed .Panel__Heading {


### PR DESCRIPTION
Exposing the `Panel` component's padding through a `--panel-padding`  variable allows consumers to override it and/or set negative margins based on it to get children that span the entire width of the `Panel`