### PR TITLE
chore: add release-please as github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - release-please-testing
+      - develop
 
 permissions:
   contents: write
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          pull-request-header: :robot: This PR is created automatically ([see releasing](../blob/develop/RELEASING.md))
           release-type: node
           package-name: cauldron
-          default-branch: develop
+          component: cauldron
+          default-branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
-          default-branch: release-please
+          default-branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: node
-          package-name: release-please-action
+          package-name: cauldron
           default-branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - release-please
+      - release-please-testing
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           release-type: node
           package-name: cauldron
-          default-branch: master
+          default-branch: develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - release-please
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Cauldron Release
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+          default-branch: release-please

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,9 @@
 # Releasing (for maintainers only)
 
-To create a new release of this package, follow the steps below.
+To create a new release of @deque/cauldron-react and @deque/cauldron-styles, follow the steps below.
 
 1. Navigate to [cauldron pull requests](https://github.com/dequelabs/cauldron/pulls?q=is%3Apr+is%3Aopen+label%3A%22autorelease%3A+pending%22) to see if there are any open PRs tagged as `autorelease: pending`.
-2. Review the changelog
+2. Review the changelog / commits
 3. If everything looks good, merge the PR into `master`
 
 _NOTE: Do **not** `npm publish` yourself. CI will do this for you._

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,27 +2,8 @@
 
 To create a new release of this package, follow the steps below.
 
-1. Ensure you have the latest changes
-   ```
-   git checkout develop
-   git pull origin develop
-   ```
-1. Create a release branch using today's date
-   ```
-   git checkout -b release-YYYY-MM-DD
-   git push -u origin release-YYYY-MM-DD
-   ```
-1. Ensure dependencies are installed, then run the release script
-   ```
-   yarn
-   yarn release
-   ```
-1. Push the changes (in accordance to the `release` script's output):
+1. Navigate to [cauldron pull requests](https://github.com/dequelabs/cauldron/pulls?q=is%3Apr+is%3Aopen+label%3A%22autorelease%3A+pending%22) to see if there are any open PRs tagged as `autorelease: pending`.
+2. Review the changelog
+3. If everything looks good, merge the PR into `master`
 
-   ```
-   git push --follow-tags origin release-YYYY-MM-DD
-   ```
-
-   _NOTE: Do **not** `npm publish` yourself. CI will do this for you._
-
-1. Open a Pull Request into the `master` branch by visiting `https://github.com/dequelabs/cauldron/compare/master...<release-YYYY-MM-DD>?expand=1` in your browser (replacing `YYYY-MM-DD` with the date)
+_NOTE: Do **not** `npm publish` yourself. CI will do this for you._


### PR DESCRIPTION
closes #922

Standardize/simplify our release process by migrating to use [`release-please`](https://github.com/googleapis/release-please)