### PR TITLE
docs: fix grammar and typos

### DIFF
--- a/docs/pages/components.mdx
+++ b/docs/pages/components.mdx
@@ -8,7 +8,7 @@ path: /component-guidelines
 
 ### Primitive Components
 
-Primitive components are the "building blocks" of cauldron and are intended to be simple and basic in their functionality. These components are not necessarily intended to be used in isolation, but composed and connected together to build different types of UI. Some examples of primitive components would be `Button`, `Link`, `Icon`, or `Tag`.
+Primitive components are the "building blocks" of Cauldron and are intended to be simple and basic in their functionality. These components are not necessarily intended to be used in isolation but are composed and connected to build different types of UI. Some examples of primitive components would be `Button`, `Link`, `Icon`, or `Tag`.
 
 ### Pattern Components
 
@@ -16,7 +16,7 @@ Pattern components are collections of components intended to replicate common pa
 
 ### Helper Components
 
-Helper components are components that wrap components to provide specific functionality but don't necessarily render ui directly. Some examples of this would be `ClickOutsideListener` to handle clicks outside of a component, or `ThemeProvider` to be able to control setting the theme of components.
+Helper components are components that wrap components to provide specific functionality but don't necessarily render UI directly. Some examples of this would be `ClickOutsideListener` to handle clicks outside of a component, or `ThemeProvider` to be able to control setting the theme of components.
 
 ## Component Standards
 

--- a/docs/pages/components/Notice.mdx
+++ b/docs/pages/components/Notice.mdx
@@ -1,6 +1,6 @@
 ---
 title: Notice
-description: A notification banner - similar to a Toast, but allows for more flexibile positioning and control.
+description: A notification banner - similar to a Toast, but allows for more flexible positioning and control.
 source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/Notice/Notice.tsx
 ---
 

--- a/docs/pages/components/OptionsMenu.mdx
+++ b/docs/pages/components/OptionsMenu.mdx
@@ -36,7 +36,7 @@ import {
 
 ### Alternate Trigger
 
-The trigger can be any type of component that acts as a button, allowing for advanced      customization of the trigger:
+The trigger can be any type of component that acts as a button, allowing for advanced customization of the trigger:
 
 ```jsx example
 <OptionsMenu

--- a/docs/pages/components/Pagination.mdx
+++ b/docs/pages/components/Pagination.mdx
@@ -26,7 +26,7 @@ import { Pagination } from '@deque/cauldron-react'
 
 ### Customizing Pagination Labels
 
-The pagination component sets labels by default, but these labels can be overridden if you need to customize the labels based on the types of items that are being displayed, or to provide the labels in a different locale.
+The pagination component sets labels by default, but these labels can be overridden if you need to customize the labels based on the types of items that are being displayed or to provide the labels in a different locale.
 
 ```jsx example
 <Pagination
@@ -156,7 +156,7 @@ The pagination hook returns an object containing the properties `pagination`, a 
     {
       name: 'thin',
       type: 'boolean',
-      description: 'Displays pagination with "thin" modifier (reduces height of buttons and spacing)'
+      description: 'Displays pagination with "thin" modifier (reduces the height of buttons and spacing)'
     }
   ]}
 />

--- a/docs/pages/components/Panel.mdx
+++ b/docs/pages/components/Panel.mdx
@@ -20,7 +20,7 @@ import { Panel, PanelHeader, PanelContent } from '@deque/cauldron-react';
 
 ### Panel Component
 
-At its simplest, a `Panel` is a styled semantic HTML `<section>` element with with content inside.
+At its simplest, a `Panel` is a styled semantic HTML `<section>` element with content inside.
 
 <Note>
   If your section needs to have an accessible name, be sure to include an
@@ -118,7 +118,7 @@ In the following example, we are using CSS `columns` to create a two-column layo
 
 ### Header With Flexbox Content
 
