### PR TITLE
chore: undo strict pixel matching

### DIFF
--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -32,11 +32,5 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] }
     }
-  ],
-  expect: {
-    toHaveScreenshot: {
-      maxDiffPixels: 0,
-      threshold: 0
-    }
-  }
+  ]
 });


### PR DESCRIPTION
Even while using docker, it seems there's still some flaky issues with visual diffs with screenshots, see:

- https://github.com/microsoft/playwright/issues/8161
- https://github.com/microsoft/playwright/issues/13873

We can undo this change for now, but may want to investigate addressing this in the future as we should be able to perform strict pixel matching when using docker images.