### PR TITLE
fix: corrected color of button tags on hover in light theme.

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -88,7 +88,7 @@ button.Link {
 }
 
 .Button--tag:not([disabled]):not([aria-disabled='true']):hover:before {
-  box-shadow: 0 0 0 1px var(--button-outline-color-primary);
+  box-shadow: 0 0 0 1px var(--button-outline-color-secondary);
 }
 
 .Button--primary:focus:before,


### PR DESCRIPTION
Closes #1156

Updated the light theme hover button tag border to be #333 for button tags