### PR TITLE
fix(styles): fix spacing between PanelHeading and PanelContent

### DIFF
--- a/docs/pages/components/Panel.mdx
+++ b/docs/pages/components/Panel.mdx
@@ -57,8 +57,8 @@ In addition to using the `heading` prop, you can also compose the `Panel` compon
 `PanelContent` components.
 
 <Note>
-  The `PanelHeader` and `PanelContent` should not be used with the `Panel`
-  heading prop at the same time. Choose one or the other.
+  The `PanelHeader` should not be used with the Panel
+  `heading` prop at the same time. Choose one or the other.
 </Note>
 
 ```jsx example

--- a/packages/styles/panel.css
+++ b/packages/styles/panel.css
@@ -39,6 +39,10 @@
     var(--space-small) calc(var(--panel-padding) * -1);
 }
 
+.Panel__Heading + .Panel__Content {
+  margin-top: calc(var(--panel-padding) * -1);
+}
+
 .Panel__Header {
   margin: calc(var(--panel-padding) * -1) calc(var(--panel-padding) * -1) 0
     calc(var(--panel-padding) * -1);


### PR DESCRIPTION
There was a disproportionate amount of spacing between the heading/content section that is unnecessary:

![panel component with extra spacing between heading and panelcontent component](https://user-images.githubusercontent.com/1062039/236282058-9d08403d-4617-4a19-b322-35990b9f86f7.png)
