### PR TITLE
fix(Button): ensure button.Link variant inherits its font-size to match inline text

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -47,6 +47,7 @@
 
 button.Link {
   cursor: pointer;
+  font-size: inherit;
 }
 
 .Button--primary:focus,


### PR DESCRIPTION
closes #964 