### PR TITLE
fix(IconButton): loosen polymorphic type to allow for any type of JSXElement

### DIFF
--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -40,10 +40,7 @@ it('should add button role for custom components', () => {
   ) {
     return <div data-testid="custom" ref={ref} {...props}></div>;
   });
-  render(
-    // @ts-expect-error this technically should be allowed
-    <IconButton icon="pencil" label="Edit" as={CustomButton} />
-  );
+  render(<IconButton icon="pencil" label="Edit" as={CustomButton} />);
   expect(screen.getByTestId('custom')).toBeInTheDocument();
   expect(screen.getByTestId('custom')).toHaveAttribute('role', 'button');
   expect(screen.getByTestId('custom')).toHaveAttribute('tabIndex', '0');
@@ -121,15 +118,7 @@ test('should return no axe violations when rendered as CustomElement', async () 
   ) {
     return <div data-testid="custom" ref={ref} {...props}></div>;
   });
-  render(
-    <IconButton
-      icon="pencil"
-      label="Edit"
-      // @ts-expect-error this technically should be allowed
-      as={CustomButton}
-      href="/somewhere"
-    />
-  );
+  render(<IconButton icon="pencil" label="Edit" as={CustomButton} />);
   const results = await axe(screen.getByTestId('custom'));
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -16,8 +16,7 @@ import {
 
 export interface IconButtonProps
   extends PolymorphicProps<
-    React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>,
-    'button' | 'a'
+    React.HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>
   > {
   icon: IconType;
   label: React.ReactNode;
@@ -112,7 +111,6 @@ const IconButton = forwardRef(
             'IconButton--error': variant === 'error',
             'IconButton--large': large
           })}
-          // @ts-expect-error the concrete type is unknown, so HTMLElement is expected
           ref={internalRef}
           disabled={disabled}
           tabIndex={disabled ? -1 : tabIndex}
@@ -130,7 +128,7 @@ const IconButton = forwardRef(
       </React.Fragment>
     );
   }
-) as PolymorphicComponent<IconButtonProps, 'button' | 'a'>;
+) as PolymorphicComponent<IconButtonProps>;
 
 IconButton.displayName = 'IconButton';
 


### PR DESCRIPTION
closes #1490 

The original intention was to only allow for `button` or `a` elements to be passed in here. Unfortunately, this can be somewhat restrictive since the intrinsic element type is not known leading to errors when trying to pass something in like a link from React Router. We lose a little bit of safety here, but we do try to do some duck typing in the component to figure out if the role should be a `button` or `link` so we're not losing too much by loosening the type restrictions.