### PR TITLE
feat(Toast): make non-dismissible toasts positioned statically

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -126,3 +126,7 @@ code {
     bottom: 3.45rem;
   }
 }
+
+.Toast:not(.Toast--dismissible) {
+  margin-bottom: 1rem;
+}

--- a/docs/index.css
+++ b/docs/index.css
@@ -126,7 +126,3 @@ code {
     bottom: 3.45rem;
   }
 }
-
-.Toast:not(.Toast--dismissible) {
-  margin-bottom: 1rem;
-}

--- a/docs/patterns/components/Toast/index.js
+++ b/docs/patterns/components/Toast/index.js
@@ -131,6 +131,12 @@ export default class Demo extends Component {
               </>
             ),
             show: type === 'not-dismissible',
+            DEMO_renderBefore: (
+              <p>
+                A current limitation is that non-dismissible Toasts are shown
+                where they are rendered to prevent them from clipping content.
+              </p>
+            ),
             DEMO_renderAfter: (
               <Button
                 variant="error"

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Icon from '../Icon';
 import AriaIsolate from '../../utils/aria-isolate';
 import { typeMap, tabIndexHandler } from './utils';
@@ -119,7 +120,12 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
 
     const defaultProps: React.HTMLAttributes<HTMLDivElement> = {
       tabIndex: -1,
-      className: `Toast Toast--${typeMap[type].className} ${animationClass}`
+      className: classNames(
+        'Toast',
+        `Toast--${typeMap[type].className}`,
+        animationClass,
+        { 'Toast--dismissible': dismissible }
+      )
     };
 
     if (!focus) {

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -124,7 +124,7 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
         'Toast',
         `Toast--${typeMap[type].className}`,
         animationClass,
-        { 'Toast--dismissible': dismissible }
+        { 'Toast--non-dismissible': !dismissible }
       )
     };
 

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -1,6 +1,4 @@
 .Toast {
-  top: var(--top-bar-height);
-  position: fixed;
   color: #0b0e11;
   font-size: var(--text-size-small);
   z-index: var(--z-index-toast);
@@ -8,6 +6,11 @@
   box-sizing: border-box;
   display: flex;
   padding: 4px 15px;
+}
+
+.Toast.Toast--dismissible {
+  top: var(--top-bar-height);
+  position: fixed;
   right: 0;
   left: 0;
 }

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -1,4 +1,8 @@
 .Toast {
+  top: var(--top-bar-height);
+  position: fixed;
+  right: 0;
+  left: 0;
   color: #0b0e11;
   font-size: var(--text-size-small);
   z-index: var(--z-index-toast);
@@ -8,11 +12,9 @@
   padding: 4px 15px;
 }
 
-.Toast.Toast--dismissible {
-  top: var(--top-bar-height);
-  position: fixed;
-  right: 0;
-  left: 0;
+.Toast.Toast--non-dismissible {
+  position: static;
+  margin-bottom: var(--space-small);
 }
 
 .TopBar--thin .Toast {


### PR DESCRIPTION
This pr makes non-dismissible toasts static so they don't cover up content.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/15200521/225713691-56fbbc5e-9905-498d-8a62-8d196d62d651.png">

Closes: https://github.com/dequelabs/cauldron/issues/954