### PR TITLE
fix(Notice): allow className to be passed into Notice component

### DIFF
--- a/packages/react/src/components/Notice/index.test.tsx
+++ b/packages/react/src/components/Notice/index.test.tsx
@@ -75,6 +75,11 @@ test('should allow a ref to be forwarded', () => {
   expect(ref.current).toBeTruthy();
 });
 
+test('should support className prop', () => {
+  render(<Notice className="bananas" data-testid="notice" title={''} />);
+  expect(screen.getByTestId('notice')).toHaveClass('bananas', 'Notice');
+});
+
 test('should return no axe violations with type="info"', async () => {
   const { container } = render(
     <Notice type="info" title="foo">

--- a/packages/react/src/components/Notice/index.tsx
+++ b/packages/react/src/components/Notice/index.tsx
@@ -21,6 +21,7 @@ export interface NoticeProps
 const Notice = forwardRef<HTMLDivElement, NoticeProps>(
   (
     {
+      className,
       type = 'info',
       title,
       icon,
@@ -32,7 +33,7 @@ const Notice = forwardRef<HTMLDivElement, NoticeProps>(
   ) => {
     return (
       <div
-        className={classNames('Notice', {
+        className={classNames('Notice', className, {
           [`Notice--${type}`]: type,
           [`Notice--condensed`]: variant === 'condensed'
         })}


### PR DESCRIPTION
closes #1609 