### PR TITLE
fix: onSelect prop for OptionsMenu is optional

### DIFF
--- a/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/react/src/components/OptionsMenu/OptionsMenu.tsx
@@ -22,7 +22,7 @@ export interface OptionsMenuProps extends OptionsMenuAlignmentProps {
   menuRef?: React.Ref<HTMLUListElement>;
   trigger?: (props: OptionsMenuRenderTriggerProps) => React.ReactNode;
   onClose?: () => void;
-  onSelect: (e: React.MouseEvent<HTMLElement>) => void;
+  onSelect?: (e: React.MouseEvent<HTMLElement>) => void;
   closeOnSelect?: boolean;
   show?: boolean;
   children: React.ReactNode;


### PR DESCRIPTION
With the new update to React 17, this component requires the `onSelect` prop. This can be changed to optional since it does not need to be used to function properly.

<img width="762" alt="Screenshot 2024-10-21 at 12 56 08 PM" src="https://github.com/user-attachments/assets/27f4b142-3064-4d36-99e0-16426b28946a">
