### PR TITLE
fix(react): only render icon button label where it is needed

### DIFF
--- a/packages/react/__tests__/src/components/IconButton/index.js
+++ b/packages/react/__tests__/src/components/IconButton/index.js
@@ -19,7 +19,8 @@ test('should render button by default', async () => {
   expect(button.prop('type')).toBe('button');
   expect(button.prop('tabIndex')).toBe(0);
   expect(button.prop('role')).toBeUndefined();
-  expect(button.text()).toBe('Edit');
+  expect(button.text()).toBe('');
+  expect(wrapper.find('Tooltip').text()).toBe('Edit');
 });
 
 test('should render a "as" an anchor', async () => {
@@ -104,4 +105,5 @@ test('should not render tooltip when disabled prop is true', async () => {
   expect(wrapper.find('Tooltip').exists()).toBe(false);
   const button = wrapper.find('button');
   expect(button.prop('tabIndex')).toBe(-1);
+  expect(button.text()).toBe('Edit');
 });

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -91,7 +91,7 @@ const IconButton = forwardRef(
           {...other}
         >
           <Icon type={icon} />
-          <Offscreen>{label}</Offscreen>
+          {disabled && <Offscreen>{label}</Offscreen>}
         </Component>
         {!disabled && (
           <Tooltip


### PR DESCRIPTION
Closes https://github.com/dequelabs/cauldron/issues/961