### PR TITLE
chore: ignore esm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
         patterns:
           - "playwright"
           - "@playwright/*"
+    ignore:
+      # Prevent updates to ESM-only versions
+      - dependency-name: 'log-symbols'
+        versions: ['>=5.0.0']


### PR DESCRIPTION
closes #1529

For now we'll ignore specific ESM dependencies which are incompatible with the way we import modules.