### PR TITLE
fix: sync Tag component with uxpin

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -93,8 +93,7 @@ button.Link {
 
 .Button--primary:focus:before,
 .Button--secondary:focus:before,
-.Button--error:focus:before,
-.Button--tag:focus:before {
+.Button--error:focus:before {
   box-shadow: 0 0 1px 2px var(--button-focus-ring-color, --focus);
 }
 

--- a/packages/styles/tag.css
+++ b/packages/styles/tag.css
@@ -9,7 +9,7 @@
   --tag-text-color: var(--white);
   --tag-label-text-color: var(--accent-light);
   --tag-background-color: var(--accent-medium);
-  --tag-border-color: var(--accent-medium);
+  --tag-border-color: var(--stroke-dark);
 }
 
 .Tag {

--- a/packages/styles/tag.css
+++ b/packages/styles/tag.css
@@ -24,11 +24,6 @@
   padding: 2px 8px;
   font-weight: var(--font-weight-medium);
 }
-.Tag:focus {
-  outline: none;
-  box-shadow: rgb(255, 255, 255) 0px 0px 0px 2px,
-    rgb(181, 26, 209) 0px 0px 0px 4px;
-}
 
 .Tag__label {
   color: var(--tag-label-text-color);

--- a/packages/styles/tag.css
+++ b/packages/styles/tag.css
@@ -24,6 +24,11 @@
   padding: 2px 8px;
   font-weight: var(--font-weight-medium);
 }
+.Tag:focus {
+  outline: none;
+  box-shadow: rgb(255, 255, 255) 0px 0px 0px 2px,
+    rgb(181, 26, 209) 0px 0px 0px 4px;
+}
 
 .Tag__label {
   color: var(--tag-label-text-color);


### PR DESCRIPTION
I fixed the thicker focus ring for button tags and corrected the border when in dark mode (it should be noted that it is still barely visible on the current background which differs from the background color in UXPin).

Closes: https://github.com/dequelabs/cauldron/issues/1055