### PR TITLE
ci: Remove myself from sync branches workflow

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -14,5 +14,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"
           pr-body: "Remember to _merge_ (rather than squash) this PR!"
-          pr-reviewers: schne324,scurker,stephenmathieson
+          pr-reviewers: schne324,scurker
           head: master


### PR DESCRIPTION
I do not frequently work on Cauldron, so I probably shouldn't be involved in its release process.