### PR TITLE
fix(react): prevent esm modules from appearing in cjs dist

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -8,7 +8,12 @@ export default {
   input: 'src/index.ts',
   external: [
     ...Object.keys(pkg.dependencies),
-    ...Object.keys(pkg.peerDependencies)
+    ...Object.keys(pkg.peerDependencies),
+    // Note: We directly import only the specific language syntax needed
+    // directly in the Code component. This ensures it is still treated as
+    // an external dependency since it won't match the dependencies or
+    // peerDependencies when pulled from package.json.
+    /^react-syntax-highlighter/
   ],
   output: {
     dir: 'lib',

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
-import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import classNames from 'classnames';
-import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
-import css from 'react-syntax-highlighter/dist/esm/languages/hljs/css';
-import xml from 'react-syntax-highlighter/dist/esm/languages/hljs/xml';
-import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
+import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript';
+import css from 'react-syntax-highlighter/dist/cjs/languages/hljs/css';
+import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml';
+import yaml from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml';
 
 SyntaxHighlighter.registerLanguage('javascript', js);
 SyntaxHighlighter.registerLanguage('css', css);
@@ -14,9 +14,8 @@ SyntaxHighlighter.registerLanguage('html', xml);
 SyntaxHighlighter.registerLanguage('yaml', yaml);
 
 // HACK: This is a workaround for a bug in react-syntax-highlighter's types.
-const Highlighter = SyntaxHighlighter as React.ComponentType<
-  SyntaxHighlighterProps
->;
+const Highlighter =
+  SyntaxHighlighter as React.ComponentType<SyntaxHighlighterProps>;
 
 type Props = {
   children: string;


### PR DESCRIPTION
It appears something in the [npm changes with babel/rollup](https://github.com/dequelabs/cauldron/compare/v5.7.1...v5.8.0) caused react-syntax-highlighter to be pulled in as a dependency in the production bundle instead of inlined. Using the cjs dist of react-syntax-highlighter should prevent this issue from occuring.