### PR TITLE
fix(react): corrected toast component's padding

### DIFF
--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -9,7 +9,7 @@
   align-items: center;
   box-sizing: border-box;
   display: flex;
-  padding: 4px 15px;
+  padding: var(--space-smallest) var(--space-small);
 }
 
 .Toast.Toast--non-dismissible {


### PR DESCRIPTION
Closes #829

Corrected the toast padding to top and bottom padding of 8 px and left/right to 16px.