### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,8 @@
 # Request a review from cauldron codeowners on all PRs
 * @dequelabs/cauldron-codeowners
 
+# Request a review from either design team or codeowner for screenshots
+/e2e/screenshots/*.png @dequelabs/cauldron-codeowners @dequelabs/cauldron-design
+
 # Request a review from cauldron team on docs PRs
 /docs/ @dequelabs/cauldron


### PR DESCRIPTION
The design team should be tagged whenever a component screenshot/snapshot changes.