### PR TITLE
docs: fix invalid JSX with IconButton

### DIFF
--- a/docs/pages/components/IconButton.mdx
+++ b/docs/pages/components/IconButton.mdx
@@ -56,15 +56,13 @@ The default tooltip can be modified by setting the relevant props configuration 
 If there are multiple icon buttons with the same label, the visible label text can be combined with `Offscreen` to provide additional context to users using assistive technology (AT).
 
 ```jsx example
-<div class="users">
-  <div>
-    User: Jason 
-    <IconButton icon="trash" label={<>Delete User <Offscreen>Jason</Offscreen></>} />
-  </div>
-  <div>
-    User: Harris 
-    <IconButton icon="trash" label={<>Delete User <Offscreen>Harris</Offscreen></>} />
-  </div>
+<div>
+  User: Jason 
+  <IconButton icon="trash" label={<>Delete User <Offscreen>Jason</Offscreen></>} />
+</div>
+<div>
+  User: Harris 
+  <IconButton icon="trash" label={<>Delete User <Offscreen>Harris</Offscreen></>} />
 </div>
 ```
 


### PR DESCRIPTION
Noticed that we were using `class` here which isn't valid in JSX but wasn't actually necessary.