### PR TITLE
test: fix code coverage

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -90,7 +90,7 @@
     "functions": 85,
     "lines": 85,
     "exclude": [
-      "dist",
+      "lib",
       "coverage",
       "test/**/*.js"
     ]
@@ -105,7 +105,7 @@
       "**/src/components/**/*.test.tsx"
     ],
     "collectCoverageFrom": [
-      "**/src/**/*.{ts,tsx}"
+      "src/**/*.{ts,tsx}"
     ],
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/__tests__/styleMock.js",


### PR DESCRIPTION
Code coverage was previously including `lib/**` files, so this scopes it to just use `src/**` files.