### PR TITLE
docs: button typo

### DIFF
--- a/docs/pages/components/Link.mdx
+++ b/docs/pages/components/Link.mdx
@@ -42,7 +42,7 @@ An example of a secondary button is a "Cancel" button next to a "Submit" button 
 </Link>
 ```
 
-### Buttin (with thin modifier)
+### Button (with thin modifier)
 
 A link with visual styling applied to make it look like a button with reduced height.
 


### PR DESCRIPTION
Fixes a typo where "button" was spelled incorrectly.