### PR TITLE
fix(Combobox): prevent default event  when Combobox listbox is expanded on enter keypress

### DIFF
--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -247,8 +247,12 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         const escKeypress = event.key === Escape;
         const arrowKeypress = ['ArrowDown', 'ArrowUp'].includes(event.key);
 
-        if ([Home, End].includes(event.key)) {
+        if (
           // prevent the page from scrolling and allow start/end option activation
+          [Home, End].includes(event.key) ||
+          // prevent combobox from submitting any forms when the listbox is expanded
+          (enterKeypress && open)
+        ) {
           event.preventDefault();
         }
 


### PR DESCRIPTION
closes #1311 