### PR TITLE
fix(styles): fix incorrect icon size with Dialog close buttons

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -110,8 +110,8 @@
 }
 
 .Dialog__close svg {
-  height: 100%;
-  width: 100%;
+  /* match icon size with height/width of button */
+  --icon-size: 100%;
 }
 
 .cauldron--theme-dark .Dialog__close {


### PR DESCRIPTION
Noticed there was a visual regression with the close button:

![cauldron modal with x misaligned in close button](https://github.com/dequelabs/cauldron/assets/1062039/82729364-e25f-4e95-9912-47ee56af0a61)
