### PR TITLE
fix(react): remove defaultProps from sidebar, use default parameters instead

### DIFF
--- a/packages/react/src/components/SideBar/SideBarItem.tsx
+++ b/packages/react/src/components/SideBar/SideBarItem.tsx
@@ -9,7 +9,7 @@ export interface SideBarItemProps extends React.HTMLAttributes<HTMLLIElement> {
 
 const SideBarItem: React.ComponentType<
   React.PropsWithChildren<SideBarItemProps>
-> = ({ children, autoClickLink, ...other }: SideBarItemProps) => {
+> = ({ children, autoClickLink = true, ...other }: SideBarItemProps) => {
   const onClick = (e: React.MouseEvent<HTMLLIElement>) => {
     if (!autoClickLink) {
       return;
@@ -27,8 +27,5 @@ const SideBarItem: React.ComponentType<
 };
 
 SideBarItem.displayName = 'SideBarItem';
-SideBarItem.defaultProps = {
-  autoClickLink: true
-};
 
 export default SideBarItem;


### PR DESCRIPTION

Fixing the following error: 

> console.error
>      Warning: SideBarItem: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
>          at SideBarItem (/home/runner/work/cauldron/cauldron/packages/react/src/components/SideBar/SideBarItem.tsx:12:8)
>          at ul
>          at nav
>          at ClickOutsideListener > (/home/runner/work/cauldron/cauldron/packages/react/src/components/ClickOutsideListener/index.tsx:17:5)
          at SideBar (/home/runner/work/cauldron/cauldron/packages/react/src/components/SideBar/SideBar.tsx:33:5)