### PR TITLE
ci: add github action for creating releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,3 +20,5 @@ jobs:
         run: yarn run release
         env:
           COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,5 +21,4 @@ jobs:
           yarn run release
         env:
           COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,8 +17,7 @@ jobs:
           node-version: 18
       - run: yarn
       - name: Release
-        run: |
-          yarn run release
+        run: yarn run release
         env:
           COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,8 @@ jobs:
           node-version: 18
       - run: yarn
       - name: Release
-        run: yarn run release
+        run: |
+          yarn run release
         env:
           COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,20 @@
+name: Create Release PR
+
+on: [workflow_dispatch]
+
+jobs:
+  create_release:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn
+      - id: release
+        run: yarn run release
+        env:
+          COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18
       - run: yarn
-      - id: release
+      - name: Release
         run: yarn run release
         env:
           COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,6 @@
 name: Create Release PR
 
-# on: [workflow_dispatch]
-on:
-  push:
+on: [workflow_dispatch]
 
 jobs:
   create_release:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Release
         run: yarn run release
         env:
-          COMMIT_BODY_HEADER: 'This PR was opened by a robot :robot: :tada: \n\n'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          COMMIT_BODY_HEADER: "This PR was opened by a robot :robot: :tada: \n\n"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Release
         run: yarn run release
         env:
-          COMMIT_BODY_HEADER: "This PR was opened by a robot :robot: :tada: \n\n"
+          COMMIT_BODY_HEADER: ":robot: This PR is created automatically ([see releasing](../blob/develop/RELEASING.md)) \n\n"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,8 @@
 name: Create Release PR
 
-on: [workflow_dispatch]
+# on: [workflow_dispatch]
+on:
+  push:
 
 jobs:
   create_release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,15 @@ To create a new release of `@deque/cauldron-react` and `@deque/cauldron-styles`,
 
 ## Creating a New Release
 
+- Open a new browser tab to https://github.com/dequelabs/cauldron/actions/workflows/create-release.yml
+- Run the `workflow_dispatch` event from the `develop` branch
+
+This will create a release PR after the action has run successfully.
+
+Once the release has been reviewed, merge the release branch into the `master` branch.
+
+## Creating a new Release (Manual)
+
 ```bash
 # Ensure you have the latest `develop` code.
 git checkout develop

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,12 @@ message=${COMMIT_MESSAGE:-"chore(cauldron): Release {{currentTag}}"}
 echo "Creating release staging branch: $branch_name"
 git checkout -b "$branch_name"
 
+if [[ ! -z "$CI" ]] && [[ ! -z "$GITHUB_ACTION" ]]; then
+  # use the default github actions bot when in ci
+  git config user.email "github-actions[bot]@users.noreply.github.comm"
+  git config user.name "github-actions[bot]"
+fi
+
 # Run release stuff (update package.json#version, changelog, etc.)
 npx standard-version \
   --releaseCommitMessageFormat="$message" \
@@ -59,9 +65,6 @@ if [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTION" ]]; then
   open -n $pr_url
 
 else
-
-  git config user.name ":robot:"
-  git config user.email "aciattestteamci@deque.com"
 
   commit_body="$COMMIT_BODY_HEADER $release_notes $COMMIT_BODY_FOOTER"
   gh pr create --title $message --body $commit_body --base $base

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,13 +51,13 @@ release_notes=$(
     --output-indicator-new=! CHANGELOG.md | egrep '^!' | awk -F'^[!]' '{print $2}' | sed -e 's/\n/$0A/g'
 )
 
+git push origin $release_branch
+
 if [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTION" ]]; then
 
   # Get the additions to the changelog as the commit body and generate the PR url
   uri_encoded_commit_body=$(echo $release_notes | node -p 'encodeURIComponent(require("fs").readFileSync(0))')
   uri_encoded_message=$(git show --no-patch --format=%s | node -p 'encodeURIComponent(require("fs").readFileSync(0))')
-
-  git push origin $release_branch
 
   pr_url="https://github.com/dequelabs/cauldron/compare/$base...$release_branch?title=$uri_encoded_message&body=$uri_encoded_commit_body"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,6 +67,6 @@ if [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTION" ]]; then
 else
 
   commit_body="$COMMIT_BODY_HEADER $release_notes $COMMIT_BODY_FOOTER"
-  gh pr create --title $message --body $commit_body --base $base
+  gh pr create --title "$message" --body "$commit_body" --base "$base"
 
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,6 +67,8 @@ if [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTION" ]]; then
 else
 
   commit_body="$COMMIT_BODY_HEADER $release_notes $COMMIT_BODY_FOOTER"
-  gh pr create --title "$message" --body "$commit_body" --base "$base"
+  commit_title=$(git show --no-patch --format=%s)
+
+  gh pr create --title "$commit_title" --body "$commit_body" --base "$base"
 
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,6 +60,9 @@ if [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTION" ]]; then
 
 else
 
+  git config user.name ":robot:"
+  git config user.email "aciattestteamci@deque.com"
+
   commit_body="$COMMIT_BODY_HEADER $release_notes $COMMIT_BODY_FOOTER"
   gh pr create --title $message --body $commit_body --base $base
 


### PR DESCRIPTION
Some more light automation allowing anyone to create cauldron releases from a github action dispatch.

(see https://github.com/dequelabs/cauldron/pull/1042 as an example of one that was run via an action)