### PR TITLE
build: Ensure all source files are formatted by Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 # Ignore generated files
 CHANGELOG.md
+**/coverage/**
+packages/react/lib/**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:react": "yarn --cwd=packages/react dev",
     "dev:styles": "yarn --cwd=packages/styles dev",
     "dev:docs": "webpack-dev-server",
-    "fmt": "prettier --write \"e2e/*.ts\" \"docs/**/*.{css,js}\" \"packages/react/**/*.{js,ts,tsx}\" \"packages/styles/*.css\" *.{js,json,md,ts}",
+    "fmt": "prettier --write .",
     "lint": "eslint . --quiet",
     "typecheck": "yarn --cwd=packages/react tsc --noEmit --skipLibCheck",
     "prebuild": "yarn clean",


### PR DESCRIPTION
This patch allows Prettier to select which files are formatted rather than manually specifying them ourselves.

If merged, this will prevent huge diffs like #1796 moving forward.