### PR TITLE
fix(react): prevent error for ComboboxOption when text contents are empty

### DIFF
--- a/packages/react/src/components/Combobox/ComboboxOption.tsx
+++ b/packages/react/src/components/Combobox/ComboboxOption.tsx
@@ -25,6 +25,10 @@ const ComboboxMatch = ({
 }): JSX.Element => {
   const { inputValue } = useComboboxContext();
 
+  if (!text) {
+    return <span></span>;
+  }
+
   if (!inputValue?.length) {
     return <span>{text}</span>;
   }


### PR DESCRIPTION
Noticed that combobox would through an error when text matching on empty options, e.g. `<ComboboxOption></ComboboxOption>`