### PR TITLE
test: remove noisy console error for MenuItem

### DIFF
--- a/packages/react/src/components/MenuItem/index.test.tsx
+++ b/packages/react/src/components/MenuItem/index.test.tsx
@@ -9,9 +9,11 @@ const user = userEvent.setup();
 
 test('clicks first direct child link given a click', async () => {
   const onClick = sinon.spy();
+  // Note: Using a hash link instead of a url link because jsdom doesn't correctly
+  // support navigation and throws a noisy console error we don't care about
   render(
     <MenuItem>
-      <a href="/foo" onClick={onClick}>
+      <a href="#foo" onClick={onClick}>
         Foo
       </a>
     </MenuItem>


### PR DESCRIPTION
This removes the `Error: Not implemented: navigation (except hash changes)` error that happens within the menu item test.