### PR TITLE
fix(react): deprecate RadioCardGroup component

### DIFF
--- a/docs/pages/components/RadioCardGroup.mdx
+++ b/docs/pages/components/RadioCardGroup.mdx
@@ -1,6 +1,7 @@
 ---
 title: RadioCardGroup
 description: A radio group with options styled like cards.
+deprecated: true
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/RadioCardGroup/index.tsx
 ---
 


### PR DESCRIPTION
This pattern is deprecated and should not be used going forward. We have a desired pattern to move forward with but want to at least document this as deprecated https://github.com/dequelabs/cauldron/issues/1289