### PR TITLE
fix(styles): fix color contrast issue with selected Combobox text

### DIFF
--- a/packages/styles/combobox.css
+++ b/packages/styles/combobox.css
@@ -181,6 +181,7 @@
 }
 
 .ComboboxOption {
+  --field-listbox-selected-text-color: var(--combobox-option-font-color);
   color: var(--combobox-option-font-color);
   padding: var(--space-smallest);
   cursor: pointer;


### PR DESCRIPTION
Selected Combobox options have a color contrast issue with the text of the current selected option: 
![](https://github.com/dequelabs/cauldron/assets/1062039/6681d20e-2b3d-49ea-ab9f-09e1b8aa6f3b)
