### PR TITLE
chore: prevent preview action from running against master branch

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -3,6 +3,8 @@ name: PR preview cleanup
 on:
   pull_request:
     types: [closed]
+    branches-ignore:
+      - master
 
 jobs:
   deploy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,8 @@ name: PR preview
 on:
   pull_request:
     types: [opened]
+    branches-ignore:
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
The action frequently fails on master, and we really only need previews against pull requests as `develop` will always have the latest branch.