### PR TITLE
feat(react): Add property to include trailing children for SearchField component

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -151,6 +151,11 @@ h6:has(> .Permalink):hover .Permalink,
   margin: var(--space-large);
 }
 
+.SearchField .TextFieldWrapper .page {
+  flex-shrink: 0;
+  margin-right: var(--space-smallest);
+}
+
 @media (max-width: 64rem) {
   .Content {
     grid-template-columns: 1fr;

--- a/docs/index.css
+++ b/docs/index.css
@@ -151,11 +151,6 @@ h6:has(> .Permalink):hover .Permalink,
   margin: var(--space-large);
 }
 
-.SearchField .TextFieldWrapper .page {
-  flex-shrink: 0;
-  margin-right: var(--space-smallest);
-}
-
 @media (max-width: 64rem) {
   .Content {
     grid-template-columns: 1fr;

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -57,11 +57,11 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
 
 ### SearchField with trailing children
 
-We include a right-oriented "slot" to allow for additional input context to be provided, such as texts, buttons, icons, etc. To achieve this, SearchField takes an additional prop named trailingChildren, which will be "slotted" into the component as a child of TextFieldWrapper after the native input.
+We include trailing children to allow for additional input context to be provided, such as texts, buttons, icons, etc. The trailing children will be placed at the right end of the SearchField.
 
 ```jsx example
 <FieldWrap>
-  <SearchField label="Search Field with trailing children" trailingChildren={<span class="page">
+  <SearchField label="Search Field with trailing children" trailingChildren={<span style={{ marginRight: '8px'}}>
     <strong>1</strong> of <strong>1</strong>
   </span>} />
 </FieldWrap>

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -4,7 +4,7 @@ description: A form element that allows users to type in text for searching.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/SearchField/index.tsx
 ---
 
-import { SearchField, FieldWrap } from '@deque/cauldron-react';
+import { SearchField, FieldWrap, IconButton } from '@deque/cauldron-react';
 
 ```js
 import { SearchField } from '@deque/cauldron-react';
@@ -55,6 +55,16 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
 </form>
 ```
 
+### SearchField with trailingChildren
+
+```jsx example
+<FieldWrap>
+  <SearchField label="Search Field with trailingChildren" trailingChildren={<span class="page">
+    <strong>1</strong> of <strong>1</strong>
+  </span>} />
+</FieldWrap>
+```
+
 ## Props
 
 <ComponentProps
@@ -96,6 +106,12 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
       description:
         'If true, the label and input will be rendered in a `<form>` tag. If false, the label and input will be rendered in a `<div>` tag.',
       defaultValue: 'true'
+    },
+    {
+      name: 'trailingChildren',
+      type: ['ReactNode, string'],
+      description:
+        'if provided, the children will be slotted into the right end of the field.'
     }
   ]}
 />

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -4,7 +4,7 @@ description: A form element that allows users to type in text for searching.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/SearchField/index.tsx
 ---
 
-import { SearchField, FieldWrap, IconButton } from '@deque/cauldron-react';
+import { SearchField, FieldWrap } from '@deque/cauldron-react';
 
 ```js
 import { SearchField } from '@deque/cauldron-react';

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -111,7 +111,7 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
       name: 'trailingChildren',
       type: ['ReactNode, string'],
       description:
-        'if provided, the children will be slotted into the right end of the field.'
+        'If provided, the children will be slotted into the right end of the field.'
     }
   ]}
 />

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -57,7 +57,7 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
 
 ### SearchField with trailing children
 
-We include trailing children to allow for additional input context to be provided, such as texts, buttons, icons, etc. The trailing children will be placed at the right end of the SearchField.
+We include trailing children to allow for additional input context to be provided, such as texts, buttons, icons, etc. The trailing children will be placed at the right end of SearchField.
 
 ```jsx example
 <FieldWrap>

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -55,11 +55,13 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
 </form>
 ```
 
