### PR TITLE
feat: impact badge component

### DIFF
--- a/docs/pages/components/ImpactBadge.mdx
+++ b/docs/pages/components/ImpactBadge.mdx
@@ -1,0 +1,33 @@
+---
+title: ImpactBadge
+description: A primitive component to display various impact levels with an associated icon and background color
+source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/ImpactBadge/index.tsx
+---
+
+import { Icon, Button, Code, ImpactBadge } from '@deque/cauldron-react'
+
+```js
+import { ImpactBadge } from '@deque/cauldron-react'
+```
+
+## Examples
+
+### Minor
+```jsx example
+<ImpactBadge />
+```
+
+### Moderate
+```jsx example
+<ImpactBadge />
+```
+
+### Serious
+```jsx example
+<ImpactBadge />
+```
+
+### Critical
+```jsx example
+<ImpactBadge />
+```

--- a/packages/react/src/components/ImpactBadge/index.tsx
+++ b/packages/react/src/components/ImpactBadge/index.tsx
@@ -1,0 +1,15 @@
+import React, { forwardRef } from 'react';
+import { ContentNode } from '../../types';
+
+interface ImpactBadgeProps extends React.HTMLAttributes<HTMLElement> {
+  type: 'critical' | 'serious' | 'moderate' | 'minor';
+  label?: ContentNode;
+}
+
+const ImpactBadge = forwardRef(() => {
+  return <div className="ImpactBadge">Serious</div>;
+});
+
+ImpactBadge.displayName = 'ImpactBadge';
+
+export default ImpactBadge;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -127,6 +127,7 @@ export {
 export { default as Popover } from './components/Popover';
 export { default as Timeline, TimelineItem } from './components/Timeline';
 export { default as TextEllipsis } from './components/TextEllipsis';
+export { default as ImpactBadge } from './components/ImpactBadge';
 
 /**
  * Helpers / Utils

--- a/packages/styles/impact-badge.css
+++ b/packages/styles/impact-badge.css
@@ -1,0 +1,6 @@
+.ImpactBadge {
+  height: var(--target-size-minimum);
+  border-radius: 999px;
+  background-color: var(--issue-serious);
+  display: inline-flex;
+}

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -45,3 +45,4 @@
 @import './timeline.css';
 @import './search-field.css';
 @import './text-ellipsis.css';
+@import './impact-badge.css';


### PR DESCRIPTION
https://github.com/dequelabs/cauldron/issues/1141

- Creates a new `ImpactBadge` component with critical, serious, moderate, and minor types
- Adds a new doc page for the `ImpactBadge`