### PR TITLE
docs: fix markdown intermingling with react components

### DIFF
--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MDXProvider } from '@mdx-js/react';
 import { Code } from '@deque/cauldron-react';
 import CopyToClipboardButton from './CopyToClipboardButton';
 import './example.css';

--- a/docs/remark-plugins.mjs
+++ b/docs/remark-plugins.mjs
@@ -10,6 +10,8 @@ import { mdxjs } from 'micromark-extension-mdxjs';
 import { mdxFromMarkdown } from 'mdast-util-mdx';
 import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression'
 
+const index = 0
+
 const exampleFromMDX = () => {
   return (tree) => {
     visit(tree, 'code', (node, index, parent) => {
@@ -39,6 +41,15 @@ const exampleFromMDX = () => {
         }
       }
 
+      if (!func) {
+        // We want to ensure that any react markup renders pure and does
+        // not get rendered using markdown components, so export the code
+        // wrapped in a function to ensure it's pure
+        index++
+        func = `\n\nexport function CodeExample${index}() { return <>${raw}</> }\n\n`
+        render = `<CodeExample${index} />`
+      }
+
       const exampleMarkdown =  `${func}<Example raw={''}>
 {
   <div className="Component__example__react">
@@ -51,10 +62,6 @@ const exampleFromMDX = () => {
         exampleMarkdown,
         options
       );
-
-      // Note: From markdown will strip extra whitespace from raw code, which
-      // we want to preserve so manually include it in the mdast
-      updatedNode.children[func ? 1 : 0].attributes[0].value = raw
 
       Object.assign(node, updatedNode);
     });

--- a/docs/remark-plugins.mjs
+++ b/docs/remark-plugins.mjs
@@ -44,7 +44,7 @@ const exampleFromMDX = () => {
       if (!func) {
         // We want to ensure that any react markup renders pure and does
         // not get rendered using markdown components, so export the code
-        // wrapped in a function to ensure it's pure
+        // wrapped in a function to ensure components do not get applied
         index++
         func = `\n\nexport function CodeExample${index}() { return <>${raw}</> }\n\n`
         render = `<CodeExample${index} />`
@@ -62,6 +62,10 @@ const exampleFromMDX = () => {
         exampleMarkdown,
         options
       );
+
+      // Note: From markdown will strip extra whitespace from raw code, which
+      // we want to preserve so manually include it in the mdast
+      updatedNode.children[func ? 1 : 0].attributes[0].value = raw
 
       Object.assign(node, updatedNode);
     });


### PR DESCRIPTION
I noticed that some of the react examples were getting intermingled with the [mdx components](https://github.com/dequelabs/cauldron/blob/develop/docs/mdx-components.tsx) causing some weird layout issues. Wrapping the rendered code in a named function seems to resolve that problem.

The following markdown:

````markdown
```jsx example
<Button>Hello</Button>
```
````

Will now end up transformed into something like:

```mdx
export function CodeExample1234() {
  return <><Button>Hello</Button></>
}

{
  <Example>
    <CodeExample1234 />
  </Example>
}
```