### PR TITLE
fix(TextField): prevent className clobbering on TextField input

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -72,6 +72,7 @@ export default class TextField extends React.Component<
       requiredText,
       multiline,
       'aria-describedby': ariaDescribedby,
+      className,
       ...other
     } = this.props;
     // typescript can't infer the type so it's complaining about
@@ -99,7 +100,7 @@ export default class TextField extends React.Component<
           )}
         </label>
         <Field
-          className={classNames({
+          className={classNames(className, {
             'Field__text-input': !multiline,
             Field__textarea: multiline,
             'Field--has-error': error


### PR DESCRIPTION
I noticed this while updating the tests in #1337 that the input's `className` was getting clobbered on `TextField` when passed as a prop. #1337 will handle the tests, while this PR is just for the fix.