### PR TITLE
feat: add support for tabIndex and other div element props to radiogroup

### DIFF
--- a/packages/react/src/components/RadioGroup/index.tsx
+++ b/packages/react/src/components/RadioGroup/index.tsx
@@ -9,7 +9,8 @@ export interface RadioItem extends React.InputHTMLAttributes<HTMLInputElement> {
   labelDescription?: React.ReactNode;
 }
 
-export interface RadioGroupProps {
+export interface RadioGroupProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   name?: string;
   className?: string;
   radios: RadioItem[];


### PR DESCRIPTION
Relates to [Walnut #5739](https://github.com/dequelabs/walnut/issues/5739)