### PR TITLE
chore: remove duplicate e2e volume mount

### DIFF
--- a/e2e/helpers/playwright.ts
+++ b/e2e/helpers/playwright.ts
@@ -1,5 +1,4 @@
 import type { Page, Locator } from '@playwright/test';
-import path from 'path';
 
 export async function setTheme(page: Page, theme: 'light' | 'dark') {
   await page.evaluate(

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "yarn --cwd=packages/react test",
     "test:a11y": "ts-node e2e/accessibility.ts",
     "postinstall": "if [ -z \"$CI\" ]; then yarn --cwd=packages/styles && yarn --cwd=packages/react; fi",
-    "screenshots": "docker run --rm --ipc=host -v $(pwd)/playwright-ct.config.ts:/app/playwright-ct.config.ts -v $(pwd)/packages:/app/packages -v $(pwd)/e2e:/app/e2e -v $(pwd)/e2e:/app/e2e cauldron-playwright-e2e-screenshots",
+    "screenshots": "docker run --rm --ipc=host -v $(pwd)/playwright-ct.config.ts:/app/playwright-ct.config.ts -v $(pwd)/packages:/app/packages -v $(pwd)/e2e:/app/e2e cauldron-playwright-e2e-screenshots",
     "screenshots:docker": "docker build . -t cauldron-playwright-e2e-screenshots -f e2e/Dockerfile --build-arg playwright_version=$(npm list --depth=0 playwright | grep playwright | cut -f2 -d '@')",
     "release": "./scripts/release.sh"
   },


### PR DESCRIPTION
I found this when debugging why the Playwright tests weren't failing after changing a CSS var in https://github.com/dequelabs/cauldron/pull/1808.