### PR TITLE
fix(DescriptionList): force description list details to break-word when no space is available

### DIFF
--- a/packages/styles/description-list.css
+++ b/packages/styles/description-list.css
@@ -85,6 +85,8 @@
   color: var(--data-list-value-text-color);
   background-color: var(--data-list-value-background-color);
   font-weight: var(--font-weight-normal);
+  overflow: hidden;
+  overflow-wrap: break-word;
 }
 
 .DescriptionList__term,


### PR DESCRIPTION
closes #907 

## Default Example

![cauldron description list with word breaking](https://user-images.githubusercontent.com/1062039/226724433-a54fb1d5-b136-405f-af86-8ad867354339.png)

## Collapsed Example

![cauldron description list collapsed with word breaking](https://user-images.githubusercontent.com/1062039/226724223-410ca42b-036e-43f5-916a-0ed82eed8ecd.png)
