### PR TITLE
ci: fix missing registry-url for node step in github action

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -19,6 +19,7 @@ runs:
         node-version: 18
         cache: yarn
         cache-dependency-path: '**/yarn.lock'
+        registry-url: 'https://registry.npmjs.org'
     - name: Install root dependencies
       run: yarn install --frozen-lockfile
       shell: bash


### PR DESCRIPTION
Publishing is currently failing in `develop`: https://github.com/dequelabs/cauldron/actions/runs/6882188075/job/18720262812

Looks like I forgot to include the registry url for the `setup-node` step.