-A common use-case for the `Panel` is to display a header with a button or other content. To achieve this, you
+A common use case for the `Panel` is to display a header with a button or other content. To achieve this, you
 can compose the `Panel` using a `PanelHeader` with a flexbox layout.
 
 ```jsx example

--- a/docs/pages/components/Pointout.mdx
+++ b/docs/pages/components/Pointout.mdx
@@ -48,11 +48,11 @@ import { Pointout } from '@deque/cauldron-react'
 
 ### Targeted First Time Point Outs
 
-First time point outs can specify a `target` prop that will dynamically position itself pointing to the target element on render. Under the hood, we are using Portals to render the element to `document.body` but you can customize the portal location by setting the `portal` prop with your own element or ref.
+First time point outs can specify a `target` prop that will dynamically position itself pointing to the target element on render. Under the hood, we are using Portals to render the element to `document.body` but you can customize the portal location by setting the `portal` prop with your element or ref.
 
 Positioning tracks `window.resize` events so that the First Time Point Out should always be positioned correctly no matter the context. If your component has a side effect where a target's position is changed that does not cause a trigger a resize, you can call `forceUpdate()` on the First Time Point out to reset the positioning.
 
-Please be aware that when using a `target` prop, the First Time Point Out's children are duplicated in order to address accessibility concerns. Any ids that are present in children will be sanitized in order to prevent duplicate ids from existing in the DOM. These ids will not be available to style, so it's recommended that you use classes or attribute to target styling instead.
+Please be aware that when using a `target` prop, the First Time Point Out's children are duplicated to address accessibility concerns. Any ids that are present in children will be sanitized to prevent duplicate ids from existing in the DOM. These ids will not be available to style, so it's recommended that you use classes or attributes to target styling instead.
 
 <Note>
   Any ids/attributes of children will be applied to the offscreen/screen-reader-only ftpo, so things like aria-labelledby and aria-describedby etc will still work as expected.

--- a/docs/pages/components/Popover.mdx
+++ b/docs/pages/components/Popover.mdx
@@ -51,7 +51,7 @@ function PromptPopoverExample() {
 
 ### Custom Popover
 
-For custom purposes you can use "custom" variant, which is default.
+For custom purposes, you can use the "custom" variant, which is the default.
 
 ```jsx example
 function CustomPopoverExample() {
@@ -118,13 +118,13 @@ function CustomPopoverExample() {
       name: 'infoText',
       required: true,
       type: 'string',
-      description: 'Information text to show some warning or useful information in Prompt variant of the component. Please note that required is only for "Prompt" variant.',
+      description: 'Information text to show some warning or useful information in Prompt variant of the component. Please note that required is only for the "Prompt" variant.',
     },
     {
       name: 'onApply',
       required: true,
       type: 'function',
-      description: 'Callback, which is used for Apply button in Prompt variant of the component. Please note, that is only required for Prompt variant',
+      description: 'Callback, which is used for the Apply button in the Prompt variant of the component. Please note, that this is only required for the "Prompt" variant',
     },
     {
       name: 'placement',
@@ -153,13 +153,13 @@ function CustomPopoverExample() {
     {
       name: 'applyButtonText',
       type: 'string',
-      description: 'Label for button, which is used to apply action in Prompt variant of the popover',
+      description: 'Label for the button, which is used to apply action in Prompt variant of the popover',
       defaultValue: 'Apply'
     },
     {
       name: 'closeButtonText',
       type: 'string',
-      description: 'Label for button, which is used to close popover in Prompt variant of the component',
+      description: 'Label for the button, which is used to close popover in Prompt variant of the component',
       defaultValue: 'Close'
     },
     {

--- a/docs/pages/components/ProgressBar.mdx
+++ b/docs/pages/components/ProgressBar.mdx
@@ -31,7 +31,7 @@ import { ProgressBar } from '@deque/cauldron-react'
 
 ### Animated Progress
 
-If the progress indicates that some activity is currently progressing, the progress bar will will update the current progress based on the value of the `progress` prop:
+If the progress indicates that some activity is currently progressing, the progress bar will update the current progress based on the value of the `progress` prop:
 
 ```jsx example
 function ProgressExample() {

--- a/docs/pages/components/RadioGroup.mdx
+++ b/docs/pages/components/RadioGroup.mdx
@@ -82,7 +82,7 @@ import { RadioGroup } from '@deque/cauldron-react'
 
 ### Inline Layout
 
-If your list of options is short, `RadioGroup` can optionally accept a `inline` prop to display the radio items in a horizontal orientation instead of vertical.
+If your list of options is short, `RadioGroup` can optionally accept an `inline` prop to display the radio items in a horizontal orientation instead of vertically.
 
 ```jsx example
 <FieldWrap>

--- a/docs/pages/components/Scrim.mdx
+++ b/docs/pages/components/Scrim.mdx
@@ -13,7 +13,7 @@ import { Scrim } from '@deque/cauldron-react'
 A scrim is a component that is a semi-transparent overlay over the viewport to provide emphasis, focus, or draw attention to certain information. This is most commonly used as a backdrop for dialogs, modals, and other elements that need primary focus on the page.
 
 <Note>
-  It is recommended that a focus trap is used to contain keyboard focus within the element that has a primary focus. [Alert](./Alert) and [Modal](./Modal) both use [react-focus-trap](https://www.npmjs.com/package/focus-trap-react) to manage focus. If `Scrim` is being used with other components, a focus trap may be needed to prevent certain keyboard accessibility issues.
+  It is recommended that a focus trap is used to contain keyboard focus within the element that has primary focus. [Alert](./Alert) and [Modal](./Modal) both use [react-focus-trap](https://www.npmjs.com/package/focus-trap-react) to manage focus. If `Scrim` is being used with other components, a focus trap may be needed to prevent certain keyboard accessibility issues.
 </Note>
 
 ## Example

--- a/docs/pages/components/Scrim.mdx
+++ b/docs/pages/components/Scrim.mdx
@@ -10,10 +10,10 @@ import { Scrim, Button } from '@deque/cauldron-react'
 import { Scrim } from '@deque/cauldron-react'
 ```
 
-A scrim is a component that is a semi-transparent overlay over the viewport to provide emphasis, focus, or draw attention to certain information. This is most commonly used as a backdrop for dialogs and modals and other elements that need primary focus on the page.
+A scrim is a component that is a semi-transparent overlay over the viewport to provide emphasis, focus, or draw attention to certain information. This is most commonly used as a backdrop for dialogs, modals, and other elements that need primary focus on the page.
 
 <Note>
-  It is recommended that a focus trap is used to contain keyboard focus within the element that has primary focus. [Alert](./Alert) and [Modal](./Modal) both use [react-focus-trap](https://www.npmjs.com/package/focus-trap-react) to manage focus. If `Scrim` is being used with other components, a focus trap may be needed to prevent certain keyboard accessibility issues.
+  It is recommended that a focus trap is used to contain keyboard focus within the element that has a primary focus. [Alert](./Alert) and [Modal](./Modal) both use [react-focus-trap](https://www.npmjs.com/package/focus-trap-react) to manage focus. If `Scrim` is being used with other components, a focus trap may be needed to prevent certain keyboard accessibility issues.
 </Note>
 
 ## Example

--- a/docs/pages/components/Select.mdx
+++ b/docs/pages/components/Select.mdx
@@ -149,7 +149,7 @@ Select can be uncontrolled or controlled. For an uncontrolled component, use `de
 
 ### Controlled
 
-For a controlled select, use `value` to set the currently selected value of the listed options. You must also use this in conjunction with `onChange` in order for the value to get updated on change.
+For a controlled select, use `value` to set the currently selected value of the listed options. You must also use this in conjunction with `onChange` for the value to get updated on change.
 
 ```jsx example
 function ControlledSelectExample() {
@@ -243,7 +243,7 @@ function OptionsExample() {
     {
       name: 'value',
       type: 'string',
-      description: 'Use for "controlled" selects. Caller is responsible for managing the value of the select element.'
+      description: 'Use for "controlled" selects. The caller is responsible for managing the value of the select element.'
     },
     {
       name: 'defaultValue',

--- a/docs/pages/components/Stepper.mdx
+++ b/docs/pages/components/Stepper.mdx
@@ -10,7 +10,7 @@ import { Stepper, Step } from '@deque/cauldron-react'
 import { Stepper, Step } from '@deque/cauldron-react'
 ```
 
-Stepper is a segmented progress list that displays the current state of a multi-stepped process marking the current active step with `aria-current="step"`. This component is commonly used in wizard-like workflows.
+Stepper is a segmented progress list that displays the current state of a multi-stepped process marking the currently active step with `aria-current="step"`. This component is commonly used in wizard-like workflows.
 
 ## Examples
 
@@ -64,7 +64,7 @@ For more compact steppers, the additional descriptive information can be include
 
 <ComponentProps
   children={{
-    description: 'children to be rendered as the step\'s visible label (if not visible label is desired, use the "tooltip" prop instead)'
+    description: 'children to be rendered as the step\'s visible label (if a not visible label is desired, use the "tooltip" prop instead)'
   }}
   className={true}
   props={[

--- a/docs/pages/components/Stepper.mdx
+++ b/docs/pages/components/Stepper.mdx
@@ -64,7 +64,7 @@ For more compact steppers, the additional descriptive information can be include
 
 <ComponentProps
   children={{
-    description: 'children to be rendered as the step\'s visible label (if a not visible label is desired, use the "tooltip" prop instead)'
+    description: 'children to be rendered as the step\'s visible label (if no visible label is desired, use the "tooltip" prop instead)'
   }}
   className={true}
   props={[

--- a/docs/pages/components/Tabs.mdx
+++ b/docs/pages/components/Tabs.mdx
@@ -165,7 +165,7 @@ function ThinTabs() {
       name: 'target',
       required: true,
       type: ['React.RefObject<HTMLDivElement>', 'HTMLElement'],
-      description: 'Pointer to the targeted TabPanel to display when tab is active.'
+      description: 'Pointer to the targeted TabPanel to display when the tab is active.'
     }
   ]}
 />

--- a/docs/pages/components/Toast.mdx
+++ b/docs/pages/components/Toast.mdx
@@ -176,7 +176,7 @@ function NonDismissibleToastExample() {
       name: 'dismissible',
       type: 'boolean',
       defaultValue: 'true',
-      description: 'Whether or not the user is able to dismiss the toast.'
+      description: 'Whether or not the user can dismiss the toast.'
     },
     {
       name: 'toastRef',

--- a/docs/pages/components/Tooltip.mdx
+++ b/docs/pages/components/Tooltip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooltip
-description: A small text box that gives more information about a UI element when a user hovers over or focuses it.
+description: A small text box that gives more information about a UI element when a user hovers over or focuses on it.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Tooltip/index.tsx
 ---
 

--- a/docs/pages/components/TooltipTabstop.mdx
+++ b/docs/pages/components/TooltipTabstop.mdx
@@ -1,6 +1,6 @@
 ---
 title: TooltipTabstop
-description: A keyboard accesible tooltip for non-interactive elements.
+description: A keyboard-accesible tooltip for non-interactive elements.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/TooltipTabstop/index.tsx
 ---
 
@@ -10,7 +10,7 @@ import { TooltipTabstop, Icon } from '@deque/cauldron-react'
 import { TooltipTabstop } from '@deque/cauldron-react'
 ```
 
-This component allows for a keyboard user to access additional information or description for an element that is non-interactive. Some examples of this would be a help icon that provides additional context for a particular feature, or a progress item that provides numeric steps with additional contextual information about each step.
+This component allows for a keyboard user to access additional information or descriptions for a non-interactive element. Some examples of this would be a help icon that provides additional context for a particular feature, or a progress item that provides numeric steps with additional contextual information about each step.
 
 <Note>
   Be sure to always include an accessible name if rendering something visual that does not have any text content, like an image or an icon - or else the underlying button will be inaccessible to users using assistive technology (AT).

--- a/docs/pages/components/TopBar.mdx
+++ b/docs/pages/components/TopBar.mdx
@@ -110,7 +110,7 @@ In addition to navigational items, the `MenuBar` can also contain a dropdown men
     {
       name: 'onClick',
       type: 'function',
-      description: 'Callback when item is clicked.'
+      description: 'Callback when the item is clicked.'
     },
     {
       name: 'onKeyDown',
@@ -121,7 +121,7 @@ In addition to navigational items, the `MenuBar` can also contain a dropdown men
       name: 'autoClickLink',
       type: 'boolean',
       defaultValue: 'true',
-      description: 'Automatically clicks links when click occurs on TopBarItem.'
+      description: 'Automatically clicks links when a click occurs on TopBarItem.'
     },
     {
       name: 'menuItemRef',

--- a/docs/pages/components/TwoColumnPanel.mdx
+++ b/docs/pages/components/TwoColumnPanel.mdx
@@ -30,7 +30,7 @@ import {
 
 ### Default
 
-`TwoColumnPanel` takes in a set of columns, `ColumnLeft` and `ColumnRight` with the left column containing the list of items to choose from and the right column intended to be the currently selected item. It is expected that accessible names are provided for both of the left/right column via `aria-label` or `aria-labelledby`.
+`TwoColumnPanel` takes in a set of columns, `ColumnLeft` and `ColumnRight` with the left column containing the list of items to choose from and the right column intended to be the currently selected item. It is expected that accessible names are provided for both of the left/right columns via `aria-label` or `aria-labelledby`.
 
 ```jsx example
 function TwoColumnPanelExample() {
@@ -100,7 +100,7 @@ function TwoColumnPanelExample() {
 
 ### With Optional Group Headings
 
-The list of items can also contain optional group headings if the list of items needs to be segmented. This can be combined with [Breadcrumb](./Breadcrumb) to group sections of provide a hierarchical navigation context.
+The list of items can also contain optional group headings if the list of items needs to be segmented. This can be combined with [Breadcrumb](./Breadcrumb) to group sections to provide a hierarchical navigation context.
 
 ```jsx example
 function TwoColumnPanelGroupedItemsExample() {

--- a/docs/pages/intro.mdx
+++ b/docs/pages/intro.mdx
@@ -7,7 +7,7 @@ index: 1
 
 ## Purpose
 
-Friends don’t let friends ship inaccessible code! These accessible packages include everything from typography and colors, to components like custom form controls. The design and interactions shown throughout this site are intended to show how Deque provides accessible experiences for the users of our own products - through the use of common, accessible components like these.
+Friends don’t let friends ship inaccessible code! These accessible packages include everything from typography and colors to components like custom form controls. The design and interactions shown throughout this site are intended to show how Deque provides accessible experiences for the users of our own products - through the use of common, accessible components like these.
 
 ## Usage
 
@@ -53,7 +53,7 @@ import '@deque/cauldron-react/lib/cauldron.css'
 
 If you're interested in contributing to Cauldron, you can check out our [contribution guide](https://github.com/dequelabs/cauldron/blob/develop/CONTRIBUTING.md) as well as our [code of conduct](https://github.com/dequelabs/cauldron/blob/develop/CODE_OF_CONDUCT.md).
 
-Found a bug or have a feature request? [Open an issue!](https://github.com/dequelabs/cauldron/issues/new/choose)
+Did you find a bug or have a feature request? [Open an issue!](https://github.com/dequelabs/cauldron/issues/new/choose)
 
 ## More Accessibility Tools
 

--- a/docs/pages/styles.mdx
+++ b/docs/pages/styles.mdx
@@ -10,7 +10,7 @@ Cauldron is divided into two parts, [cauldron-react](https://github.com/dequelab
 
 ### Creating Styles
 
-We use [BEM](http://getbem.com/introduction/) for our CSS naming conventions. Examples for a mythical "Calendar" component as follows:
+We use [BEM](http://getbem.com/introduction/) for our CSS naming conventions. Examples of a mythical "Calendar" component are as follows:
 
 Styles always start with the component name, uppercased:
 
@@ -42,7 +42,7 @@ For modifiers, such as variants or states, these values would be delimited by tw
 
 ### Variables
 
-It is inevitable that some flexibility in components may be needed, and this flexibility can be provided via [css variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties). These variables can be a global variable, as defined in [variables.css](https://github.com/dequelabs/cauldron/blob/develop/packages/styles/variables.css) or locally in a component's individual css file.
+Some flexibility in components may inevitably be needed, and this flexibility can be provided via [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties). These variables can be a global variable, as defined in [variables.css](https://github.com/dequelabs/cauldron/blob/develop/packages/styles/variables.css) or locally in a component's individual CSS file.
 
 <Note>
   Component level variables should not be set in `variables.css`, this is reserved for things that should apply globally across all cauldron components. If a component variable needs to use a global variable, it should use a cascading component variable that inherits from the global variable.
@@ -68,7 +68,7 @@ A component variable name should be as descriptive as possible so that its inten
 }
 ```
 
-When necessary, setting a CSS variable for a component style is preferred over a hard coded value. Alternatively, a fallback value can be provided if no CSS variable has been initialized for a component:
+When necessary, setting a CSS variable for a component style is preferred over a hard-coded value. Alternatively, a fallback value can be provided if no CSS variable has been initialized for a component:
 
 ```css
 .Button {

--- a/docs/pages/theming.mdx
+++ b/docs/pages/theming.mdx
@@ -45,7 +45,7 @@ export default function MyComponent() {
 
 ## Global CSS Class
 
-Alternatively if you are not using react and just using the styled components, the theme can be set by using a global css class somewhere in the root of your dom using the global class `cauldron--theme-dark` or `cauldron--theme-light` for the desired theme:
+Alternatively, if you are not using React and just using the styled components, the theme can be set by using a global CSS class somewhere in the root of your DOM using the global class `cauldron--theme-dark` or `cauldron--theme-light` for the desired theme:
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
This PR fixes typos, acronyms, and rewords some things in sections for all of the docs pages.