### PR TITLE
chore(dependabot): monthly updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'
+    groups:
+      # Any updates not caught by the group config will get individual PRs
+      gha-low-risk:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Since many of the GitHub Actions versions in this repo are older, this PR adds a Dependabot config for updating dependencies for GitHub Actions similar to how it's done in `axe-core`.

https://github.com/dequelabs/axe-core/blob/develop/.github/dependabot.yml#L3-L16