### PR TITLE
fix(react): make focusOnInitialRender work without setTimeout

### DIFF
--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -42,14 +42,9 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
       };
     }, [focusTrap, overlayRef.current]);
 
-    useEffect(() => {
-      if (!!focusOnInitialRender && overlayRef.current) {
-        setTimeout(() => {
-          return overlayRef.current?.focus();
-        });
-      }
-      return;
-    }, [overlayRef.current]);
+    if (!!focusOnInitialRender && overlayRef.current) {
+      overlayRef.current.focus();
+    }
 
     const Wrapper = focusTrap ? FocusTrap : React.Fragment;
     const wrapperProps = focusTrap

--- a/packages/react/src/components/LoaderOverlay/index.tsx
+++ b/packages/react/src/components/LoaderOverlay/index.tsx
@@ -42,9 +42,11 @@ const LoaderOverlay = forwardRef<HTMLDivElement, LoaderOverlayProps>(
       };
     }, [focusTrap, overlayRef.current]);
 
-    if (!!focusOnInitialRender && overlayRef.current) {
-      overlayRef.current.focus();
-    }
+    useEffect(() => {
+      if (!!focusOnInitialRender && overlayRef.current) {
+        overlayRef.current.focus();
+      }
+    }, []);
 
     const Wrapper = focusTrap ? FocusTrap : React.Fragment;
     const wrapperProps = focusTrap


### PR DESCRIPTION
- This pull request removes the loader overlay's `focusOnInitialRender`'s dependency on setTimeout + the loader's ref as a dependency in the `useEffect`'s dependency array. 
- closes: #747 (replaces #833) 