### PR TITLE
fix(react): announce required once through attribute only

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -113,7 +113,9 @@ export default class TextField extends React.Component<
         >
           <span>{label}</span>
           {isRequired && (
-            <span className="Field__required-text">{requiredText}</span>
+            <span className="Field__required-text" aria-hidden="true">
+              {requiredText}
+            </span>
           )}
         </label>
         <Field


### PR DESCRIPTION
- uses the `required` attribute to announce 'required' to screen readers while still displaying 'required' for sighted users.

<img width="1255" alt="required being announced on TextField component once to screenreader users while being displayed to sighted users" src="https://github.com/dequelabs/cauldron/assets/6422248/236debf0-875f-48a8-8715-c2170c328dfc">

Closes: #1293