### PR TITLE
chore: remove unused fontsource packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,6 @@
     "eslint-plugin-ssr-friendly": "^1.3.0",
     "express": "^4.19.2",
     "focusable": "^2.3.0",
-    "fontsource-lato": "^4.0.0",
-    "fontsource-roboto": "^3.0.3",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^1.0.0-rc.14",
     "lint-staged": "^7.2.2",


### PR DESCRIPTION
Noticed dependabot was requesting a bump here: https://github.com/dequelabs/cauldron/pull/1545, but we are already using `@fontsource/roboto` so these dependencies are likely outdated:

https://github.com/dequelabs/cauldron/blob/7e01173a2d12b1f09a89678205795d023418eaa7/package.json#L55-L57