### PR TITLE
fix(styles): prevent select text from overlapping with carat indicator

### DIFF
--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -36,6 +36,7 @@
   width: 100%;
   min-height: var(--select-min-height);
   padding: var(--space-three-quarters) var(--space-smallest);
+  padding-right: var(--space-large);
   border: 1px solid var(--field-border-color);
   font-family: Roboto;
   font-weight: normal;


### PR DESCRIPTION
closes #196 