### PR TITLE
fix(react): maintain focus on pagination button when last or first page is reached

### DIFF
--- a/docs/Demo/index.js
+++ b/docs/Demo/index.js
@@ -52,16 +52,18 @@ const Demo = props => {
               DEMO_renderAfter,
               DEMO_renderBefore,
               DEMO_hide_renderAfterBefore = false,
+              DEMO_key,
               ...thinState
             } = state;
             const componentMarkup = renderState(thinState);
+            const key = DEMO_key || componentMarkup;
             const afterMarkup =
               DEMO_renderAfter &&
               !DEMO_hide_renderAfterBefore &&
               jsxStringify(DEMO_renderAfter, stringifyConfig);
 
             return (
-              <div key={componentMarkup}>
+              <div key={key}>
                 {DEMO_renderBefore}
                 <Component {...thinState} />
                 {DEMO_renderAfter}

--- a/docs/patterns/components/Pagination/index.js
+++ b/docs/patterns/components/Pagination/index.js
@@ -34,7 +34,8 @@ const PaginationDemo = () => {
             firstPageLabel: 'FIRST PAGE!!',
             nextPageLabel: 'NEXT PAGE!!',
             previousPageLabel: 'PREV PAGE!!',
-            lastPageLabel: 'JIMMY PAGE!!'
+            lastPageLabel: 'JIMMY PAGE!!',
+            DEMO_key: 'pagination'
           }
         ]}
         propDocs={{

--- a/packages/react/__tests__/src/components/Pagination/index.js
+++ b/packages/react/__tests__/src/components/Pagination/index.js
@@ -28,29 +28,39 @@ describe('Pagination', () => {
           wrapper
             .find('button')
             .at(0)
-            .is('[aria-disabled="true"]')
-        ).toBe(true);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('true');
 
         expect(
           wrapper
             .find('button')
             .at(1)
-            .is('[aria-disabled="true"]')
-        ).toBe(true);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('true');
 
+        console.log(
+          wrapper
+            .find('button')
+            .at(2)
+            .debug()
+        );
         expect(
           wrapper
             .find('button')
             .at(2)
-            .is('[aria-disabled="true"]')
-        ).toBe(false);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('false');
 
         expect(
           wrapper
             .find('button')
             .at(3)
-            .is('[aria-disabled="true"]')
-        ).toBe(false);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('false');
 
         wrapper
           .find('button')
@@ -82,29 +92,33 @@ describe('Pagination', () => {
           wrapper
             .find('button')
             .at(0)
-            .is('[aria-disabled="true"]')
-        ).toBe(false);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('false');
 
         expect(
           wrapper
             .find('button')
             .at(1)
-            .is('[aria-disabled="true"]')
-        ).toBe(false);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('false');
 
         expect(
           wrapper
             .find('button')
             .at(2)
-            .is('[aria-disabled="true"]')
-        ).toBe(true);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('true');
 
         expect(
           wrapper
             .find('button')
             .at(3)
-            .is('[aria-disabled="true"]')
-        ).toBe(true);
+            .getDOMNode()
+            .getAttribute('aria-disabled')
+        ).toBe('true');
 
         wrapper
           .find('button')

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Placement } from '@popperjs/core';
 import IconButton from '../IconButton';
-import TooltipTabstop from '../TooltipTabstop';
-import Icon from '../Icon';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   totalItems: number;
@@ -15,18 +13,10 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   previousPageLabel?: string;
   nextPageLabel?: string;
   lastPageLabel?: string;
-  onNextPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onPreviousPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onFirstPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onLastPageClick?: (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => void;
+  onNextPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onPreviousPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onFirstPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onLastPageClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   tooltipPlacement?: Placement;
   thin?: boolean;
   className?: string;
@@ -69,45 +59,23 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
       >
         <ul>
           <li>
-            {isFirstPage ? (
-              <TooltipTabstop
-                className="IconButton"
-                hideElementOnHidden
-                association="aria-labelledby"
-                tooltip={firstPageLabel}
-                placement={tooltipPlacement}
-              >
-                <Icon type="chevron-double-left" />
-              </TooltipTabstop>
-            ) : (
-              <IconButton
-                icon="chevron-double-left"
-                tooltipPlacement={tooltipPlacement}
-                label={firstPageLabel}
-                onClick={onFirstPageClick}
-              />
-            )}
+            <IconButton
+              icon="chevron-double-left"
+              tooltipPlacement={tooltipPlacement}
+              label={firstPageLabel}
+              aria-disabled={isFirstPage}
+              onClick={isFirstPage ? undefined : onFirstPageClick}
+            />
           </li>
 
           <li>
-            {isFirstPage ? (
-              <TooltipTabstop
-                className="IconButton"
-                hideElementOnHidden
-                association="aria-labelledby"
-                tooltip={previousPageLabel}
-                placement={tooltipPlacement}
-              >
-                <Icon type="chevron-left" />
-              </TooltipTabstop>
-            ) : (
-              <IconButton
-                icon="chevron-left"
-                tooltipPlacement={tooltipPlacement}
-                label={previousPageLabel}
-                onClick={onPreviousPageClick}
-              />
-            )}
+            <IconButton
+              icon="chevron-left"
+              tooltipPlacement={tooltipPlacement}
+              label={previousPageLabel}
+              aria-disabled={isFirstPage}
+              onClick={isFirstPage ? undefined : onPreviousPageClick}
+            />
           </li>
 
           <li>
@@ -122,45 +90,23 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
           </li>
 
           <li>
-            {isLastPage ? (
-              <TooltipTabstop
-                className="IconButton"
-                hideElementOnHidden
-                association="aria-labelledby"
-                tooltip={nextPageLabel}
-                placement={tooltipPlacement}
-              >
-                <Icon type="chevron-right" />
-              </TooltipTabstop>
-            ) : (
-              <IconButton
-                icon="chevron-right"
-                tooltipPlacement={tooltipPlacement}
-                label={nextPageLabel}
-                onClick={onNextPageClick}
-              />
-            )}
+            <IconButton
+              icon="chevron-right"
+              tooltipPlacement={tooltipPlacement}
+              label={nextPageLabel}
+              aria-disabled={isLastPage}
+              onClick={isLastPage ? undefined : onNextPageClick}
+            />
           </li>
 
           <li>
-            {isLastPage ? (
-              <TooltipTabstop
-                className="IconButton"
-                hideElementOnHidden
-                association="aria-labelledby"
-                tooltip={lastPageLabel}
-                placement={tooltipPlacement}
-              >
-                <Icon type="chevron-double-right" />
-              </TooltipTabstop>
-            ) : (
-              <IconButton
-                icon="chevron-double-right"
-                tooltipPlacement={tooltipPlacement}
-                label={lastPageLabel}
-                onClick={onLastPageClick}
-              />
-            )}
+            <IconButton
+              icon="chevron-double-right"
+              tooltipPlacement={tooltipPlacement}
+              label={lastPageLabel}
+              aria-disabled={isLastPage}
+              onClick={isLastPage ? undefined : onLastPageClick}
+            />
           </li>
         </ul>
       </div>
@@ -184,7 +130,8 @@ Pagination.propTypes = {
   onLastPageClick: PropTypes.func,
   // @ts-expect-error
   tooltipPlacement: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  thin: PropTypes.bool
 };
 
 export default Pagination;


### PR DESCRIPTION
Closes https://github.com/dequelabs/cauldron/issues/703

Trying to manage focus when child components are replaced seems error-prone. Instead, I got rid of the tabstop component and made the button component behave like the tabstop component when disabled.