### PR TITLE
docs: fix associated label for the twocolumn region example

### DIFF
--- a/docs/pages/components/TwoColumnPanel.mdx
+++ b/docs/pages/components/TwoColumnPanel.mdx
@@ -152,9 +152,9 @@ function TwoColumnPanelGroupedItemsExample() {
   return (
     <TwoColumnPanel>
       <ColumnLeft aria-labelledby="group-heading">
-        <ColumnHeader>Grouped Items</ColumnHeader>
+        <ColumnHeader id="group-heading">Grouped Items</ColumnHeader>
         <ColumnList>
-          <ColumnGroupHeader id="group-heading">
+          <ColumnGroupHeader>
             <h3>Optional group heading</h3>
           </ColumnGroupHeader>
           <nav aria-labelledby="group-heading">


### PR DESCRIPTION
closes #1389 