### PR TITLE
test: fix act errors in react tests

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { axe } from 'jest-axe';
@@ -97,18 +97,20 @@ test('should handle focus correctly', async () => {
   expect(onFocus.calledOnce).toBeTruthy();
 });
 
-test('should handle blur correctly', () => {
+test('should handle blur correctly', async () => {
   const onBlur = spy();
-  const input = renderCheckbox({ onBlur, checked: true });
+  const input = await renderCheckbox({ onBlur, checked: true });
   const checkboxIcon = input.parentElement!.querySelector(
     '.Checkbox__overlay'
   ) as HTMLElement;
   expect(checkboxIcon).not.toHaveClass('.Checkbox__overlay--focused');
   expect(onBlur.notCalled).toBeTruthy();
 
-  input.focus();
-  input.blur();
-  expect(input).not.toHaveFocus();
+  await waitFor(() => {
+    input.focus();
+    input.blur();
+    expect(input).not.toHaveFocus();
+  });
   expect(checkboxIcon).not.toHaveClass('Checkbox__overlay--focused');
   expect(onBlur.calledOnce).toBeTruthy();
 });

--- a/packages/react/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react/src/components/Drawer/Drawer.test.tsx
@@ -320,7 +320,7 @@ test('should return no axe violations when open', async () => {
     </Drawer>
   );
 
-  const results = await axe(screen.getByTestId('drawer'));
+  const results = await axe(await screen.findByTestId('drawer'));
   expect(results).toHaveNoViolations();
 });
 
@@ -331,6 +331,6 @@ test('should return no axe violations when closed', async () => {
     </Drawer>
   );
 
-  const results = await axe(screen.getByTestId('drawer'));
+  const results = await axe(await screen.findByTestId('drawer'));
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -1,11 +1,11 @@
 import React, { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import IconButton from './';
 
-it('should render button', () => {
+test('should render button', async () => {
   render(<IconButton icon="pencil" label="Edit" />);
-  const button = screen.getByRole('button', { name: 'Edit' });
+  const button = await screen.findByRole('button', { name: 'Edit' });
   expect(button).toBeInTheDocument();
   expect(button).toHaveAttribute('type', 'button');
   expect(button).toHaveAttribute('tabIndex', '0');
@@ -13,51 +13,52 @@ it('should render button', () => {
   expect(button).toHaveTextContent('');
 });
 
-it('should render secondary variant', () => {
+test('should render secondary variant', async () => {
   render(<IconButton icon="pencil" label="Edit" variant="secondary" />);
-  const button = screen.getByRole('button', { name: 'Edit' });
+  const button = await screen.findByRole('button', { name: 'Edit' });
   expect(button).toHaveClass('IconButton--secondary');
 });
 
-it('should render primary variant', () => {
+test('should render primary variant', async () => {
   render(<IconButton icon="pencil" label="Edit" variant="primary" />);
-  const button = screen.getByRole('button', { name: 'Edit' });
+  const button = await screen.findByRole('button', { name: 'Edit' });
   expect(button).toHaveClass('IconButton--primary');
 });
 
-it('should render tertiary variant', () => {
+test('should render tertiary variant', async () => {
   render(<IconButton icon="pencil" label="Edit" variant="tertiary" />);
-  const button = screen.getByRole('button', { name: 'Edit' });
+  const button = await screen.findByRole('button', { name: 'Edit' });
   expect(button).toHaveClass('IconButton--tertiary');
 });
 
-it('should render error variant', () => {
+test('should render error variant', async () => {
   render(<IconButton icon="pencil" label="Edit" variant="error" />);
-  const button = screen.getByRole('button', { name: 'Edit' });
+  const button = await screen.findByRole('button', { name: 'Edit' });
   expect(button).toHaveClass('IconButton--error');
 });
 
-it('should render a "as" an anchor', () => {
+test('should render a "as" an anchor', async () => {
   render(<IconButton icon="pencil" label="Edit" as="a" href="/somewhere" />);
-  const button = screen.queryByRole('link', { name: 'Edit' });
+  const button = await screen.findByRole('link', { name: 'Edit' });
   expect(button).toBeInTheDocument();
   expect(button).not.toHaveAttribute('role');
 });
 
-it('should be disabled', () => {
+test('should be disabled', async () => {
   render(<IconButton icon="pencil" label="Edit" disabled />);
-  expect(screen.queryByRole('button')).toBeDisabled();
+  expect(await screen.findByRole('button')).toBeDisabled();
 });
 
-it('should use aria-disabled for non-buttons when disabled', () => {
+test('should use aria-disabled for non-buttons when disabled', async () => {
   render(
     <IconButton icon="pencil" label="Edit" as="a" href="/somewhere" disabled />
   );
-  expect(screen.queryByRole('link')).not.toBeDisabled();
-  expect(screen.queryByRole('link')).toHaveAttribute('aria-disabled', 'true');
+  const link = await screen.findByRole('link');
+  expect(link).not.toBeDisabled();
+  expect(link).toHaveAttribute('aria-disabled', 'true');
 });
 
-it('should add button role for custom components', () => {
+test('should add button role for custom components', async () => {
   const CustomButton = React.forwardRef<HTMLDivElement>(function Component(
     props,
     ref
@@ -65,12 +66,13 @@ it('should add button role for custom components', () => {
     return <div data-testid="custom" ref={ref} {...props}></div>;
   });
   render(<IconButton icon="pencil" label="Edit" as={CustomButton} />);
-  expect(screen.getByTestId('custom')).toBeInTheDocument();
-  expect(screen.getByTestId('custom')).toHaveAttribute('role', 'button');
-  expect(screen.getByTestId('custom')).toHaveAttribute('tabIndex', '0');
+  const custom = await screen.findByTestId('custom');
+  expect(custom).toBeInTheDocument();
+  expect(custom).toHaveAttribute('role', 'button');
+  expect(custom).toHaveAttribute('tabIndex', '0');
 });
 
-it('should add link role when component behaves like a link', () => {
+test('should add link role when component behaves like a link', async () => {
   const CustomLink = React.forwardRef<HTMLDivElement>(function Component(
     props,
     ref
@@ -81,31 +83,38 @@ it('should add link role when component behaves like a link', () => {
     // @ts-expect-error this technically should be allowed
     <IconButton icon="pencil" label="Edit" as={CustomLink} to="/testing" />
   );
-  expect(screen.getByTestId('custom')).toBeInTheDocument();
-  expect(screen.getByTestId('custom')).toHaveAttribute('role', 'link');
-  expect(screen.getByTestId('custom')).toHaveAttribute('tabIndex', '0');
+  const custom = await screen.findByTestId('custom');
+  expect(custom).toBeInTheDocument();
+  expect(custom).toHaveAttribute('role', 'link');
+  expect(custom).toHaveAttribute('tabIndex', '0');
 });
 
-it('should not render tooltip when disabled prop is true', () => {
+test('should not render tooltip when disabled prop is true', () => {
   render(<IconButton icon="pencil" label="Edit" disabled />);
   expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   expect(screen.queryByRole('button')).toHaveAttribute('tabIndex', '-1');
   expect(screen.queryByRole('button')).toHaveAccessibleName('Edit');
 });
 
-it('should support className prop', () => {
+test('should support className prop', async () => {
   render(<IconButton className="bananas" icon="pencil" label="Edit" />);
-  expect(screen.queryByRole('button')).toHaveClass('IconButton', 'bananas');
+  expect(await screen.findByRole('button')).toHaveClass(
+    'IconButton',
+    'bananas'
+  );
 });
 
-it('should support ref prop', () => {
+test('should support ref prop', async () => {
   const ref = createRef<HTMLButtonElement>();
   render(<IconButton icon="pencil" label="Edit" ref={ref} />);
+  waitFor(() => {
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
   expect(ref.current).toBeTruthy();
   expect(ref.current).toEqual(screen.queryByRole('button'));
 });
 
-it('should support tooltipProps', () => {
+test('should support tooltipProps', async () => {
   render(
     <>
       <div id="foo">custom name</div>
@@ -120,12 +129,12 @@ it('should support tooltipProps', () => {
   // Note: this test is a bit obtuse since by default Tooltip overrides
   // aria-labelledby so we're testing the "none" association to ensure
   // we can set our own custom aria-label when necessary
-  expect(screen.queryByRole('button')).toHaveAccessibleName('custom name');
+  expect(await screen.findByRole('button')).toHaveAccessibleName('custom name');
 });
 
 test('should return no axe violations', async () => {
   render(<IconButton icon="pencil" label="Edit" />);
-  const results = await axe(screen.getByRole('button'));
+  const results = await axe(await screen.findByRole('button'));
   expect(results).toHaveNoViolations();
 });
 

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -131,7 +131,8 @@ test('should return no axe violations', async () => {
 
 test('should return no axe violations when rendered as anchor', async () => {
   render(<IconButton icon="pencil" label="Edit" as="a" href="/somewhere" />);
-  const results = await axe(screen.getByRole('link'));
+  const button = await screen.findByRole('link');
+  const results = await axe(button);
   expect(results).toHaveNoViolations();
 });
 
@@ -142,7 +143,9 @@ test('should return no axe violations when rendered as CustomElement', async () 
   ) {
     return <div data-testid="custom" ref={ref} {...props}></div>;
   });
+
   render(<IconButton icon="pencil" label="Edit" as={CustomButton} />);
-  const results = await axe(screen.getByTestId('custom'));
+  const button = await screen.findByTestId('custom');
+  const results = await axe(button);
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/MenuItem/index.test.tsx
+++ b/packages/react/src/components/MenuItem/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MenuItem from '../MenuItem';
 import { axe } from 'jest-axe';
@@ -29,6 +29,7 @@ test('calls onClick prop', async () => {
   await user.click(screen.getByText('BOOGNISH'));
   expect(onClick.calledOnce).toBeTruthy();
 });
+
 test('clicks the menuitem given enter/space keydowns', async () => {
   const onClick = sinon.spy();
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -67,6 +68,9 @@ test('should return no axe violations', async () => {
       <MenuItem>Foo</MenuItem>
     </ul>
   );
+  await waitFor(() => {
+    expect(container).toBeInTheDocument();
+  });
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/Pagination/index.test.tsx
+++ b/packages/react/src/components/Pagination/index.test.tsx
@@ -1,16 +1,21 @@
 import React, { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act
+} from '@testing-library/react';
 import Pagination, { usePagination } from './';
 import axe from '../../axe';
 
-test('should set `thin` variant when thin prop is provided', () => {
+test('should set `thin` variant when thin prop is provided', async () => {
   render(<Pagination totalItems={18} currentPage={1} thin />);
-  expect(screen.getByRole('list').parentElement).toHaveClass(
-    'Pagination--thin'
-  );
+  const list = await screen.findByRole('list');
+  expect(list.parentElement).toHaveClass('Pagination--thin');
 });
 
-test('should disable first/prev page buttons', () => {
+test('should disable first/prev page buttons', async () => {
   const onFirstPageClick = jest.fn();
   const onPreviousPageClick = jest.fn();
 
@@ -23,31 +28,23 @@ test('should disable first/prev page buttons', () => {
     />
   );
 
-  expect(screen.getAllByRole('button')[0]).toHaveAttribute(
-    'aria-disabled',
-    'true'
-  );
-  expect(screen.getAllByRole('button')[1]).toHaveAttribute(
-    'aria-disabled',
-    'true'
-  );
-  expect(screen.getAllByRole('button')[2]).toHaveAttribute(
-    'aria-disabled',
-    'false'
-  );
-  expect(screen.getAllByRole('button')[3]).toHaveAttribute(
-    'aria-disabled',
-    'false'
-  );
+  const buttons = await screen.findAllByRole('button');
 
-  fireEvent.click(screen.getAllByRole('button')[0]);
-  fireEvent.click(screen.getAllByRole('button')[1]);
+  expect(buttons[0]).toHaveAttribute('aria-disabled', 'true');
+  expect(buttons[1]).toHaveAttribute('aria-disabled', 'true');
+  expect(buttons[2]).toHaveAttribute('aria-disabled', 'false');
+  expect(buttons[3]).toHaveAttribute('aria-disabled', 'false');
+
+  await act(async () => {
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+  });
 
   expect(onFirstPageClick).not.toHaveBeenCalled();
   expect(onPreviousPageClick).not.toHaveBeenCalled();
 });
 
-test('should disable last/next page buttons', () => {
+test('should disable last/next page buttons', async () => {
   const onNextPageClick = jest.fn();
   const onLastPageClick = jest.fn();
 
@@ -60,40 +57,34 @@ test('should disable last/next page buttons', () => {
     />
   );
 
-  expect(screen.getAllByRole('button')[0]).toHaveAttribute(
-    'aria-disabled',
-    'false'
-  );
-  expect(screen.getAllByRole('button')[1]).toHaveAttribute(
-    'aria-disabled',
-    'false'
-  );
-  expect(screen.getAllByRole('button')[2]).toHaveAttribute(
-    'aria-disabled',
-    'true'
-  );
-  expect(screen.getAllByRole('button')[3]).toHaveAttribute(
-    'aria-disabled',
-    'true'
-  );
+  const buttons = await screen.findAllByRole('button');
 
-  fireEvent.click(screen.getAllByRole('button')[2]);
-  fireEvent.click(screen.getAllByRole('button')[3]);
+  expect(buttons[0]).toHaveAttribute('aria-disabled', 'false');
+  expect(buttons[1]).toHaveAttribute('aria-disabled', 'false');
+  expect(buttons[2]).toHaveAttribute('aria-disabled', 'true');
+  expect(buttons[3]).toHaveAttribute('aria-disabled', 'true');
+
+  await act(async () => {
+    fireEvent.click(buttons[2]);
+    fireEvent.click(buttons[3]);
+  });
 
   expect(onNextPageClick).not.toHaveBeenCalled();
   expect(onLastPageClick).not.toHaveBeenCalled();
 });
 
-test('should support custom status label text', () => {
+test('should support custom status label text', async () => {
   render(
     <Pagination totalItems={18} statusLabel={<div id="foo">hello world</div>} />
   );
 
-  expect(screen.getByText('hello world')).toHaveAttribute('id', 'foo');
-  expect(screen.getByRole('log')).toHaveTextContent('hello world');
+  const element = await screen.findByText('hello world');
+  expect(element).toHaveAttribute('id', 'foo');
+  const log = await screen.findByRole('log');
+  expect(log).toHaveTextContent('hello world');
 });
 
-test('should call on { Next, Previous, First, Last } click as expected', () => {
+test('should call on { Next, Previous, First, Last } click as expected', async () => {
   const onNextPageClick = jest.fn();
   const onPreviousPageClick = jest.fn();
   const onFirstPageClick = jest.fn();
@@ -111,37 +102,48 @@ test('should call on { Next, Previous, First, Last } click as expected', () => {
     />
   );
 
-  fireEvent.click(screen.getAllByRole('button')[0]);
+  const buttons = await screen.findAllByRole('button');
+
+  await act(async () => {
+    fireEvent.click(buttons[0]);
+  });
   expect(onFirstPageClick).toHaveBeenCalledTimes(1);
   expect(onPreviousPageClick).not.toHaveBeenCalled();
   expect(onNextPageClick).not.toHaveBeenCalled();
   expect(onLastPageClick).not.toHaveBeenCalled();
 
-  fireEvent.click(screen.getAllByRole('button')[1]);
+  await act(async () => {
+    fireEvent.click(buttons[1]);
+  });
   expect(onFirstPageClick).toHaveBeenCalledTimes(1);
   expect(onPreviousPageClick).toHaveBeenCalledTimes(1);
   expect(onNextPageClick).not.toHaveBeenCalled();
   expect(onLastPageClick).not.toHaveBeenCalled();
 
-  fireEvent.click(screen.getAllByRole('button')[2]);
+  await act(async () => {
+    fireEvent.click(buttons[2]);
+  });
   expect(onFirstPageClick).toHaveBeenCalledTimes(1);
   expect(onPreviousPageClick).toHaveBeenCalledTimes(1);
   expect(onNextPageClick).toHaveBeenCalledTimes(1);
   expect(onLastPageClick).not.toHaveBeenCalled();
 
-  fireEvent.click(screen.getAllByRole('button')[3]);
+  await act(async () => {
+    fireEvent.click(buttons[3]);
+  });
   expect(onFirstPageClick).toHaveBeenCalledTimes(1);
   expect(onPreviousPageClick).toHaveBeenCalledTimes(1);
   expect(onNextPageClick).toHaveBeenCalledTimes(1);
   expect(onLastPageClick).toHaveBeenCalledTimes(1);
 });
 
-test('should render the expected default status label', () => {
+test('should render the expected default status label', async () => {
   render(<Pagination totalItems={500} currentPage={3} itemsPerPage={17} />);
-  expect(screen.getByRole('log')).toHaveTextContent('Showing 35 to 51 of 500');
+  const log = await screen.findByRole('log');
+  expect(log).toHaveTextContent('Showing 35 to 51 of 500');
 });
 
-test('should initialize and handle pagesize change as expected', () => {
+test('should initialize and handle pagesize change as expected', async () => {
   let testPagination = null;
   let testPageStatus = null;
 
@@ -183,7 +185,11 @@ test('should initialize and handle pagesize change as expected', () => {
     pageEnd: 30
   });
 
-  fireEvent.click(screen.getAllByRole('button')[3]);
+  const buttons = await screen.findAllByRole('button');
+
+  await act(async () => {
+    fireEvent.click(buttons[3]);
+  });
 
   expect(testPageStatus).toMatchObject({
     currentPage: 4,
@@ -191,7 +197,9 @@ test('should initialize and handle pagesize change as expected', () => {
     pageEnd: 40
   });
 
-  fireEvent.click(screen.getAllByRole('button')[0]);
+  await act(async () => {
+    fireEvent.click(buttons[0]);
+  });
 
   expect(testPagination).toMatchObject({
     itemsPerPage: 25,
@@ -205,7 +213,7 @@ test('should initialize and handle pagesize change as expected', () => {
   });
 });
 
-test('should initialize and call on { Next, Previous, First, Last } click as expected', () => {
+test('should initialize and call on { Next, Previous, First, Last } click as expected', async () => {
   let testPagination;
   let testPageStatus;
 
@@ -235,7 +243,11 @@ test('should initialize and call on { Next, Previous, First, Last } click as exp
     pageEnd: 30
   });
 
-  fireEvent.click(screen.getAllByRole('button')[1]);
+  const buttons = await screen.findAllByRole('button');
+
+  await act(async () => {
+    fireEvent.click(buttons[1]);
+  });
 
   expect(testPageStatus).toMatchObject({
     currentPage: 2,
@@ -243,7 +255,9 @@ test('should initialize and call on { Next, Previous, First, Last } click as exp
     pageEnd: 20
   });
 
-  fireEvent.click(screen.getAllByRole('button')[2]);
+  await act(async () => {
+    fireEvent.click(buttons[2]);
+  });
 
   expect(testPageStatus).toMatchObject({
     currentPage: 3,
@@ -251,7 +265,9 @@ test('should initialize and call on { Next, Previous, First, Last } click as exp
     pageEnd: 30
   });
 
-  fireEvent.click(screen.getAllByRole('button')[0]);
+  await act(async () => {
+    fireEvent.click(buttons[0]);
+  });
 
   expect(testPageStatus).toMatchObject({
     currentPage: 1,
@@ -259,7 +275,9 @@ test('should initialize and call on { Next, Previous, First, Last } click as exp
     pageEnd: 10
   });
 
-  fireEvent.click(screen.getAllByRole('button')[3]);
+  await act(async () => {
+    fireEvent.click(buttons[3]);
+  });
 
   expect(testPageStatus).toMatchObject({
     currentPage: 50,
@@ -270,23 +288,36 @@ test('should initialize and call on { Next, Previous, First, Last } click as exp
 
 test('returns no axe violations', async () => {
   const { container } = render(<Pagination totalItems={500} currentPage={3} />);
+  await waitFor(() => {
+    expect(container).toBeInTheDocument();
+  });
   expect(await axe(container)).toHaveNoViolations();
 });
 
-test('should show start and end pagination buttons when hideStartEndPagination is not provided', () => {
+test('should show start and end pagination buttons when hideStartEndPagination is not provided', async () => {
   render(<Pagination totalItems={18} currentPage={1} />);
 
-  expect(screen.getByText('First page')).toBeInTheDocument();
-  expect(screen.getByText('Previous page')).toBeInTheDocument();
-  expect(screen.getByText('Next page')).toBeInTheDocument();
-  expect(screen.getByText('Last page')).toBeInTheDocument();
+  const firstPage = await screen.findByText('First page');
+  const previousPage = await screen.findByText('Previous page');
+  const nextPage = await screen.findByText('Next page');
+  const lastPage = await screen.findByText('Last page');
+
+  expect(firstPage).toBeInTheDocument();
+  expect(previousPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
+  expect(lastPage).toBeInTheDocument();
 });
 
-test('should hide start and end pagination buttons when hideStartEndPagination is true', () => {
+test('should hide start and end pagination buttons when hideStartEndPagination is true', async () => {
   render(<Pagination totalItems={18} currentPage={1} hideStartEndPagination />);
 
-  expect(screen.queryByText('First page')).not.toBeInTheDocument();
-  expect(screen.queryByText('Last page')).not.toBeInTheDocument();
-  expect(screen.getByText('Previous page')).toBeInTheDocument();
-  expect(screen.getByText('Next page')).toBeInTheDocument();
+  const firstPage = screen.queryByText('First page');
+  const lastPage = screen.queryByText('Last page');
+  const previousPage = await screen.findByText('Previous page');
+  const nextPage = await screen.findByText('Next page');
+
+  expect(firstPage).not.toBeInTheDocument();
+  expect(lastPage).not.toBeInTheDocument();
+  expect(previousPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
 });

--- a/packages/react/src/components/Popover/index.test.tsx
+++ b/packages/react/src/components/Popover/index.test.tsx
@@ -93,13 +93,13 @@ const WrapperPrompt = ({
 
 test('renders without blowing up', async () => {
   render(<Wrapper />);
-  expect(screen.getByText('Popover content')).toBeTruthy();
+  expect(await screen.findByText('Popover content')).toBeTruthy();
 });
 
 test('should auto-generate id', async () => {
   render(<Wrapper />);
-  const popover = screen.getByRole('dialog');
-  const button = screen.getByText('Popover button');
+  const popover = await screen.findByRole('dialog');
+  const button = await screen.findByText('Popover button');
   expect(popover).toBeTruthy();
   const id = popover?.getAttribute('id');
   expect(id).toBeTruthy();
@@ -126,7 +126,7 @@ test('should attach attribute aria-expanded correctly based on shown state', () 
 
 test('should support adding className to tooltip', async () => {
   render(<Wrapper tooltipProps={{ className: 'foo' }} />);
-  const popover = screen.getByRole('dialog');
+  const popover = await screen.findByRole('dialog');
   expect(popover).toBeTruthy();
   expect(popover).toHaveClass('Popover');
   expect(popover).toHaveClass('foo');
@@ -136,8 +136,8 @@ test('should not overwrite user provided id and aria-describedby', async () => {
   const buttonProps = { 'aria-describedby': 'foo popoverid' };
   const tooltipProps = { id: 'popoverid' };
   render(<Wrapper buttonProps={buttonProps} tooltipProps={tooltipProps} />);
-  const popover = screen.getByRole('dialog');
-  const button = screen.getByText('Popover button');
+  const popover = await screen.findByRole('dialog');
+  const button = await screen.findByText('Popover button');
   expect(popover).toHaveAttribute('id', 'popoverid');
   expect(button.getAttribute('aria-describedby')).toEqual('foo popoverid');
 });
@@ -277,7 +277,7 @@ test('should have no axe violations for prompt variant', async () => {
 test('aria-labelledby should exist for variant="custom"', async () => {
   render(<Wrapper />);
 
-  const popover = screen.getByRole('dialog');
+  const popover = await screen.findByRole('dialog');
   const ariaLabelledById = popover.getAttribute('aria-labelledby');
 
   expect(ariaLabelledById).toBeTruthy();

--- a/packages/react/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { axe } from 'jest-axe';
@@ -167,7 +167,7 @@ test('should handle focus correctly', async () => {
   expect(onFocus.calledOnce).toBeTruthy();
 });
 
-test('should handle blur correctly', () => {
+test('should handle blur correctly', async () => {
   const onBlur = spy();
   const [input] = renderRadioGroup({ onBlur });
   const radioIcon = input.parentElement!.querySelector(
@@ -176,9 +176,11 @@ test('should handle blur correctly', () => {
   expect(radioIcon).not.toHaveClass('.Radio__overlay--focused');
   expect(onBlur.notCalled).toBeTruthy();
 
-  input.focus();
-  input.blur();
-  expect(input).not.toHaveFocus();
+  await waitFor(() => {
+    input.focus();
+    input.blur();
+    expect(input).not.toHaveFocus();
+  });
   expect(radioIcon).not.toHaveClass('Radio__overlay--focused');
   expect(onBlur.calledOnce).toBeTruthy();
 });

--- a/packages/react/src/components/Scrim/index.test.tsx
+++ b/packages/react/src/components/Scrim/index.test.tsx
@@ -52,5 +52,8 @@ test('should return null when given a falsey show prop', () => {
 
 test('returns no axe violations', async () => {
   const { container } = render(<Scrim show={true} />);
+  await waitFor(() => {
+    expect(container).toBeInTheDocument();
+  });
   expect(await axe(container)).toHaveNoViolations();
 });

--- a/packages/react/src/components/SearchField/SearchField.test.tsx
+++ b/packages/react/src/components/SearchField/SearchField.test.tsx
@@ -1,5 +1,9 @@
 import React, { createRef, ComponentProps, useState } from 'react';
-import { render as testingRender, screen } from '@testing-library/react';
+import {
+  render as testingRender,
+  screen,
+  waitFor
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { axe } from 'jest-axe';
@@ -193,13 +197,17 @@ test('SearchField should render trailingChildren as a component', async () => {
     )
   });
 
+  waitFor(() => {
+    expect(input).toBeInTheDocument();
+  });
+
   expect(
     input.parentElement!.contains(
       screen.getByRole('button', {
         name: 'go to previous match'
       })
     )
-  ).toBeTruthy;
+  ).toBeTruthy();
 });
 
 test('SearchField should render trailingChildren as a string', async () => {
@@ -207,8 +215,9 @@ test('SearchField should render trailingChildren as a string', async () => {
     trailingChildren: 'I am a string'
   });
 
-  expect(input.parentElement!.contains(screen.getByText('I am a string')))
-    .toBeTruthy;
+  expect(
+    input.parentElement!.contains(screen.getByText('I am a string'))
+  ).toBeTruthy();
 });
 
 test('SearchField should render trailingChildren as an element', async () => {
@@ -222,7 +231,7 @@ test('SearchField should render trailingChildren as an element', async () => {
         name: 'I am a button'
       })
     )
-  ).toBeTruthy;
+  ).toBeTruthy();
 });
 
 test('SearchField should have no axe violations with default params', async () => {

--- a/packages/react/src/components/TextEllipsis/TextEllipsis.test.tsx
+++ b/packages/react/src/components/TextEllipsis/TextEllipsis.test.tsx
@@ -52,7 +52,7 @@ test('should display tooltip with overflow', async () => {
   act(() => {
     button.focus();
   });
-  expect(screen.queryByRole('tooltip')).toBeInTheDocument();
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 });
 
 test('should not display tooltip with no multiline overflow', () => {
@@ -68,7 +68,7 @@ test('should not display tooltip with no multiline overflow', () => {
   expect(screen.getByTestId('text-ellipsis')).not.toHaveAttribute('tabindex');
 });
 
-test('should display tooltip with multiline overflow', () => {
+test('should display tooltip with multiline overflow', async () => {
   sandbox.stub(global.HTMLDivElement.prototype, 'clientHeight').value(100);
   sandbox.stub(global.HTMLDivElement.prototype, 'scrollHeight').value(200);
   render(<TextEllipsis maxLines={2}>Hello World</TextEllipsis>);
@@ -81,7 +81,7 @@ test('should display tooltip with multiline overflow', () => {
   act(() => {
     button.focus();
   });
-  expect(screen.queryByRole('tooltip')).toBeInTheDocument();
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 });
 
 test('should support className prop', () => {

--- a/packages/react/src/components/Toast/toast.test.tsx
+++ b/packages/react/src/components/Toast/toast.test.tsx
@@ -98,13 +98,15 @@ Object.entries(toastTypes).forEach(([key, value]) => {
       </Toast>
     );
 
-    // wait for animation tiemouts / async setState calls
-    await setTimeout(undefined, () => {
-      expect(screen.getByTestId('toast')).toHaveClass(
-        'Toast',
-        'Toast--info',
-        'is--hidden'
-      );
+    // wait for animation timeouts / async setState calls
+    await waitFor(async () => {
+      await setTimeout(undefined, () => {
+        expect(screen.getByTestId('toast')).toHaveClass(
+          'Toast',
+          'Toast--info',
+          'is--hidden'
+        );
+      });
     });
   });
 
@@ -241,6 +243,9 @@ test('non-dismissible toast has no accessibility issues', async () => {
     </Toast>
   );
 
+  waitFor(() => {
+    expect(container).toBeInTheDocument();
+  });
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/components/TooltipTabstop/index.test.tsx
+++ b/packages/react/src/components/TooltipTabstop/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
 import TooltipTabstop from './';
 import axe from '../../axe';
 
@@ -12,9 +12,13 @@ test('should display tooltip on hover', async () => {
   render(<TooltipTabstop tooltip="World">Hello</TooltipTabstop>);
 
   expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
-  await fireEvent.focusIn(screen.getByRole('button'));
-  expect(screen.queryByRole('tooltip')).toBeInTheDocument();
-  expect(screen.getByRole('button')).toHaveAccessibleDescription('World');
+  act(() => {
+    fireEvent.focusIn(screen.getByRole('button'));
+  });
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+  expect(await screen.findByRole('button')).toHaveAccessibleDescription(
+    'World'
+  );
 });
 
 test('should return no axe violations', async () => {

--- a/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.test.tsx
+++ b/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.test.tsx
@@ -8,7 +8,7 @@ import {
 } from './';
 import SkipLink from '../SkipLink';
 import axe from '../../axe';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const sandbox = createSandbox();
@@ -36,7 +36,7 @@ afterEach(() => {
   sandbox.restore();
 });
 
-test('should render TwoColumnPanel', () => {
+test('should render TwoColumnPanel', async () => {
   render(
     <TwoColumnPanel
       data-testid="two-column-panel"
@@ -85,15 +85,17 @@ test('should render TwoColumnPanel', () => {
     name: /test-hide-panel/i
   });
 
-  expect(columnRightToggleButton).toBeInTheDocument();
-  expect(columnRightToggleButton).toHaveAttribute('aria-expanded', 'true');
-  expect(columnRightToggleButton).toHaveAttribute(
-    'aria-controls',
-    'column-left-id'
-  );
+  waitFor(() => {
+    expect(columnRightToggleButton).toBeInTheDocument();
+    expect(columnRightToggleButton).toHaveAttribute('aria-expanded', 'true');
+    expect(columnRightToggleButton).toHaveAttribute(
+      'aria-controls',
+      'column-left-id'
+    );
+  });
 });
 
-test('should render collapsed TwoColumnPanel', () => {
+test('should render collapsed TwoColumnPanel', async () => {
   matchMediaStub.withArgs('(max-width: 45rem)').returns({
     matches: true,
     addEventListener: noop,
@@ -148,7 +150,9 @@ test('should render collapsed TwoColumnPanel', () => {
     name: /test-hide-panel/i
   });
 
-  expect(columnRightToggleButton).not.toBeInTheDocument();
+  waitFor(() => {
+    expect(columnRightToggleButton).not.toBeInTheDocument();
+  });
 });
 
 test('should collapse panel when prefers-reduced-motion: reduce is set', async () => {
@@ -199,10 +203,12 @@ test('should collapse panel when prefers-reduced-motion: reduce is set', async (
     })
   );
 
-  expect(screen.queryByTestId('column-left')).not.toBeInTheDocument();
+  waitFor(() => {
+    expect(screen.queryByTestId('column-left')).not.toBeInTheDocument();
+  });
 });
 
-test('should render configurable collapsed TwoColumnPanel', () => {
+test('should render configurable collapsed TwoColumnPanel', async () => {
   matchMediaStub.withArgs('(max-width: 999rem)').returns({
     matches: true,
     addEventListener: noop,
@@ -250,7 +256,9 @@ test('should render configurable collapsed TwoColumnPanel', () => {
   expect(screen.queryByTestId('column-left')).not.toBeInTheDocument();
 
   const columnRight = screen.getByTestId('column-right');
-  expect(columnRight).toBeInTheDocument();
+  waitFor(() => {
+    expect(columnRight).toBeInTheDocument();
+  });
 
   expect(
     within(columnRight).getByRole('button', {
@@ -259,7 +267,7 @@ test('should render configurable collapsed TwoColumnPanel', () => {
   ).toHaveAttribute('aria-expanded', 'false');
 });
 
-test('should accept a skip link', () => {
+test('should accept a skip link', async () => {
   render(
     <TwoColumnPanel
       data-testid="two-column-panel"
@@ -305,7 +313,9 @@ test('should accept a skip link', () => {
     </TwoColumnPanel>
   );
 
-  screen.getByRole('link', { name: /Test skip to Test content/i });
+  expect(
+    await screen.findByRole('link', { name: /Test skip to Test content/i })
+  ).toBeInTheDocument();
 });
 
 test('should return no axe violations', async () => {
@@ -344,7 +354,9 @@ test('should return no axe violations', async () => {
       </ColumnRight>
     </TwoColumnPanel>
   );
-
+  await waitFor(() => {
+    expect(container).toBeInTheDocument();
+  });
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });

--- a/packages/react/src/contexts/theme.test.tsx
+++ b/packages/react/src/contexts/theme.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { ThemeProvider, useThemeContext } from './theme';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 let theme: string,
   toggleTheme: () => void,


### PR DESCRIPTION
Test output has been very difficult to read because it was interspersed with `When testing, code that causes React state updates should be wrapped into act(...)`. This makes it hard to narrow down issues when tests are failing because of all of these console messages.

This PR cleans up these test cases where this error is occurring to make the test output more readable.