### PR TITLE
test: moved `useSharedRef` tests from `Enzyme` to `RTL`

### DIFF
--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -7,11 +7,13 @@ const config: Config = {
     '**/__tests__/src/**/*.js',
     '**/__tests__/demo/**/*.js',
     '**/src/components/**/*.test.tsx',
-    '**/src/utils/**/*.test.{ts,tsx}'
+    '**/src/utils/**/*.test.{ts,tsx}',
+    '!**/src/utils/polymorphicComponent.test.tsx'
   ],
   collectCoverageFrom: [
     '<rootDir>/src/components/**/*.{tsx,ts}',
-    '<rootDir>/src/utils/**/*.{tsx,ts}'
+    '<rootDir>/src/utils/**/*.{tsx,ts}',
+    '!<rootDir>/src/utils/polymorphicComponent.test.tsx'
   ],
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/__tests__/styleMock.js',

--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -7,9 +7,12 @@ const config: Config = {
     '**/__tests__/src/**/*.js',
     '**/__tests__/demo/**/*.js',
     '**/src/components/**/*.test.tsx',
-    '**/src/utils/**/*.test.ts'
+    '**/src/utils/**/*.test.{ts,tsx}'
   ],
-  collectCoverageFrom: ['<rootDir>/src/components/**/*.{tsx,ts}'],
+  collectCoverageFrom: [
+    '<rootDir>/src/components/**/*.{tsx,ts}',
+    '<rootDir>/src/utils/**/*.{tsx,ts}'
+  ],
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/__tests__/styleMock.js',
     'react-syntax-highlighter/dist/esm/light':

--- a/packages/react/src/utils/polymorphicComponent.test.tsx
+++ b/packages/react/src/utils/polymorphicComponent.test.tsx
@@ -143,3 +143,7 @@ const htmlAnchorRef = React.createRef<HTMLAnchorElement>();
     bananas
   </ConstrainedComponent>
 );
+
+test('polymorphicComponent', () => {
+  // avoid `yarn test` error (Your test suite must contain at least one test.)
+});

--- a/packages/react/src/utils/polymorphicComponent.test.tsx
+++ b/packages/react/src/utils/polymorphicComponent.test.tsx
@@ -143,7 +143,3 @@ const htmlAnchorRef = React.createRef<HTMLAnchorElement>();
     bananas
   </ConstrainedComponent>
 );
-
-test('polymorphicComponent', () => {
-  // avoid `yarn test` error (Your test suite must contain at least one test.)
-});

--- a/packages/react/src/utils/useSharedRef.test.tsx
+++ b/packages/react/src/utils/useSharedRef.test.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { spy } from 'sinon';
-import useSharedRef from 'src/utils/useSharedRef';
+import useSharedRef from './useSharedRef';
 
 // eslint-disable-next-line react/display-name,react/prop-types
-const ComponentWithSharedRef = React.forwardRef(({ callback }, ref) => {
+const ComponentWithSharedRef = React.forwardRef<
+  HTMLSpanElement,
+  { callback: (ref: React.RefObject<HTMLSpanElement>) => void }
+>(({ callback }, ref) => {
   const sharedRef = useSharedRef(ref);
   callback(sharedRef);
   return <span ref={sharedRef}></span>;
 });
 
 test('it supports external functional refs', () => {
-  let refEl = null;
+  let refEl: HTMLSpanElement | null = null;
   const internalRefCallback = spy();
-  act(() => {
-    const wrapper = mount(
-      <ComponentWithSharedRef
-        ref={el => (refEl = el)}
-        callback={internalRefCallback}
-      />
-    );
-    wrapper.update();
-  });
-  expect(refEl?.tagName.toLowerCase()).toEqual('span');
+
+  render(
+    <ComponentWithSharedRef
+      ref={(el) => (refEl = el)}
+      callback={internalRefCallback}
+    />
+  );
+
+  expect(refEl ? (refEl as HTMLSpanElement).tagName.toLowerCase() : '').toEqual(
+    'span'
+  );
   expect(
     internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
   ).toEqual('span');
@@ -32,13 +35,15 @@ test('it supports external functional refs', () => {
 test('it supports mutable refs', () => {
   const fakeRef = { current: null };
   const internalRefCallback = spy();
-  act(() => {
-    const wrapper = mount(
-      <ComponentWithSharedRef ref={fakeRef} callback={internalRefCallback} />
-    );
-    wrapper.update();
-  });
-  expect(fakeRef.current?.tagName.toLowerCase()).toEqual('span');
+  render(
+    <ComponentWithSharedRef ref={fakeRef} callback={internalRefCallback} />
+  );
+
+  expect(
+    fakeRef.current
+      ? (fakeRef.current as HTMLSpanElement)?.tagName.toLowerCase()
+      : ''
+  ).toEqual('span');
   expect(
     internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
   ).toEqual('span');
@@ -46,12 +51,7 @@ test('it supports mutable refs', () => {
 
 test('it supports undefined parent ref', () => {
   const internalRefCallback = spy();
-  act(() => {
-    const wrapper = mount(
-      <ComponentWithSharedRef callback={internalRefCallback} />
-    );
-    wrapper.update();
-  });
+  render(<ComponentWithSharedRef callback={internalRefCallback} />);
   expect(
     internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
   ).toEqual('span');


### PR DESCRIPTION
Issue https://github.com/dequelabs/cauldron/issues/1159

This PR switches the `useSharedRef` tests to React Testing Library.

Validation steps

Run yarn test
See that there are coverage percentages in the table
Verify that the tests are converted properly