### PR TITLE
docs: prevent propName from wrapping in component props

### DIFF
--- a/docs/components/ComponentLayout.css
+++ b/docs/components/ComponentLayout.css
@@ -125,6 +125,15 @@ ul.Component__list li {
   text-align: center;
 }
 
+table.Component__Props tr td:first-child,
+ul.Component__Props
+  li
+  dl
+  .DescriptionList__item:first-child
+  .DescriptionList__details {
+  white-space: nowrap;
+}
+
 ul.Component__Props {
   list-style-type: none;
   margin: 0 !important;


### PR DESCRIPTION
Component props were sometimes wrapping in the middle of of the prop name. Updating that column/item to not wrap should help make these look a little bit cleaner and should not introduce a11y overflow issues as prop names are generally fairly short.

![""](https://github.com/dequelabs/cauldron/assets/1062039/c0284b12-a639-4963-ad7a-647a720f63a2)
