### PR TITLE
fix(styles): fix color contrast issue for required text on TextField with error

### DIFF
--- a/docs/pages/components/TextField.mdx
+++ b/docs/pages/components/TextField.mdx
@@ -53,6 +53,7 @@ import { TextField } from '@deque/cauldron-react'
   <TextField
     label="Error"
     error="This field has an error!"
+    required
   />
 </FieldWrap>
 ```

--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -41,6 +41,7 @@
   --field-background-color-disabled: #5d676f;
   --field-required-text-color: var(--white);
   --field-label-text-color: var(--white);
+  --field-label-error-text-color: var(--error);
   --field-label-description-text-color: var(--accent-light);
   --field-icon-inactive-color: var(--white);
   --field-icon-active-color: rgba(212, 221, 224, 0.25);


### PR DESCRIPTION
Found a color contrast issue in dark mode when TextField was an an error state and required. Matching the color with what's currently in our design system.

## Before

![required text above text field with poor color contrast](https://github.com/dequelabs/cauldron/assets/1062039/2938efe5-4415-412e-ad12-8fe92ae57e5f)

## After

![required text above text field with correct color contrast](https://github.com/dequelabs/cauldron/assets/1062039/1ffb44cc-2aa8-4807-a14d-4b6d80cd3981)
