### PR TITLE
feat(react): add focusTrap options to AnchoredOverlay

### DIFF
--- a/docs/pages/components/AnchoredOverlay.mdx
+++ b/docs/pages/components/AnchoredOverlay.mdx
@@ -174,6 +174,16 @@ function AnchoredOverlayWithOffsetExample() {
       description: 'An optional offset number to position the anchor element from its anchored target.'
     },
     {
+      name: 'focusTrap',
+      type: 'boolean',
+      description: 'When set, traps focus within the AnchoredOverlay.'
+    },
+    {
+      name: 'focusTrapOptions',
+      type: 'object',
+      description: 'When `focusTrap` is true, optional arguments to configure the focus trap.'
+    },
+    {
       name: 'as',
       type: 'React.ElementType',
       defaultValue: 'div',

--- a/packages/react/src/components/AnchoredOverlay/index.tsx
+++ b/packages/react/src/components/AnchoredOverlay/index.tsx
@@ -10,6 +10,7 @@ import { type PolymorphicProps } from '../../utils/polymorphicComponent';
 import resolveElement from '../../utils/resolveElement';
 import useSharedRef from '../../utils/useSharedRef';
 import useEscapeKey from '../../utils/useEscapeKey';
+import useFocusTrap from '../../utils/useFocusTrap';
 
 type AnchoredOverlayProps<
   Overlay extends HTMLElement,
@@ -27,6 +28,10 @@ type AnchoredOverlayProps<
   onPlacementChange?: (placement: Placement) => void;
   /** An optional offset number to position the anchor element from its anchored target. */
   offset?: number;
+  /** When set, traps focus within the AnchoredOverlay. */
+  focusTrap?: boolean;
+  /** When `focusTrap` is true, optional arguments to configure the focus trap. */
+  focusTrapOptions?: Parameters<typeof useFocusTrap>[1];
   children?: React.ReactNode;
 } & PolymorphicProps<React.HTMLAttributes<Overlay>>;
 
@@ -56,6 +61,8 @@ const AnchoredOverlay = forwardRef(
       style,
       open = false,
       offset,
+      focusTrap,
+      focusTrapOptions,
       onOpenChange,
       onPlacementChange,
       ...props
@@ -97,6 +104,11 @@ const AnchoredOverlay = forwardRef(
           onOpenChange(!open);
         }
       }
+    });
+
+    useFocusTrap(ref, {
+      disabled: !focusTrap,
+      ...(focusTrap ? focusTrapOptions : {})
     });
 
     useEffect(() => {

--- a/packages/react/src/components/AnchoredOverlay/index.tsx
+++ b/packages/react/src/components/AnchoredOverlay/index.tsx
@@ -106,10 +106,7 @@ const AnchoredOverlay = forwardRef(
       }
     });
 
-    useFocusTrap(ref, {
-      disabled: !focusTrap,
-      ...(focusTrap ? focusTrapOptions : {})
-    });
+    useFocusTrap(ref, !focusTrap ? { disabled: true } : focusTrapOptions);
 
     useEffect(() => {
       if (typeof onPlacementChange === 'function') {


### PR DESCRIPTION
Focus trap settings on AnchoredOverlay should be able to be configured for outside projects that do not have access to Cauldron internals.