### PR TITLE
docs: fix incorrect accessible labels for icon button documentation

### DIFF
--- a/docs/pages/components/IconButton.mdx
+++ b/docs/pages/components/IconButton.mdx
@@ -63,11 +63,11 @@ If there are multiple icon buttons with the same label, the visible label text c
 <div class="users">
   <div>
     User: Jason 
-    <IconButton icon="trash" label={<>Delete User <Offscreen>Harris</Offscreen></>} />
+    <IconButton icon="trash" label={<>Delete User <Offscreen>Jason</Offscreen></>} />
   </div>
   <div>
     User: Harris 
-    <IconButton icon="trash" label={<>Delete User <Offscreen>Jason</Offscreen></>} />
+    <IconButton icon="trash" label={<>Delete User <Offscreen>Harris</Offscreen></>} />
   </div>
 </div>
 ```


### PR DESCRIPTION
closes #1216 