### PR TITLE
feat(react): support use of custom classNames with Toast component

### DIFF
--- a/packages/react/__tests__/src/components/Toast/index.js
+++ b/packages/react/__tests__/src/components/Toast/index.js
@@ -246,3 +246,16 @@ test('dismiss control is not rendered when dismissible is `false`', (done) => {
     done();
   }); // wait for animation timeouts / async setState calls
 });
+
+test.only('allows for custom class names', () => {
+  const mountElement = document.createElement('div');
+  document.body.appendChild(mountElement);
+  const wrapper = mount(
+    <Toast {...defaultProps} show={true} className="custom-class" type="info">
+      {'hi'}
+    </Toast>,
+    { attachTo: mountElement }
+  );
+
+  expect(wrapper.find('.Toast').hasClass('custom-class')).toBeTruthy();
+});

--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -5,7 +5,7 @@ import AriaIsolate from '../../utils/aria-isolate';
 import { typeMap, tabIndexHandler } from './utils';
 import setRef from '../../utils/setRef';
 
-export interface ToastProps {
+export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   type: 'confirmation' | 'caution' | 'error' | 'action-needed' | 'info';
   onDismiss: () => void;
   dismissText?: string;
@@ -106,7 +106,8 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
         'Toast',
         `Toast--${typeMap[type].className}`,
         animationClass,
-        { 'Toast--non-dismissible': !dismissible }
+        { 'Toast--non-dismissible': !dismissible },
+        otherProps.className
       )
     };
 
@@ -122,7 +123,7 @@ export default class Toast extends React.Component<ToastProps, ToastState> {
             setRef(toastRef, el);
           }}
           {...defaultProps}
-          {...otherProps}
+          className={defaultProps.className}
         >
           <div className="Toast__message">
             <Icon type={typeMap[type].icon} />


### PR DESCRIPTION
closes: https://github.com/dequelabs/cauldron/issues/619