### PR TITLE
docs(CONTRIBUTING.md): fix typo regarding writing new tests with RTL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ The testing methodology should account for both testing the interface of a compo
 
 ### Unit Tests
 
-Cauldron uses [Jest](https://jestjs.io/) as its test runner to run unit tests along with [Enzyme](https://enzymejs.github.io/enzyme) (deprecated) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/). We are currently in the process of migrating tests away from Enzyme to React Testing Library so no new tests should be using Enzyme.
+Cauldron uses [Jest](https://jestjs.io/) as its test runner to run unit tests along with [Enzyme](https://enzymejs.github.io/enzyme) (deprecated) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/). We are currently in the process of migrating tests away from Enzyme to React Testing Library so no new tests should be using React Testing Library.
 
 ### Accessibility Testing
 


### PR DESCRIPTION
I noticed a typo in the contributing guide. It says that new unit tests should be written in Enzyme, but I think it's meant to be React Testing Library.