### PR TITLE
fix(styles): fix overflow styling on Radio Group and Checkbox and align styles with Pattern Library

### DIFF
--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -120,9 +120,9 @@ import { Checkbox } from '@deque/cauldron-react'
   />
   <Checkbox
     error="You must check this checkbox to continue"
-    id="checkbox-error"
+    id="checkbox-error-list"
     label="Error Checkbox"
-    name="error-checkbox"
+    name="error-checkbox-list"
     value="1"
   />
 </FieldWrap>

--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -90,6 +90,7 @@ import { Checkbox } from '@deque/cauldron-react'
 
 ```jsx example
 <FieldWrap>
+<div className="Field__label" id="checkbox-list-label">Checkbox List Label</div>
   <Checkbox
     id="checkbox-list-unchecked"
     label="Unchecked Checkbox"
@@ -106,7 +107,7 @@ import { Checkbox } from '@deque/cauldron-react'
   <Checkbox
     disabled
     id="checkbox-list-checkbox-disabled-unchecked"
-    label="Checked Disabled Checkbox"
+    label="Unchecked Disabled Checkbox"
     name="disabled-checkbox-list-unchecked"
     value="1"
   />
@@ -114,7 +115,7 @@ import { Checkbox } from '@deque/cauldron-react'
     disabled
     checked
     id="checkbox-list-checkbox-disabled-checked"
-    label="Unchecked Disabled Checkbox"
+    label="Checked Disabled Checkbox"
     name="disabled-checkbox-list-checked"
     value="1"
   />
@@ -161,6 +162,7 @@ import { Checkbox } from '@deque/cauldron-react'
 
 ```jsx example
 <FieldWrap>
+<div className="Field__label" id="checkbox-list-label">Checkbox with Description List Label</div>
   <Checkbox
     id="description-checkbox-list-unchecked"
     label="Description Checkbox Unchecked"

--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -86,6 +86,48 @@ import { Checkbox } from '@deque/cauldron-react'
 </FieldWrap>
 ```
 
+### Checkbox List
+
+```jsx example
+<FieldWrap>
+  <Checkbox
+    id="checkbox-list-unchecked"
+    label="Unchecked Checkbox"
+    name="unchecked-checkbox-list"
+    value="1"
+  />
+  <Checkbox
+    checked
+    id="checkbox-list-checked"
+    label="Checked Checkbox"
+    name="checked-checkbox-list"
+    value="1"
+  />
+  <Checkbox
+    disabled
+    id="checkbox-list-checkbox-disabled-unchecked"
+    label="Checked Disabled Checkbox"
+    name="disabled-checkbox-list-unchecked"
+    value="1"
+  />
+  <Checkbox
+    disabled
+    checked
+    id="checkbox-list-checkbox-disabled-checked"
+    label="Unchecked Disabled Checkbox"
+    name="disabled-checkbox-list-checked"
+    value="1"
+  />
+  <Checkbox
+    error="You must check this checkbox to continue"
+    id="checkbox-error"
+    label="Error Checkbox"
+    name="error-checkbox"
+    value="1"
+  />
+</FieldWrap>
+```
+
 ### Checkbox with Description
 
 ```jsx example

--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -162,7 +162,7 @@ import { Checkbox } from '@deque/cauldron-react'
 
 ```jsx example
 <FieldWrap>
-<div className="Field__label" id="checkbox-list-label">Checkbox with Description List Label</div>
+<div className="Field__label" id="checkbox-list-with-description-label">Checkbox with Description List Label</div>
   <Checkbox
     id="description-checkbox-list-unchecked"
     label="Description Checkbox Unchecked"

--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -157,6 +157,53 @@ import { Checkbox } from '@deque/cauldron-react'
 </FieldWrap>
 ```
 
+### Checkbox with Description List
+
+```jsx example
+<FieldWrap>
+  <Checkbox
+    id="description-checkbox-unchecked"
+    label="Description Checkbox Unchecked"
+    labelDescription="Additional text to describe the checkbox"
+    name="description-checkbox- unchecked"
+    value="1"
+  />
+  <Checkbox
+  checked
+    id="description-checkbox-checked"
+    label="Description Checkbox Checked"
+    labelDescription="Additional text to describe the checkbox"
+    name="description-checkbox-checked"
+    value="1"
+  />
+  <Checkbox
+    disabled
+    id="description-checkbox-disabled-unchecked"
+    label="Description Checkbox Disabled Unchecked"
+    labelDescription="Additional text to describe the checkbox"
+    name="description-checkbox-disabled-unchecked"
+    value="1"
+  />
+  <Checkbox
+    disabled
+    checked
+    id="description-checkbox-disabled-checked"
+    label="Description Checkbox Disabled Checked"
+    labelDescription="Additional text to describe the checkbox"
+    name="description-checkbox-disabled-checked"
+    value="1"
+  />
+  <Checkbox
+    error="You must check this checkbox to continue"
+    id="description-error-checkbox"
+    label="Description Error Checkbox"
+    labelDescription="Additional text to describe the checkbox"
+    name="description-error-checkbox"
+    value="1"
+  />
+</FieldWrap>
+```
+
 ## Props
 
 <ComponentProps

