### PR TITLE
fix(react): fix a11y active-descendant issue with controlled Listboxes

### DIFF
--- a/packages/react/src/components/Listbox/Listbox.tsx
+++ b/packages/react/src/components/Listbox/Listbox.tsx
@@ -104,15 +104,19 @@ const Listbox = forwardRef<
           )
         );
         setSelectedOptions(matchingOptions);
-        setActiveOption(matchingOptions[0] || null);
+        if (!activeOption) {
+          setActiveOption(matchingOptions[0] || null);
+        }
       } else {
         const matchingOption = options.find((option) =>
           optionMatchesValue(option, listboxValue)
         );
         setSelectedOptions(matchingOption ? [matchingOption] : []);
-        setActiveOption(matchingOption || null);
+        if (!activeOption) {
+          setActiveOption(matchingOption || null);
+        }
       }
-    }, [isControlled, options, value, defaultValue]);
+    }, [isControlled, options, value, defaultValue, activeOption]);
 
     useEffect(() => {
       if (activeOption) {


### PR DESCRIPTION
This addresses an obscure issue when using controlled listboxes. The behavior basically was whenever the value would change, it would always reset the active element to the first selected element in the list causing the focus to reset on the element whenever new selections were made.