### PR TITLE
fix(table): adjust border table thickness and sortable table icon

### DIFF
--- a/docs/pages/components/Table.mdx
+++ b/docs/pages/components/Table.mdx
@@ -264,6 +264,10 @@ function SortableTableExample() {
 }
 ```
 
+<Note>
+  As a best practice, when a table has sorted columns an author should indicate which column is currently sorted by setting the sort direction for the active sorted column.
+</Note>
+
 ## Props
 
 ### Table

--- a/packages/react/src/components/Icon/icons/table-sort-ascending.svg
+++ b/packages/react/src/components/Icon/icons/table-sort-ascending.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -100 320 720">
   <!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
   <path
     fill="currentColor"

--- a/packages/react/src/components/Icon/icons/table-sort-descending.svg
+++ b/packages/react/src/components/Icon/icons/table-sort-descending.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -100 320 720">
   <!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
   <path
     fill="currentColor"

--- a/packages/styles/table.css
+++ b/packages/styles/table.css
@@ -117,6 +117,10 @@
   border: 1px solid var(--gray-40);
 }
 
+.Table--border .TableHeader {
+  border-bottom: 2px solid var(--gray-40);
+}
+
 .cauldron--theme-dark .Table--border,
 .cauldron--theme-dark .Table--border .TableHeader,
 .cauldron--theme-dark .Table--border .TableFooter,


### PR DESCRIPTION
- adds thickness to bordered tables to match UXPin designs
- adds a note for recommended best practices when sorting tables
- adjusts the table-sort-ascending and table-sort-descending icons to match UXPin designs

Closes Issue: #1053 

Testing:

Confirm bordered table borders and sort icons [now match their UXPIN counterparts](https://app.uxpin.com/design-system/c933c74928e2195cc540/ui-patterns/213536)