### PR TITLE
fix(react): removed line height styling from thin button

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -187,7 +187,6 @@ button.Link {
   min-height: var(--button-thin-height);
   min-width: 100px;
   font-size: var(--text-size-smallest);
-  line-height: var(--text-size-smallest);
   padding: 0 16px;
 }
 


### PR DESCRIPTION
Closes: #620 

Please let me know if there is any additional styling that needs to be added or if there is a prototype the styling should be based on.

Before:

<img width="218" alt="three buttons one being the thin one with line height compressing it" src="https://user-images.githubusercontent.com/13560664/235035150-a51b5a13-b883-459b-8050-8aaf853e0a46.png">


After:

<img width="169" alt="three buttons with the thin button no longer being compressed" src="https://user-images.githubusercontent.com/13560664/235035237-99775db6-cc32-454b-953f-35495f06ff50.png">
