### PR TITLE
chore: update pagination to use updated IconButton props

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -61,7 +61,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
           <li>
             <IconButton
               icon="chevron-double-left"
-              tooltipPlacement={tooltipPlacement}
+              tooltipProps={{ placement: tooltipPlacement }}
               label={firstPageLabel}
               aria-disabled={isFirstPage}
               onClick={isFirstPage ? undefined : onFirstPageClick}
@@ -71,7 +71,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
           <li>
             <IconButton
               icon="chevron-left"
-              tooltipPlacement={tooltipPlacement}
+              tooltipProps={{ placement: tooltipPlacement }}
               label={previousPageLabel}
               aria-disabled={isFirstPage}
               onClick={isFirstPage ? undefined : onPreviousPageClick}
@@ -92,7 +92,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
           <li>
             <IconButton
               icon="chevron-right"
-              tooltipPlacement={tooltipPlacement}
+              tooltipProps={{ placement: tooltipPlacement }}
               label={nextPageLabel}
               aria-disabled={isLastPage}
               onClick={isLastPage ? undefined : onNextPageClick}
@@ -102,7 +102,7 @@ const Pagination = React.forwardRef<HTMLDivElement, Props>(
           <li>
             <IconButton
               icon="chevron-double-right"
-              tooltipPlacement={tooltipPlacement}
+              tooltipProps={{ placement: tooltipPlacement }}
               label={lastPageLabel}
               aria-disabled={isLastPage}
               onClick={isLastPage ? undefined : onLastPageClick}


### PR DESCRIPTION
This was using the deprecated pattern of tooltip placement, leading to a bunch of unnecessary logging happening in tests (and probably in development) when using Pagination. 