### PR TITLE
feat(styles): flag DefinitionButton as a deprecated class

### DIFF
--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -163,12 +163,14 @@ button.Link {
   height: calc(var(--button-thin-height) - 8px);
 }
 
+/* Usage of .DefinitionButton is deprecated and no longer supported */
 .DefinitionButton {
   display: inline;
   vertical-align: baseline;
   position: relative;
 }
 
+/* Usage of .DefinitionButton is deprecated and no longer supported */
 .DefinitionButton button {
   background-color: transparent;
   color: var(--text-color-base);


### PR DESCRIPTION
This is flagging these selectors as deprecated so they can be removed in a future version of Cauldron.

ref #1591 