--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -162,43 +162,43 @@ import { Checkbox } from '@deque/cauldron-react'
 ```jsx example
 <FieldWrap>
   <Checkbox
-    id="description-checkbox-unchecked"
+    id="description-checkbox-list-unchecked"
     label="Description Checkbox Unchecked"
     labelDescription="Additional text to describe the checkbox"
-    name="description-checkbox- unchecked"
+    name="description-checkbox-list-unchecked"
     value="1"
   />
   <Checkbox
   checked
-    id="description-checkbox-checked"
+    id="description-checkbox-list-checked"
     label="Description Checkbox Checked"
     labelDescription="Additional text to describe the checkbox"
-    name="description-checkbox-checked"
+    name="description-checkbox-list-checked"
     value="1"
   />
   <Checkbox
     disabled
-    id="description-checkbox-disabled-unchecked"
+    id="description-checkbox-list-disabled-unchecked"
     label="Description Checkbox Disabled Unchecked"
     labelDescription="Additional text to describe the checkbox"
-    name="description-checkbox-disabled-unchecked"
+    name="description-checkbox-list-disabled-unchecked"
     value="1"
   />
   <Checkbox
     disabled
     checked
-    id="description-checkbox-disabled-checked"
+    id="description-checkbox-list-disabled-checked"
     label="Description Checkbox Disabled Checked"
     labelDescription="Additional text to describe the checkbox"
-    name="description-checkbox-disabled-checked"
+    name="description-checkbox-list-disabled-checked"
     value="1"
   />
   <Checkbox
     error="You must check this checkbox to continue"
-    id="description-error-checkbox"
+    id="description-error-checkbox-list"
     label="Description Error Checkbox"
     labelDescription="Additional text to describe the checkbox"
-    name="description-error-checkbox"
+    name="description-error-checkbox-list"
     value="1"
   />
 </FieldWrap>

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -71,7 +71,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     }
 
     return (
-      <>
+      <div className="Checkbox">
         <div className={classNames('Checkbox is--flex-row', className)}>
           <input
             id={id}
@@ -124,18 +124,18 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               }
             }}
           />
-          {labelDescription && (
-            <span id={labelDescriptionId} className="Field__labelDescription">
-              {labelDescription}
-            </span>
-          )}
-          {error && (
-            <div id={errorId} className="Error">
-              {error}
-            </div>
-          )}
         </div>
-      </>
+        {labelDescription && (
+          <span id={labelDescriptionId} className="Field__labelDescription">
+            {labelDescription}
+          </span>
+        )}
+        {error && (
+          <div id={errorId} className="Error">
+            {error}
+          </div>
+        )}
+      </div>
     );
   }
 );

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -101,7 +101,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             {...other}
           />
           <label
-            className={classNames('Field__label', {
+            className={classNames('Field__label', 'Checkbox__label', {
               'Field__label--disabled': disabled
             })}
             htmlFor={id}

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -101,7 +101,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             {...other}
           />
           <label
-            className={classNames('Field__label', 'Checkbox__label', {
+            className={classNames('Checkbox__label', {
               'Field__label--disabled': disabled
             })}
             htmlFor={id}

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -71,7 +71,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     }
 
     return (
-      <div className="Checkbox">
+      <div className="Checkbox__wrap">
         <div className={classNames('Checkbox is--flex-row', className)}>
           <input
             id={id}

--- a/packages/react/src/components/RadioGroup/index.tsx
+++ b/packages/react/src/components/RadioGroup/index.tsx
@@ -98,7 +98,7 @@ const RadioGroup = ({
           />
           <label
             htmlFor={id}
-            className={classNames('Field__label', {
+            className={classNames('Field__label', 'Radio__label', {
               'Field__label--disabled': disabled
             })}
           >

--- a/packages/react/src/components/RadioGroup/index.tsx
+++ b/packages/react/src/components/RadioGroup/index.tsx
@@ -98,7 +98,7 @@ const RadioGroup = ({
           />
           <label
             htmlFor={id}
-            className={classNames('Field__label', 'Radio__label', {
+            className={classNames('Radio__label', {
               'Field__label--disabled': disabled
             })}
           >

--- a/packages/react/src/components/RadioGroup/index.tsx
+++ b/packages/react/src/components/RadioGroup/index.tsx
@@ -71,47 +71,49 @@ const RadioGroup = ({
     const isFocused = focusIndex === index;
 
     return (
-      <div className={classNames('Radio is--flex-row', className)} key={id}>
-        <input
-          type="radio"
-          name={name}
-          value={radioValue}
-          id={id}
-          ref={input => {
-            if (!input) {
-              return;
-            }
+      <div className="Radio" key={id}>
+        <div className={classNames('Radio is--flex-row', className)}>
+          <input
+            type="radio"
+            name={name}
+            value={radioValue}
+            id={id}
+            ref={input => {
+              if (!input) {
+                return;
+              }
 
-            inputs.current.push(input);
-          }}
-          onFocus={() => onRadioFocus(index)}
-          onBlur={() => onRadioBlur()}
-          onChange={() => {
-            handleChange(radioValue);
-            onChange(radio, inputs.current?.[index]);
-          }}
-          disabled={disabled}
-          checked={isChecked}
-          aria-describedby={labelDescription ? `${id}Desc` : undefined}
-          {...other}
-        />
-        <label
-          htmlFor={id}
-          className={classNames('Field__label', {
-            'Field__label--disabled': disabled
-          })}
-        >
-          {label}
-        </label>
-        <Icon
-          className={classNames('Radio__overlay', {
-            'Radio__overlay--focused': isFocused,
-            'Radio__overlay--disabled': disabled
-          })}
-          type={isChecked ? 'radio-checked' : 'radio-unchecked'}
-          aria-hidden="true"
-          onClick={() => onRadioClick(index)}
-        />
+              inputs.current.push(input);
+            }}
+            onFocus={() => onRadioFocus(index)}
+            onBlur={() => onRadioBlur()}
+            onChange={() => {
+              handleChange(radioValue);
+              onChange(radio, inputs.current?.[index]);
+            }}
+            disabled={disabled}
+            checked={isChecked}
+            aria-describedby={labelDescription ? `${id}Desc` : undefined}
+            {...other}
+          />
+          <label
+            htmlFor={id}
+            className={classNames('Field__label', {
+              'Field__label--disabled': disabled
+            })}
+          >
+            {label}
+          </label>
+          <Icon
+            className={classNames('Radio__overlay', {
+              'Radio__overlay--focused': isFocused,
+              'Radio__overlay--disabled': disabled
+            })}
+            type={isChecked ? 'radio-checked' : 'radio-unchecked'}
+            aria-hidden="true"
+            onClick={() => onRadioClick(index)}
+          />
+        </div>
         {labelDescription && (
           <span
             id={`${id}Desc`}

--- a/packages/react/src/components/RadioGroup/index.tsx
+++ b/packages/react/src/components/RadioGroup/index.tsx
@@ -71,7 +71,7 @@ const RadioGroup = ({
     const isFocused = focusIndex === index;
 
     return (
-      <div className="Radio" key={id}>
+      <div className="Radio__wrap" key={id}>
         <div className={classNames('Radio is--flex-row', className)}>
           <input
             type="radio"

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -165,7 +165,7 @@ textarea.Field--has-error:focus:hover,
   text-align: left;
   font-size: var(--text-size-smallest);
   margin-top: var(--space-half);
-  margin-left: calc(24px + 2px + var(--space-half));
+  margin-left: calc(var(--icon-size) + 2px + var(--space-half));
   padding: var(--space-half) 0;
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -16,14 +16,14 @@
   --field-label-text-color: var(--gray-90);
   --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--gray-60);
-  --field-icon-inactive-color: var(--gray-90);
-  --field-icon-active-color: rgba(60, 122, 174, 0.25);
-  --field-icon-checked-color: var(--accent-primary);
-  --field-icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
-  --field-icon-unchecked-disabled-color: var(--gray-40);
-  --field-icon-focus-color: var(--focus-light);
-  --field-error-text-color: var(--error);
-  --field-error-border-color: var(--error);
+  --icon-inactive-color: var(--gray-90);
+  --icon-active-color: rgb(212, 221, 224, 0.25);
+  --icon-checked-color: var(--accent-primary);
+  --icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
+  --icon-unchecked-disabled-color: var(--gray-40);
+  --icon-focus-color: var(--focus-light);
+  --error-text-color: var(--error);
+  --error-border-color: var(--error);
   --input-min-width: 250px;
 }
 
@@ -39,14 +39,14 @@
   --field-background-color-disabled: #5d676f;
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
-  --field-label-description-text-color: rgba(255, 255, 255, 0.8);
-  --field-icon-inactive-color: var(--white);
-  --field-icon-checked-color: var(--accent-light);
-  --field-icon-checked-disabled-color: var(--stroke-dark);
-  --field-icon-unchecked-disabled-color: var(--stroke-dark);
-  --field-error-text-color: var(--error);
-  --field-error-border-color: var(--error);
-  --field-icon-focus-color: var(--focus-dark);
+  --field-label-description-text-color: var(--accent-light);
+  --icon-inactive-color: var(--white);
+  --icon-checked-color: var(--accent-light);
+  --icon-checked-disabled-color: var(--stroke-dark);
+  --icon-unchecked-disabled-color: var(--stroke-dark);
+  --icon-focus-color: var(--focus-dark);
+  --error-text-color: var(--error);
+  --error-border-color: var(--error);
 }
 
 input,
@@ -174,8 +174,8 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Error {
-  color: var(--field-error-text-color);
-  border-top: 1px solid var(--field-error-border-color);
+  color: var(--error-text-color);
+  border-top: 1px solid var(--error-border-color);
   text-align: left;
   font-size: var(--text-size-smallest);
   margin-top: var(--space-half);
@@ -204,6 +204,10 @@ textarea.Field--has-error:focus:hover,
   margin-bottom: var(--space-smallest);
 }
 
+.Radio--inline .Radio__wrap {
+  margin-bottom: 0;
+}
+
 .Checkbox,
 .Radio {
   box-sizing: border-box;
@@ -229,6 +233,11 @@ textarea.Field--has-error:focus:hover,
 .Radio .Field__label {
   margin-bottom: 0;
   padding-bottom: 0;
+}
+
+.Checkbox + .Field__labelDescription,
+.Radio + .Field__labelDescription {
+  margin-top: var(--space-smallest);
 }
 
 .Field__label {
@@ -307,8 +316,7 @@ textarea.Field--has-error:focus:hover,
   display: flex;
 }
 
-.Icon + .Error {
-  flex-basis: 100%;
+.Field__labelDescription + .Error {
   margin-top: var(--space-smallest);
 }
 
@@ -317,10 +325,13 @@ textarea.Field--has-error:focus:hover,
   border: 1px solid transparent;
   box-sizing: border-box;
   cursor: pointer;
-  border-radius: 3px;
-  color: var(--field-icon-inactive-color);
+  color: var(--icon-inactive-color);
   margin-right: var(--space-half);
   align-self: flex-start;
+}
+
+.Checkbox__overlay {
+  border-radius: 5px;
 }
 
 .Radio__overlay {
@@ -334,7 +345,7 @@ textarea.Field--has-error:focus:hover,
 
 .Radio__overlay:active:not(.Radio__overlay--disabled),
 .Checkbox__overlay:active:not(.Checkbox__overlay--disabled) {
-  background-color: var(--field-icon-active-color);
+  background-color: var(--icon-active-color);
 }
 
 .Radio input[type='radio'] {
@@ -347,23 +358,22 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox__overlay.Checkbox__overlay--focused,
 .Radio__overlay.Radio__overlay--focused {
-  border-radius: 5px;
-  box-shadow: 0 0 0 2px var(--field-icon-focus-color);
+  box-shadow: 0 0 0 2px var(--icon-focus-color);
 }
 
 .Radio__overlay.Icon--radio-checked,
 .Checkbox__overlay.Icon--checkbox-checked {
-  color: var(--field-icon-checked-color);
+  color: var(--icon-checked-color);
 }
 
 .Radio__overlay--disabled.Icon--radio-checked,
 .Checkbox__overlay--disabled.Icon--checkbox-checked {
-  color: var(--field-icon-checked-disabled-color);
+  color: var(--icon-checked-disabled-color);
 }
 
 .Checkbox__overlay--disabled.Icon--checkbox-unchecked,
 .Radio__overlay--disabled.Icon--radio-unchecked {
-  color: var(--field-icon-unchecked-disabled-color);
+  color: var(--icon-unchecked-disabled-color);
 }
 
 .Field__label:hover ~ .Radio__overlay:not(.Radio__overlay--disabled),

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -312,7 +312,7 @@ textarea.Field--has-error:focus:hover,
 
 .Radio__overlay {
   border-radius: 50%;
-  align-self: start;
+  align-self: flex-start;
 }
 
 .Radio__overlay svg,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -258,8 +258,11 @@ textarea.Field--has-error:focus:hover,
   cursor: default;
 }
 
-.Field__label + .Checkbox__wrap,
-.Field__label + div[role='radiogroup'] {
+.Field__label + .Checkbox__wrap {
+  margin-top: var(--space-half);
+}
+
+.Field__label + [role^='radiogroup'] {
   margin-top: var(--space-smallest);
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -216,7 +216,6 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox__wrap,
 .Radio__wrap {
-  margin-top: 0;
   margin-bottom: var(--space-smallest);
 }
 
@@ -245,12 +244,6 @@ textarea.Field--has-error:focus:hover,
   gap: var(--space-small);
 }
 
-.Checkbox .Field__label,
-.Radio .Field__label {
-  margin-bottom: 0;
-  padding-bottom: 0;
-}
-
 .Checkbox + .Field__labelDescription,
 .Radio + .Field__labelDescription {
   margin-top: var(--space-half);
@@ -269,8 +262,12 @@ textarea.Field--has-error:focus:hover,
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);
   font-weight: var(--font-weight-medium);
-  margin-bottom: var(--space-smallest);
   cursor: default;
+}
+
+.Field__label + .Checkbox__wrap,
+.Field__label + div[role='radiogroup'] {
+  margin-top: var(--space-smallest);
 }
 
 .Field__label .Checkbox__label,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -187,7 +187,7 @@ textarea.Field--has-error:focus:hover,
   margin-bottom: 0;
   flex-direction: row-reverse;
   justify-content: flex-end;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .Radio--inline {
@@ -312,6 +312,7 @@ textarea.Field--has-error:focus:hover,
 
 .Radio__overlay {
   border-radius: 50%;
+  align-self: start;
 }
 
 .Radio__overlay svg,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -309,11 +309,11 @@ textarea.Field--has-error:focus:hover,
   border-radius: 3px;
   color: #333;
   margin-right: var(--space-half);
+  align-self: flex-start;
 }
 
 .Radio__overlay {
   border-radius: 50%;
-  align-self: flex-start;
 }
 
 .Radio__overlay svg,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -16,19 +16,23 @@
   --field-label-text-color: var(--gray-90);
   --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--gray-60);
-  --icon-inactive-color: var(--gray-90);
-  --icon-active-color: color-mix(
+  --field-icon-inactive-color: var(--gray-90);
+  --field-icon-active-color: color-mix(
     in srgb,
     var(--accent-primary) 20%,
     transparent
   );
-  --icon-error-active-color: color-mix(in srgb, var(--error) 20%, transparent);
-  --icon-checked-color: var(--accent-primary);
-  --icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
-  --icon-unchecked-disabled-color: var(--gray-40);
-  --icon-focus-color: var(--focus-light);
-  --error-text-color: var(--error);
-  --error-border-color: var(--error);
+  --field-icon-error-active-color: color-mix(
+    in srgb,
+    var(--error) 20%,
+    transparent
+  );
+  --field-icon-checked-color: var(--accent-primary);
+  --field-icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
+  --field-icon-unchecked-disabled-color: var(--gray-40);
+  --field-icon-focus-color: var(--focus-light);
+  --field-error-text-color: var(--error);
+  --field-error-border-color: var(--error);
   --input-min-width: 250px;
 }
 
@@ -45,19 +49,23 @@
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
   --field-label-description-text-color: var(--accent-light);
-  --icon-inactive-color: var(--white);
-  --icon-active-color: color-mix(in srgb, var(--accent-light) 20%, transparent);
-  --icon-error-active-color: color-mix(
+  --field-icon-inactive-color: var(--white);
+  --field-icon-active-color: color-mix(
+    in srgb,
+    var(--accent-light) 20%,
+    transparent
+  );
+  --field-icon-error-active-color: color-mix(
     in srgb,
     var(--accent-danger) 20%,
     transparent
   );
-  --icon-checked-color: var(--accent-light);
-  --icon-checked-disabled-color: var(--stroke-dark);
-  --icon-unchecked-disabled-color: var(--stroke-dark);
-  --icon-focus-color: var(--focus-dark);
-  --error-text-color: var(--error);
-  --error-border-color: var(--error);
+  --field-icon-checked-color: var(--accent-light);
+  --field-icon-checked-disabled-color: var(--stroke-dark);
+  --field-icon-unchecked-disabled-color: var(--stroke-dark);
+  --field-icon-focus-color: var(--focus-dark);
+  --field-error-text-color: var(--error);
+  --field-error-border-color: var(--error);
 }
 
 input,
@@ -146,7 +154,7 @@ textarea.Field--has-error,
 }
 
 .Icon--checkbox-unchecked.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
-  background-color: var(--icon-error-active-color);
+  background-color: var(--field-icon-error-active-color);
 }
 
 input.Field--has-error:hover,
@@ -189,8 +197,8 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Error {
-  color: var(--error-text-color);
-  border-top: 1px solid var(--error-border-color);
+  color: var(--field-error-text-color);
+  border-top: 1px solid var(--field-error-border-color);
   text-align: left;
   font-weight: var(--font-weight-normal);
   font-size: var(--text-size-smallest);
@@ -351,7 +359,7 @@ textarea.Field--has-error:focus:hover,
   border: 1px solid transparent;
   box-sizing: border-box;
   cursor: pointer;
-  color: var(--icon-inactive-color);
+  color: var(--field-icon-inactive-color);
   margin-right: var(--space-half);
   align-self: flex-start;
 }
@@ -371,7 +379,7 @@ textarea.Field--has-error:focus:hover,
 
 .Radio__overlay:active:not(.Radio__overlay--disabled),
 .Checkbox__overlay:active:not(.Checkbox__overlay--disabled) {
-  background-color: var(--icon-active-color);
+  background-color: var(--field-icon-active-color);
 }
 
 .Radio input[type='radio'] {
@@ -384,22 +392,22 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox__overlay.Checkbox__overlay--focused,
 .Radio__overlay.Radio__overlay--focused {
-  box-shadow: 0 0 0 2px var(--icon-focus-color);
+  box-shadow: 0 0 0 2px var(--field-icon-focus-color);
 }
 
 .Radio__overlay.Icon--radio-checked,
 .Checkbox__overlay.Icon--checkbox-checked {
-  color: var(--icon-checked-color);
+  color: var(--field-icon-checked-color);
 }
 
 .Radio__overlay--disabled.Icon--radio-checked,
 .Checkbox__overlay--disabled.Icon--checkbox-checked {
-  color: var(--icon-checked-disabled-color);
+  color: var(--field-icon-checked-disabled-color);
 }
 
 .Checkbox__overlay--disabled.Icon--checkbox-unchecked,
 .Radio__overlay--disabled.Icon--radio-unchecked {
-  color: var(--icon-unchecked-disabled-color);
+  color: var(--field-icon-unchecked-disabled-color);
 }
 
 .Field__label:hover ~ .Radio__overlay:not(.Radio__overlay--disabled),

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -268,6 +268,7 @@ textarea.Field--has-error:focus:hover,
   align-items: center;
   text-align: left;
   color: var(--field-label-text-color);
+  margin-bottom: var(--space-half);
   font-size: var(--text-size-small);
   font-weight: var(--font-weight-medium);
   cursor: default;
@@ -280,7 +281,13 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox__label,
 .Radio__label {
+  display: flex;
+  align-items: center;
+  text-align: left;
+  color: var(--field-label-text-color);
+  font-size: var(--text-size-small);
   font-weight: var(--font-weight-normal);
+  cursor: default;
 }
 
 .Field__required-text {

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -16,6 +16,7 @@
   --field-label-text-color: var(--gray-90);
   --field-label-description-text-color: var(--gray-60);
   --input-min-width: 250px;
+  --focus-glow: rgba(181, 26, 209, 1);
 }
 
 .cauldron--theme-dark {
@@ -31,6 +32,7 @@
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
   --field-label-description-text-color: rgba(255, 255, 255, 0.8);
+  --focus-glow: rgba(235, 148, 255, 1);
 }
 
 input,
@@ -159,10 +161,12 @@ textarea.Field--has-error:focus:hover,
 
 .Error {
   color: var(--error);
+  border-top: 1px solid var(--error);
   text-align: left;
   font-size: var(--text-size-smallest);
-  font-weight: var(--font-weight-normal);
-  padding-left: var(--space-half);
+  margin-top: var(--space-half);
+  margin-left: calc(24px + 2px + var(--space-half));
+  padding: var(--space-half) 0;
 }
 
 .Field {
@@ -184,10 +188,11 @@ textarea.Field--has-error:focus:hover,
 .Radio {
   box-sizing: border-box;
   position: relative;
-  margin-bottom: 0;
+  margin-top: 0;
   flex-direction: row-reverse;
   justify-content: flex-end;
   flex-wrap: nowrap;
+  margin-bottom: var(--space-smallest);
 }
 
 .Radio--inline {
@@ -197,13 +202,9 @@ textarea.Field--has-error:focus:hover,
   gap: var(--space-small);
 }
 
-.Checkbox {
-  margin-bottom: var(--space-smallest);
-}
-
-.Checkbox + .Checkbox,
-.Radio + .Radio {
-  margin-top: var(--space-smallest);
+.Checkbox:last-of-type,
+.Radio:last-of-type {
+  margin-bottom: 0;
 }
 
 .Checkbox .Field__label,
@@ -218,7 +219,6 @@ textarea.Field--has-error:focus:hover,
   text-align: left;
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);
-  font-weight: var(--font-weight-medium);
   padding-bottom: var(--space-half);
   cursor: default;
 }
@@ -282,8 +282,8 @@ textarea.Field--has-error:focus:hover,
   flex-basis: 100%;
   color: var(--field-label-description-text-color);
   font-size: var(--text-size-small);
-  font-weight: var(--font-weight-normal);
   line-height: 1;
+  margin-top: var(--space-half);
   margin-left: calc(24px + 2px + var(--space-half));
   cursor: default;
   display: flex;
@@ -292,13 +292,6 @@ textarea.Field--has-error:focus:hover,
 .Icon + .Error {
   flex-basis: 100%;
   margin-top: var(--space-smallest);
-}
-
-.Field__labelDescription + .Error {
-  border-top: 1px solid var(--error);
-  margin-left: calc(24px + 2px + var(--space-half));
-  padding: 4px 0;
-  margin-top: 4px;
 }
 
 .Radio__overlay,
@@ -336,8 +329,8 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox__overlay.Checkbox__overlay--focused,
 .Radio__overlay.Radio__overlay--focused {
-  border: 1px solid var(--focus);
-  box-shadow: inset 0 0 0 1px var(--focus), 0 0 4px 2px var(--focus-glow);
+  border-radius: 5px;
+  box-shadow: 0 0 0 2px var(--focus-glow);
 }
 
 .Radio__overlay.Icon--radio-checked {
@@ -366,7 +359,10 @@ textarea.Field--has-error:focus:hover,
   color: #3c7aae;
 }
 
-.Checkbox__overlay--disabled.Icon--checkbox-checked,
+.Checkbox__overlay--disabled.Icon--checkbox-checked {
+  color: #78a6d8;
+}
+
 .Checkbox__overlay--disabled.Icon--checkbox-unchecked {
   color: #ccc;
 }
@@ -397,5 +393,11 @@ textarea.Field--has-error:focus:hover,
 .cauldron--theme-dark .Radio__overlay--disabled,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-checked,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-unchecked {
-  color: #4c99a9;
+  color: #5d676f;
+}
+
+.Checkbox__overlay.Checkbox__overlay--focused,
+.Radio__overlay.Radio__overlay--focused {
+  border-radius: 5px;
+  box-shadow: 0 0 0 2px var(--focus-glow);
 }

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -137,7 +137,7 @@ textarea.Field--has-error,
   color: var(--field-border-color-error);
 }
 
-.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
+.Icon--checkbox-unchecked.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
   background-color: var(--field-icon-error-active-color);
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -184,15 +184,19 @@ textarea.Field--has-error:focus:hover,
   margin-bottom: 0;
 }
 
+.Checkbox__wrap,
+.Radio__wrap {
+  margin-top: 0;
+  margin-bottom: var(--space-smallest);
+}
+
 .Checkbox,
 .Radio {
   box-sizing: border-box;
   position: relative;
-  margin-top: 0;
   flex-direction: row-reverse;
   justify-content: flex-end;
   flex-wrap: nowrap;
-  margin-bottom: var(--space-smallest);
 }
 
 .Radio--inline {
@@ -202,8 +206,8 @@ textarea.Field--has-error:focus:hover,
   gap: var(--space-small);
 }
 
-.Checkbox:last-of-type,
-.Radio:last-of-type {
+.Checkbox__wrap:last-of-type,
+.Radio__wrap:last-of-type {
   margin-bottom: 0;
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -17,7 +17,12 @@
   --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--gray-60);
   --icon-inactive-color: var(--gray-90);
-  --icon-active-color: rgb(212, 221, 224, 0.25);
+  --icon-active-color: color-mix(
+    in srgb,
+    var(--accent-primary) 20%,
+    transparent
+  );
+  --icon-error-active-color: color-mix(in srgb, var(--error) 20%, transparent);
   --icon-checked-color: var(--accent-primary);
   --icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
   --icon-unchecked-disabled-color: var(--gray-40);
@@ -41,6 +46,12 @@
   --field-label-text-color: var(--white);
   --field-label-description-text-color: var(--accent-light);
   --icon-inactive-color: var(--white);
+  --icon-active-color: color-mix(in srgb, var(--accent-light) 20%, transparent);
+  --icon-error-active-color: color-mix(
+    in srgb,
+    var(--accent-danger) 20%,
+    transparent
+  );
   --icon-checked-color: var(--accent-light);
   --icon-checked-disabled-color: var(--stroke-dark);
   --icon-unchecked-disabled-color: var(--stroke-dark);
@@ -132,6 +143,10 @@ textarea.Field--has-error,
 
 .Checkbox__overlay.Field--has-error {
   color: var(--field-border-color-error);
+}
+
+.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
+  background-color: var(--icon-error-active-color);
 }
 
 input.Field--has-error:hover,
@@ -246,7 +261,7 @@ textarea.Field--has-error:focus:hover,
   text-align: left;
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);
-  padding-bottom: var(--space-half);
+  margin-bottom: var(--space-smallest);
   cursor: default;
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -16,7 +16,7 @@
   --field-label-text-color: var(--gray-90);
   --field-label-description-text-color: var(--gray-60);
   --input-min-width: 250px;
-  --focus-glow: rgba(181, 26, 209, 1);
+  --field-focus-ring-color: var(--focus-light);
 }
 
 .cauldron--theme-dark {
@@ -32,7 +32,7 @@
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
   --field-label-description-text-color: rgba(255, 255, 255, 0.8);
-  --focus-glow: rgba(235, 148, 255, 1);
+  --field-focus-ring-color: var(--focus-dark);
 }
 
 input,
@@ -334,7 +334,7 @@ textarea.Field--has-error:focus:hover,
 .Checkbox__overlay.Checkbox__overlay--focused,
 .Radio__overlay.Radio__overlay--focused {
   border-radius: 5px;
-  box-shadow: 0 0 0 2px var(--focus-glow);
+  box-shadow: 0 0 0 2px var(--field-focus-ring-color);
 }
 
 .Radio__overlay.Icon--radio-checked {
@@ -398,10 +398,4 @@ textarea.Field--has-error:focus:hover,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-checked,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-unchecked {
   color: var(--stroke-dark);
-}
-
-.Checkbox__overlay.Checkbox__overlay--focused,
-.Radio__overlay.Radio__overlay--focused {
-  border-radius: 5px;
-  box-shadow: 0 0 0 2px var(--focus-glow);
 }

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -397,7 +397,7 @@ textarea.Field--has-error:focus:hover,
 .cauldron--theme-dark .Radio__overlay--disabled,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-checked,
 .cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-unchecked {
-  color: #5d676f;
+  color: var(--stroke-dark);
 }
 
 .Checkbox__overlay.Checkbox__overlay--focused,

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -137,7 +137,7 @@ textarea.Field--has-error,
   color: var(--field-border-color-error);
 }
 
-.Icon--checkbox-unchecked.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
+.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
   background-color: var(--field-icon-error-active-color);
 }
 

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -14,9 +14,17 @@
   --field-background-color-disabled: #f7f7f7;
   --field-required-text-color: var(--gray-60);
   --field-label-text-color: var(--gray-90);
+  --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--gray-60);
+  --field-icon-inactive-color: var(--gray-90);
+  --field-icon-active-color: rgba(60, 122, 174, 0.25);
+  --field-icon-checked-color: var(--accent-primary);
+  --field-icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
+  --field-icon-unchecked-disabled-color: var(--gray-40);
+  --field-icon-focus-color: var(--focus-light);
+  --field-error-text-color: var(--error);
+  --field-error-border-color: var(--error);
   --input-min-width: 250px;
-  --field-focus-ring-color: var(--focus-light);
 }
 
 .cauldron--theme-dark {
@@ -32,7 +40,13 @@
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
   --field-label-description-text-color: rgba(255, 255, 255, 0.8);
-  --field-focus-ring-color: var(--focus-dark);
+  --field-icon-inactive-color: var(--white);
+  --field-icon-checked-color: var(--accent-light);
+  --field-icon-checked-disabled-color: var(--stroke-dark);
+  --field-icon-unchecked-disabled-color: var(--stroke-dark);
+  --field-error-text-color: var(--error);
+  --field-error-border-color: var(--error);
+  --field-icon-focus-color: var(--focus-dark);
 }
 
 input,
@@ -160,8 +174,8 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Error {
-  color: var(--error);
-  border-top: 1px solid var(--error);
+  color: var(--field-error-text-color);
+  border-top: 1px solid var(--field-error-border-color);
   text-align: left;
   font-size: var(--text-size-smallest);
   margin-top: var(--space-half);
@@ -243,7 +257,7 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Field__label--has-error .Field__required-text {
-  color: var(--error);
+  color: var(--field-label-error-text-color);
 }
 
 .Field__label--inline {
@@ -304,7 +318,7 @@ textarea.Field--has-error:focus:hover,
   box-sizing: border-box;
   cursor: pointer;
   border-radius: 3px;
-  color: #333;
+  color: var(--field-icon-inactive-color);
   margin-right: var(--space-half);
   align-self: flex-start;
 }
@@ -320,7 +334,7 @@ textarea.Field--has-error:focus:hover,
 
 .Radio__overlay:active:not(.Radio__overlay--disabled),
 .Checkbox__overlay:active:not(.Checkbox__overlay--disabled) {
-  background-color: rgba(60, 122, 174, 0.25);
+  background-color: var(--field-icon-active-color);
 }
 
 .Radio input[type='radio'] {
@@ -334,16 +348,22 @@ textarea.Field--has-error:focus:hover,
 .Checkbox__overlay.Checkbox__overlay--focused,
 .Radio__overlay.Radio__overlay--focused {
   border-radius: 5px;
-  box-shadow: 0 0 0 2px var(--field-focus-ring-color);
+  box-shadow: 0 0 0 2px var(--field-icon-focus-color);
 }
 
-.Radio__overlay.Icon--radio-checked {
-  color: #3c7aae;
+.Radio__overlay.Icon--radio-checked,
+.Checkbox__overlay.Icon--checkbox-checked {
+  color: var(--field-icon-checked-color);
 }
 
 .Radio__overlay--disabled.Icon--radio-checked,
+.Checkbox__overlay--disabled.Icon--checkbox-checked {
+  color: var(--field-icon-checked-disabled-color);
+}
+
+.Checkbox__overlay--disabled.Icon--checkbox-unchecked,
 .Radio__overlay--disabled.Icon--radio-unchecked {
-  color: #ccc;
+  color: var(--field-icon-unchecked-disabled-color);
 }
 
 .Field__label:hover ~ .Radio__overlay:not(.Radio__overlay--disabled),
@@ -359,43 +379,7 @@ textarea.Field--has-error:focus:hover,
   appearance: none;
 }
 
-.Checkbox__overlay.Icon--checkbox-checked {
-  color: #3c7aae;
-}
-
-.Checkbox__overlay--disabled.Icon--checkbox-checked {
-  color: #78a6d8;
-}
-
-.Checkbox__overlay--disabled.Icon--checkbox-unchecked {
-  color: #ccc;
-}
-
 .Field__label:hover ~ .Checkbox__overlay:not(.Checkbox__overlay--disabled),
 .Checkbox__overlay:hover:not(.Checkbox__overlay--disabled) {
   border: 1px solid currentColor;
-}
-
-/* Dark Theme */
-.cauldron--theme-dark {
-  --field-label-text-color: var(--white);
-}
-
-.cauldron--theme-dark .Radio__overlay,
-.cauldron--theme-dark .Checkbox__overlay {
-  color: var(--white);
-}
-
-.cauldron--theme-dark .Checkbox__overlay.Icon--checkbox-checked {
-  color: var(--accent-light);
-}
-
-.cauldron--theme-dark .Checkbox__overlay.Field--has-error {
-  color: var(--accent-danger);
-}
-
-.cauldron--theme-dark .Radio__overlay--disabled,
-.cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-checked,
-.cauldron--theme-dark .Checkbox__overlay--disabled.Icon--checkbox-unchecked {
-  color: var(--stroke-dark);
 }

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -17,16 +17,8 @@
   --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--gray-60);
   --field-icon-inactive-color: var(--gray-90);
-  --field-icon-active-color: color-mix(
-    in srgb,
-    var(--accent-primary) 20%,
-    transparent
-  );
-  --field-icon-error-active-color: color-mix(
-    in srgb,
-    var(--error) 20%,
-    transparent
-  );
+  --field-icon-active-color: rgba(60, 122, 174, 0.25);
+  --field-icon-error-active-color: rgba(217, 50, 81, 0.25);
   --field-icon-checked-color: var(--accent-primary);
   --field-icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
   --field-icon-unchecked-disabled-color: var(--gray-40);
@@ -50,16 +42,8 @@
   --field-label-text-color: var(--white);
   --field-label-description-text-color: var(--accent-light);
   --field-icon-inactive-color: var(--white);
-  --field-icon-active-color: color-mix(
-    in srgb,
-    var(--accent-light) 20%,
-    transparent
-  );
-  --field-icon-error-active-color: color-mix(
-    in srgb,
-    var(--accent-danger) 20%,
-    transparent
-  );
+  --field-icon-active-color: rgba(212, 221, 224, 0.25);
+  --field-icon-error-active-color: rgba(254, 109, 107, 0.25);
   --field-icon-checked-color: var(--accent-light);
   --field-icon-checked-disabled-color: var(--stroke-dark);
   --field-icon-unchecked-disabled-color: var(--stroke-dark);

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -270,9 +270,9 @@ textarea.Field--has-error:focus:hover,
   margin-top: var(--space-smallest);
 }
 
-.Field__label .Checkbox__label,
-.Field__label .Radio__label {
-  margin-bottom: var(--space-smallest);
+.Checkbox__label,
+.Radio__label {
+  font-weight: var(--font-weight-normal);
 }
 
 .Field__required-text {

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -286,6 +286,7 @@ textarea.Field--has-error:focus:hover,
   line-height: 1;
   margin-left: calc(24px + 2px + var(--space-half));
   cursor: default;
+  display: flex;
 }
 
 .Icon + .Error {

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -145,7 +145,7 @@ textarea.Field--has-error,
   color: var(--field-border-color-error);
 }
 
-.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
+.Icon--checkbox-unchecked.Checkbox__overlay:active.Field--has-error:not(.Checkbox__overlay--disabled) {
   background-color: var(--icon-error-active-color);
 }
 
@@ -192,6 +192,7 @@ textarea.Field--has-error:focus:hover,
   color: var(--error-text-color);
   border-top: 1px solid var(--error-border-color);
   text-align: left;
+  font-weight: var(--font-weight-normal);
   font-size: var(--text-size-smallest);
   margin-top: var(--space-half);
   margin-left: calc(var(--icon-size) + 2px + var(--space-half));
@@ -219,6 +220,11 @@ textarea.Field--has-error:focus:hover,
   margin-bottom: var(--space-smallest);
 }
 
+.Checkbox__wrap:last-of-type,
+.Radio__wrap:last-of-type {
+  margin-bottom: 0;
+}
+
 .Radio--inline .Radio__wrap {
   margin-bottom: 0;
 }
@@ -239,11 +245,6 @@ textarea.Field--has-error:focus:hover,
   gap: var(--space-small);
 }
 
-.Checkbox__wrap:last-of-type,
-.Radio__wrap:last-of-type {
-  margin-bottom: 0;
-}
-
 .Checkbox .Field__label,
 .Radio .Field__label {
   margin-bottom: 0;
@@ -252,7 +253,13 @@ textarea.Field--has-error:focus:hover,
 
 .Checkbox + .Field__labelDescription,
 .Radio + .Field__labelDescription {
-  margin-top: var(--space-smallest);
+  margin-top: var(--space-half);
+  margin-bottom: var(--space-small);
+}
+
+.Checkbox__wrap:last-of-type .Checkbox + .Field__labelDescription,
+.Radio__wrap:last-of-type .Radio + .Field__labelDescription {
+  margin-bottom: 0;
 }
 
 .Field__label {
@@ -261,8 +268,14 @@ textarea.Field--has-error:focus:hover,
   text-align: left;
   color: var(--field-label-text-color);
   font-size: var(--text-size-small);
+  font-weight: var(--font-weight-medium);
   margin-bottom: var(--space-smallest);
   cursor: default;
+}
+
+.Field__label .Checkbox__label,
+.Field__label .Radio__label {
+  margin-bottom: var(--space-smallest);
 }
 
 .Field__required-text {
@@ -324,6 +337,7 @@ textarea.Field--has-error:focus:hover,
   flex-basis: 100%;
   color: var(--field-label-description-text-color);
   font-size: var(--text-size-small);
+  font-weight: var(--font-weight-normal);
   line-height: 1;
   margin-top: var(--space-half);
   margin-left: calc(24px + 2px + var(--space-half));


### PR DESCRIPTION
Closes #627 
Relates to #949 
Relates to #1034 

Relates to Walnut [#5739](https://github.com/dequelabs/walnut/issues/5739)

Current behavior:
https://github.com/dequelabs/cauldron/assets/60084578/b94f6133-0c7c-4368-9277-6736618301f9

---

With .Checkbox, .Radio `flexwrap` changed to `nowrap`:
https://github.com/dequelabs/cauldron/assets/60084578/ee399c8d-88c7-4b37-be61-2e2b4403bb21
<img width="404" alt="no align-item self" src="https://github.com/dequelabs/cauldron/assets/60084578/7f97f09e-974b-44d1-bd48-8701cd2035b8">

w/ 4th option under wrapping line:
https://github.com/dequelabs/cauldron/assets/60084578/4dbaa581-63a3-41e5-9a02-d0033e09c6e0

---

With .Checkbox, .Radio `flexwrap` changed to `nowrap` and .Radio__overlay given `align-self` of `flex-start` (implemented):
https://github.com/dequelabs/cauldron/assets/60084578/6142d258-e011-451f-9427-bff88b6bcee9
<img width="404" alt="align-item self" src="https://github.com/dequelabs/cauldron/assets/60084578/0c40d66c-412f-47a6-917f-a483b92c9677">

w/ 4th option under wrapping line:
https://github.com/dequelabs/cauldron/assets/60084578/fbe68121-6973-4831-af4b-12316976020d



