### PR TITLE
fix(breadcrumbs): Allow long items and links to break fluidly

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,7 @@ const Breadcrumb = forwardRef<HTMLElement, BreadcrumbProps>(
     ref
   ) => {
     const items = React.Children.toArray(children);
-    const childrenWithSeparators: any[] = [];
+    const childrenWithSeparators: React.ReactNode[] = [];
 
     items.forEach((child, index) => {
       if (index !== items.length - 1) {

--- a/packages/styles/breadcrumb.css
+++ b/packages/styles/breadcrumb.css
@@ -1,10 +1,10 @@
 .Breadcrumb ol {
-  display: flex;
+  display: block;
+  word-break: break-all;
   align-items: center;
   list-style-type: none;
   padding: 0;
   margin: 0;
-  flex-wrap: wrap;
 }
 
 .Breadcrumb__Separator {
@@ -15,11 +15,11 @@
 .Breadcrumb__Link {
   font-weight: 400;
   padding: 0;
+  display: inline;
 }
 
 .Breadcrumb__Item {
   font-weight: 500;
   color: var(--link-text-color);
-  display: flex;
-  flex-wrap: nowrap;
+  display: inline;
 }


### PR DESCRIPTION
This PR fixes the issue of the breadcrumb links and items not breaking fluidly or having a strange layout at a certain viewport. 

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/41127686/226637044-fb3982de-11de-4b6d-8792-fba8b92761be.mov

</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/41127686/226637261-453f078a-5d3d-4ee1-8d5e-6103c9453268.mov

</details>




Closes: https://github.com/dequelabs/cauldron/issues/939