### PR TITLE
feat(button): Add "badge" variant

### DIFF
--- a/docs/pages/components/Button.mdx
+++ b/docs/pages/components/Button.mdx
@@ -4,7 +4,7 @@ description: An interactive component that performs a programmable action when a
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Button/index.tsx
 ---
 
-import { Icon, Button, Code } from '@deque/cauldron-react'
+import { Icon, Button, Code, BadgeLabel } from '@deque/cauldron-react'
 
 ```js
 import { Button } from '@deque/cauldron-react'
@@ -76,6 +76,30 @@ When you need a semantic button with the visual appearance of a link.
 
 ```jsx example
 <Button variant="tag">Tag</Button>
+```
+
+### Badge
+
+```jsx example
+<Button variant="badge">Badge</Button>
+```
+
+### Badge with Label
+
+```jsx example
+<Button variant="badge">
+  <BadgeLabel>Label:</BadgeLabel>
+  value
+</Button>
+```
+
+### Disabled Badge with Label
+
+```jsx example
+<Button variant="badge" disabled>
+  <BadgeLabel>Label:</BadgeLabel>
+  value
+</Button>
 ```
 
 ### Additional Button States

--- a/packages/react/src/components/Button/index.test.tsx
+++ b/packages/react/src/components/Button/index.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import Button from '../../../src/components/Button';
 import Icon from '../../../src/components/Icon';
 import axe from '../../axe';
+import { BadgeLabel } from '../Badge';
 
 test('should render primary button', () => {
   render(
@@ -47,6 +48,24 @@ test('should render button as tag', () => {
   render(<Button variant="tag">tag</Button>);
   const TagButton = screen.getByRole('button', { name: 'tag' });
   expect(TagButton).toHaveClass('Tag');
+});
+
+test('should render button as badge', () => {
+  render(<Button variant="badge">badge</Button>);
+  const BadgeButton = screen.getByRole('button', { name: 'badge' });
+  expect(BadgeButton).toHaveClass('Button--badge');
+});
+
+test('should support <BadgeLabel> as a child', () => {
+  render(
+    <Button>
+      <BadgeLabel>Label</BadgeLabel>
+      Value
+    </Button>
+  );
+  const button = screen.getByRole('button', { name: 'Label Value' });
+  const label = button.firstElementChild;
+  expect(label).toHaveTextContent('Label');
 });
 
 test('should handle <Icon /> as child', () => {

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,9 +1,16 @@
-import React, { ButtonHTMLAttributes, forwardRef, Ref } from 'react';
+import React, { type ButtonHTMLAttributes, forwardRef, type Ref } from 'react';
 import classNames from 'classnames';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   buttonRef?: Ref<HTMLButtonElement>;
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'error' | 'link' | 'tag';
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'error'
+    | 'link'
+    | 'tag'
+    | 'badge';
   thin?: boolean;
 }
 
@@ -20,7 +27,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => (
     <button
-      type={'button'}
+      type="button"
       className={classNames(className, {
         'Button--primary': variant === 'primary',
         'Button--secondary': variant === 'secondary',
@@ -29,7 +36,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         Link: variant === 'link',
         Tag: variant === 'tag',
         'Button--tag': variant === 'tag',
-        'Button--thin': thin
+        'Button--thin': thin,
+        'Button--badge': variant === 'badge'
       })}
       ref={ref || buttonRef}
       {...other}

--- a/packages/styles/button.css
+++ b/packages/styles/button.css
@@ -52,6 +52,20 @@
   position: relative;
 }
 
+.Button--badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-small) 0 var(--space-smaller);
+  background-color: var(--badge-background-color);
+  color: var(--gray-90);
+  border: 1px solid var(--badge-border-color);
+  border-radius: var(--badge-height);
+  font-size: var(--text-size-body);
+  font-weight: var(--font-weight-normal);
+  min-height: var(--badge-height);
+}
+
 button.Link {
   cursor: pointer;
   font-size: inherit;
@@ -71,7 +85,8 @@ button.Link {
 .Button--tertiary:before,
 .Button--clear:before,
 .Button--error:before,
-.Button--tag:before {
+.Button--tag:before,
+.Button--badge:before {
   content: '';
   position: absolute;
   top: -2px;
@@ -82,7 +97,8 @@ button.Link {
   pointer-events: none;
 }
 
-.Button--tag:before {
+.Button--tag:before,
+.Button--badge:before {
   border-radius: var(--button-height);
 }
 
@@ -99,7 +115,8 @@ button.Link {
   box-shadow: 0 0 0 1px var(--button-outline-color-error);
 }
 
-.Button--tag:not([disabled]):not([aria-disabled='true']):hover:before {
+.Button--tag:not([disabled]):not([aria-disabled='true']):hover:before,
+.Button--badge:not([disabled]):not([aria-disabled='true']):hover:before {
   box-shadow: 0 0 0 1px var(--button-outline-color-secondary);
 }
 
@@ -167,7 +184,8 @@ button.Link {
   background-color: var(--button-background-color-error-active);
 }
 
-.Button--tag:is([disabled], [aria-disabled='true']) {
+.Button--tag:is([disabled], [aria-disabled='true']),
+.Button--badge:is([disabled], [aria-disabled='true']) {
   color: var(--disabled);
 }
 


### PR DESCRIPTION
This patch adds a "badge" variant to our `<Button>` component.

Closes https://github.com/dequelabs/cauldron/issues/1783