### PR TITLE
fix(breadcrumbs): amend `/` separator colours in light and dark mode

### DIFF
--- a/packages/styles/breadcrumb.css
+++ b/packages/styles/breadcrumb.css
@@ -7,8 +7,13 @@
   margin: 0;
 }
 
-.Breadcrumb__Separator {
-  color: var(--gray-40);
+.cauldron--theme-light .Breadcrumb__Separator {
+  color: var(--gray-60);
+  padding: 0 var(--space-half);
+}
+
+.cauldron--theme-dark .Breadcrumb__Separator {
+  color: var(--accent-light);
   padding: 0 var(--space-half);
 }
 


### PR DESCRIPTION
This PR updates the colours used for the `/` in light and dark mode. See https://github.com/dequelabs/walnut/issues/6291#issuecomment-1668485052 for reference. 