### PR TITLE
docs: fix table of contents not scrolling when vertically overflowing

### DIFF
--- a/docs/components/ComponentLayout.css
+++ b/docs/components/ComponentLayout.css
@@ -22,6 +22,11 @@ main > section[aria-labelledby='on-this-page'] {
   position: sticky;
   top: var(--space-medium);
   align-self: start;
+  overflow-x: auto;
+  /* account for top + bottom bars and spacing when enforcing max-height for scroll behavior */
+  max-height: calc(
+    100vh - var(--top-bar-height) - var(--top-bar-height) - var(--space-large)
+  );
 }
 
 section[aria-labelledby='on-this-page'] > .toc {


### PR DESCRIPTION
closes #1203 