### PR TITLE
fix(styles): fix bug where Error class changes are applied globally

### DIFF
--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -188,8 +188,6 @@ textarea.Field--has-error:focus:hover,
   padding-left: var(--space-half);
 }
 
-.Field .Error,
-.Field__select .Error,
 .Checkbox__wrap .Error {
   border-top: 1px solid var(--field-error-border-color);
   margin-top: var(--space-half);

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -185,12 +185,11 @@ textarea.Field--has-error:focus:hover,
   text-align: left;
   font-size: var(--text-size-smallest);
   font-weight: var(--font-weight-normal);
-  padding-left: var(--space-half);
 }
 
 .Checkbox__wrap .Error {
-  border-top: 1px solid var(--field-error-border-color);
   margin-top: var(--space-half);
+  border-top: 1px solid var(--field-error-border-color);
   margin-left: calc(var(--icon-size) + 2px + var(--space-half));
   padding: var(--space-half) 0;
 }

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -181,11 +181,17 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Error {
-  color: var(--field-error-text-color);
-  border-top: 1px solid var(--field-error-border-color);
+  color: var(--error);
   text-align: left;
-  font-weight: var(--font-weight-normal);
   font-size: var(--text-size-smallest);
+  font-weight: var(--font-weight-normal);
+  padding-left: var(--space-half);
+}
+
+.Field .Error,
+.Field__select .Error,
+.Checkbox__wrap .Error {
+  border-top: 1px solid var(--field-error-border-color);
   margin-top: var(--space-half);
   margin-left: calc(var(--icon-size) + 2px + var(--space-half));
   padding: var(--space-half) 0;

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -181,7 +181,7 @@ textarea.Field--has-error:focus:hover,
 }
 
 .Error {
-  color: var(--error);
+  color: var(--field-error-text-color);
   text-align: left;
   font-size: var(--text-size-smallest);
   font-weight: var(--font-weight-normal);


### PR DESCRIPTION
Relates to bug noted in [this Slack thread](https://deque.slack.com/archives/G017VP5SCUB/p1690478003393319)

Reverts [changes to Error class styles](https://github.com/dequelabs/cauldron/pull/1110/files#r1276602901), and scopes new changes to their respective elements 