### PR TITLE
fix(styles): undo changes to make two panel layout scrollable

### DIFF
--- a/packages/styles/two-column-panel.css
+++ b/packages/styles/two-column-panel.css
@@ -55,11 +55,6 @@
 .TwoColumnPanel__Right {
   flex: 1;
   align-content: flex-start;
-  overflow-x: auto;
-}
-
-.TwoColumnPanel__Right > *:not(.TwoColumnPanel__Header) {
-  overflow-x: auto;
 }
 
 .TwoColumnPanel__Left,


### PR DESCRIPTION
Reverts dequelabs/cauldron#929

These changes caused the focus highlights to get cut off. We'll need to figure out a different way to address scrolling