-### SearchField with trailingChildren
+### SearchField with trailing children
+
+We include a right-oriented "slot" to allow for additional input context to be provided, such as texts, buttons, icons, etc. To achieve this, SearchField takes an additional prop named trailingChildren, which will be "slotted" into the component as a child of TextFieldWrapper after the native input.
 
 ```jsx example
 <FieldWrap>
-  <SearchField label="Search Field with trailingChildren" trailingChildren={<span class="page">
+  <SearchField label="Search Field with trailing children" trailingChildren={<span class="page">
     <strong>1</strong> of <strong>1</strong>
   </span>} />
 </FieldWrap>
@@ -109,7 +111,7 @@ By default, SearchField is wrapped in a `<form role="search">` to provide better
     },
     {
       name: 'trailingChildren',
-      type: ['ReactNode, string'],
+      type: 'ReactNode',
       description:
         'If provided, the children will be slotted into the right end of the field.'
     }

--- a/docs/pages/components/SearchField.mdx
+++ b/docs/pages/components/SearchField.mdx
@@ -61,9 +61,14 @@ We include trailing children to allow for additional input context to be provide
 
 ```jsx example
 <FieldWrap>
-  <SearchField label="Search Field with trailing children" trailingChildren={<span style={{ marginRight: '8px'}}>
-    <strong>1</strong> of <strong>1</strong>
-  </span>} />
+  <SearchField 
+    label="Search Field with trailing children" 
+    trailingChildren={
+      <span style={{ marginRight: '8px' }}>
+        <strong>1</strong> of <strong>1</strong>
+      </span>
+    }
+  />
 </FieldWrap>
 ```
 

--- a/packages/react/src/components/SearchField/SearchField.test.tsx
+++ b/packages/react/src/components/SearchField/SearchField.test.tsx
@@ -3,6 +3,7 @@ import { render as testingRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { axe } from 'jest-axe';
+import IconButton from '../IconButton';
 
 import SearchField from './';
 
@@ -18,6 +19,12 @@ const defaultProps = {
   label: 'search field',
   ref: undefined
 };
+
+const MyComponent = () => (
+  <span>
+    <strong>1</strong> of <strong>10</strong>
+  </span>
+);
 
 const render = ({
   label,
@@ -151,28 +158,46 @@ test('should support name prop', () => {
 });
 
 test('SearchField should render trailingChildren as a component', async () => {
-  const MyComponent = () => <div className="component">I am a component</div>;
-  render({
-    trailingChildren: <MyComponent />
+  const input = render({
+    trailingChildren: (
+      <IconButton
+        icon="chevron-up"
+        variant="secondary"
+        label="go to previous match"
+      />
+    )
   });
 
-  expect(screen.getByText('I am a component')).toHaveClass('component');
+  expect(
+    input.parentElement!.contains(
+      screen.getByRole('button', {
+        name: 'go to previous match'
+      })
+    )
+  ).toBeTruthy;
 });
 
 test('SearchField should render trailingChildren as a string', async () => {
-  render({
-    trailingChildren: 'I am a component'
+  const input = render({
+    trailingChildren: 'I am a string'
   });
 
-  expect(screen.getByText('I am a component')).toBeInTheDocument();
+  expect(input.parentElement!.contains(screen.getByText('I am a string')))
+    .toBeTruthy;
 });
 
 test('SearchField should render trailingChildren as an element', async () => {
-  render({
-    trailingChildren: <div className="element">I am a component</div>
+  const input = render({
+    trailingChildren: <button type="button">I am a button</button>
   });
 
-  expect(screen.getByText('I am a component')).toHaveClass('element');
+  expect(
+    input.parentElement!.contains(
+      screen.getByRole('button', {
+        name: 'I am a button'
+      })
+    )
+  ).toBeTruthy;
 });
 
 test('SearchField should have no axe violations with default params', async () => {
@@ -188,13 +213,13 @@ test('SearchField should have no axe violations with hideLabel set to true', asy
 });
 
 test('SearchField should have no axe violations with isForm set to false', async () => {
-  const input = render({ isForm: false });
+  const input = render({ isForm: false, trailingChildren: <MyComponent /> });
   const results = await axe(input);
   expect(results).toHaveNoViolations();
 });
 
 test('SearchField should have no axe violations with disabled set to true', async () => {
-  const input = render({ disabled: true });
+  const input = render({ disabled: true, trailingChildren: <MyComponent /> });
   const results = await axe(input);
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/SearchField/SearchField.test.tsx
+++ b/packages/react/src/components/SearchField/SearchField.test.tsx
@@ -150,6 +150,31 @@ test('should support name prop', () => {
   expect(input).toHaveDisplayValue('bananas');
 });
 
+test('SearchField should render trailingChildren as a component', async () => {
+  const MyComponent = () => <div className="component">I am a component</div>;
+  render({
+    trailingChildren: <MyComponent />
+  });
+
+  expect(screen.getByText('I am a component')).toHaveClass('component');
+});
+
+test('SearchField should render trailingChildren as a string', async () => {
+  render({
+    trailingChildren: 'I am a component'
+  });
+
+  expect(screen.getByText('I am a component')).toBeInTheDocument();
+});
+
+test('SearchField should render trailingChildren as an element', async () => {
+  render({
+    trailingChildren: <div className="element">I am a component</div>
+  });
+
+  expect(screen.getByText('I am a component')).toHaveClass('element');
+});
+
 test('SearchField should have no axe violations with default params', async () => {
   const input = render();
   const results = await axe(input);

--- a/packages/react/src/components/SearchField/index.tsx
+++ b/packages/react/src/components/SearchField/index.tsx
@@ -21,7 +21,7 @@ interface SearchFieldProps
   onChange?: (value: string, e: ChangeEvent<HTMLInputElement>) => void;
   hideLabel?: boolean;
   isForm?: boolean;
-  trailingChildren?: React.ReactNode | string;
+  trailingChildren?: React.ReactNode;
 }
 
 const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
@@ -64,6 +64,10 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
 
     const Field = isForm ? 'form' : 'div';
 
+    if (typeof trailingChildren === 'string') {
+      trailingChildren = <span>{trailingChildren}</span>;
+    }
+
     return (
       <Field
         role={isForm ? 'search' : undefined}
@@ -101,12 +105,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
             className={classNames(otherProps.className, 'Field__text-input')}
             type="search"
           />
-          {trailingChildren &&
-            (typeof trailingChildren === 'string' ? (
-              <span>{trailingChildren}</span>
-            ) : (
-              trailingChildren
-            ))}
+          {trailingChildren}
         </TextFieldWrapper>
       </Field>
     );

--- a/packages/react/src/components/SearchField/index.tsx
+++ b/packages/react/src/components/SearchField/index.tsx
@@ -21,6 +21,7 @@ interface SearchFieldProps
   onChange?: (value: string, e: ChangeEvent<HTMLInputElement>) => void;
   hideLabel?: boolean;
   isForm?: boolean;
+  trailingChildren?: React.ReactNode | string;
 }
 
 const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
@@ -34,6 +35,7 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       isForm = true,
       id: propId,
       value: propValue,
+      trailingChildren,
       ...otherProps
     }: SearchFieldProps,
     ref
@@ -99,6 +101,12 @@ const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
             className={classNames(otherProps.className, 'Field__text-input')}
             type="search"
           />
+          {trailingChildren &&
+            (typeof trailingChildren === 'string' ? (
+              <span>{trailingChildren}</span>
+            ) : (
+              trailingChildren
+            ))}
         </TextFieldWrapper>
       </Field>
     );

--- a/packages/styles/text-field-wrapper.css
+++ b/packages/styles/text-field-wrapper.css
@@ -74,6 +74,10 @@
   color: var(--text-field-wrapper-font-color);
 }
 
+.TextFieldWrapper > :not(input) {
+  flex-shrink: 0;
+}
+
 .TextFieldWrapper:focus-within {
   border: 1px solid var(--text-field-wrapper-border-focus-color);
   box-shadow: 0 0 0 1px var(--text-field-wrapper-border-focus-color),


### PR DESCRIPTION
closes https://github.com/dequelabs/cauldron/issues/1358