### PR TITLE
test: moved `rndid` to RTL/typescript tests

### DIFF
--- a/packages/react/src/utils/rndid/index.test.ts
+++ b/packages/react/src/utils/rndid/index.test.ts
@@ -1,4 +1,4 @@
-import rndid from 'src/utils/rndid';
+import rndid from './';
 
 test('returns a unique string', () => {
   let hasDuplicates = false;


### PR DESCRIPTION
Issue https://github.com/dequelabs/cauldron/issues/1159

This PR switches the `utils.rndid` tests to React Testing Library.

Validation steps

Run yarn test
See that there are coverage percentages in the table
Verify that the tests are converted properly