### PR TITLE
fix(styles): fix layout issues with dialog header when wrapping

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -50,6 +50,8 @@
   justify-content: space-between;
   min-height: var(--dialog-header-height);
   font-weight: var(--font-weight-bold);
+  padding: var(--space-smallest) 0;
+  gap: var(--space-smallest);
 }
 
 .Dialog__heading,
@@ -73,7 +75,7 @@
   height: var(--dialog-close-button-size);
   width: var(--dialog-close-button-size);
   margin-right: var(--space-smallest);
-  position: relative;
+  flex-shrink: 0;
 }
 
 .Dialog__close:active {


### PR DESCRIPTION
I noticed that the dialog header had some issues when text was wrapping, this adjust the spacing to correctly wrap long dialog titles.

<details>
  <summary>Before</summary>

![dialog header with incorrect spacing and sizing of close button too small](https://github.com/dequelabs/cauldron/assets/1062039/695b2ed4-9a49-473b-aff9-dbca0ade8ffe)

</details>

<details>
  <summary>After</summary>

![dialog header with correct spacing and wrapping between title and button](https://github.com/dequelabs/cauldron/assets/1062039/4765c1ff-4454-4481-b486-af6277380066)

</details>