### PR TITLE
fix(styles): fix incorrect focus ring on dialog close button

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -76,6 +76,7 @@
   width: var(--dialog-close-button-size);
   margin-right: var(--space-smallest);
   flex-shrink: 0;
+  position: relative;
 }
 
 .Dialog__close:active {


### PR DESCRIPTION
I got a little too aggressive with #1253 and this created an issue where the focus ring did not appear surrounding the close button of dialogs.