### PR TITLE
chore: group babel dependencies under dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore"
     groups:
@@ -24,6 +24,10 @@ updates:
         patterns:
           - "playwright"
           - "@playwright/*"
+      update-babel:
+        patterns:
+          - "babel-*"
+          - "@babel/*"
     ignore:
       # Prevent updates to ESM-only versions
       - dependency-name: 'log-symbols'


### PR DESCRIPTION
We likely want to be updating `babel*` dependencies in tandem. 