### PR TITLE
test: remove unnecessary console messages in theme test

### DIFF
--- a/packages/react/src/contexts/theme.test.tsx
+++ b/packages/react/src/contexts/theme.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { ThemeProvider, useThemeContext } from './theme';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 let theme: string,
   toggleTheme: () => void,
@@ -42,6 +41,10 @@ const renderProvider = (themeProviderProps = {}) => {
     </ThemeProvider>
   );
 };
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 test('it exposes the current theme (defaulting to light)', () => {
   renderProvider();
@@ -95,6 +98,10 @@ test('disconnects mutation observer when unmounted', () => {
 });
 
 test('throw an exception, without provider', () => {
+  // react will log an error when the context throws, but we don't want it
+  // to show up in our test output
+  jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
   const Component = () => {
     const { toggleTheme } = useThemeContext();
     toggleTheme();


### PR DESCRIPTION
The theme test will toss out a `console.error` which we don't really need to see...