### PR TITLE
feat(react, styles): add `PageHeader` and `SectionHeader` components with styles and tests

### DIFF
--- a/docs/pages/components/PageHeader.mdx
+++ b/docs/pages/components/PageHeader.mdx
@@ -24,9 +24,9 @@ The `PageHeader` component is used to display a header for a page, typically inc
 
 ```jsx example
 <PageHeader
+  heading={<h2>Page Title</h2>}
   overline="Optional overline text"
-  heading="Page Title"
-  description="Optinal description text"
+  description="Optional description text"
 >
   <div>
     <Button variant="primary">Save</Button>
@@ -48,15 +48,24 @@ The `PageHeader` component is used to display a header for a page, typically inc
   props={[
     {
       name: 'heading',
-      type: ['string', 'ReactNode'],
+      type: 'React.ReactNode',
       description: 'The heading to display in the header.',
       required: true
     },
     {
-      name: 'actions',
-      type: ['ReactNode'],
-      description: 'Optional actions to display in the header, such as buttons.'
+      name: 'overline',
+      type: 'React.ReactNode',
+      description: 'Optional description to display abowe the heading.'
+    },
+    {
+      name: 'description',
+      type: 'React.ReactNode',
+      description: 'Optional description to display below the heading.'
     }
   ]}
   refType="HTMLDivElement"
 />
+
+## Related Components  
+
+- [SectionHeader](./SectionHeader)  

--- a/docs/pages/components/PageHeader.mdx
+++ b/docs/pages/components/PageHeader.mdx
@@ -1,0 +1,62 @@
+---
+heading: PageHeader
+description: A header component for pages, providing a heading and optional actions.
+source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/PageHeader/PageHeader.tsx
+---
+
+import { PageHeader, Button } from '@deque/cauldron-react';
+
+```js
+import { PageHeader } from '@deque/cauldron-react';
+```
+
+The `PageHeader` component is used to display a header for a page, typically including a heading and optional actions.
+
+## Examples
+
+### Basic Usage
+
+```jsx example
+<PageHeader heading="Page Title" />
+```
+
+### With Actions
+
+```jsx example
+<PageHeader
+  overline="Optional overline text"
+  heading="Page Title"
+  description="Optinal description text"
+>
+  <div>
+    <Button variant="primary">Save</Button>
+    <Button variant="secondary">Cancel</Button>
+  </div>
+</PageHeader>
+```
+
+### Custom Title
+
+```jsx example
+<PageHeader heading={<h1>Custom Page Title</h1>} overline="Optional overline text" />
+```
+
+## Props
+
+<ComponentProps
+  children="true"
+  props={[
+    {
+      name: 'heading',
+      type: ['string', 'ReactNode'],
+      description: 'The heading to display in the header.',
+      required: true
+    },
+    {
+      name: 'actions',
+      type: ['ReactNode'],
+      description: 'Optional actions to display in the header, such as buttons.'
+    }
+  ]}
+  refType="HTMLDivElement"
+/>

--- a/docs/pages/components/PageHeader.mdx
+++ b/docs/pages/components/PageHeader.mdx
@@ -1,7 +1,7 @@
 ---
 heading: PageHeader
 description: A header component for pages, providing a heading and optional actions.
-source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/PageHeader/PageHeader.tsx
+source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/PageHeader/index.tsx
 ---
 
 import { PageHeader, Button } from '@deque/cauldron-react';

--- a/docs/pages/components/PageHeader.mdx
+++ b/docs/pages/components/PageHeader.mdx
@@ -28,17 +28,18 @@ The `PageHeader` component is used to display a header for a page, typically inc
   overline="Optional overline text"
   description="Optional description text"
 >
-  <div>
-    <Button variant="primary">Save</Button>
-    <Button variant="secondary">Cancel</Button>
-  </div>
+  <Button variant="primary">Save</Button>
+  <Button variant="secondary">Cancel</Button>
 </PageHeader>
 ```
 
 ### Custom Title
 
 ```jsx example
-<PageHeader heading={<h1>Custom Page Title</h1>} overline="Optional overline text" />
+<PageHeader
+  heading={<h1>Custom Page Title</h1>}
+  overline="Optional overline text"
+/>
 ```
 
 ## Props
@@ -66,6 +67,6 @@ The `PageHeader` component is used to display a header for a page, typically inc
   refType="HTMLDivElement"
 />
 
-## Related Components  
+## Related Components
 
-- [SectionHeader](./SectionHeader)  
+- [SectionHeader](./SectionHeader)

--- a/docs/pages/components/SectionHeader.mdx
+++ b/docs/pages/components/SectionHeader.mdx
@@ -1,0 +1,69 @@
+---
+heading: SectionHeader
+description: A header component for sections, providing a heading and optional actions.
+source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/SectionHeader/SectionHeader.tsx
+---
+
+import { SectionHeader, Button } from '@deque/cauldron-react';
+
+```js
+import { SectionHeader } from '@deque/cauldron-react';
+```
+
+The `SectionHeader` component is used to display a header for sections, typically including a heading and optional actions.
+
+## Examples
+
+### Basic Usage
+
+```jsx example
+<SectionHeader heading="Section Title" />
+```
+
+### With Actions
+
+```jsx example
+<SectionHeader
+  heading="Section Title"
+  description="Optinal description text"
+>
+  <div>
+    <Button variant="primary">Save</Button>
+    <Button variant="secondary">Cancel</Button>
+  </div>
+</SectionHeader>
+```
+
+### Custom Title
+
+```jsx example
+<SectionHeader 
+  heading={<h3>Custom Section Title</h3>} 
+  description="Optinal description text"
+/>
+```
+
+## Props
+
+<ComponentProps
+  children="true"
+  props={[
+    {
+      name: 'heading',
+      type: ['string', 'ReactNode'],
+      description: 'The heading to display in the header.',
+      required: true
+    },
+    {
+      name: 'description',
+      type: ['ReactNode'],
+      description: 'Optional description to display below the heading.'
+    },
+    {
+      name: 'actions',
+      type: ['ReactNode'],
+      description: 'Optional actions to display in the header, such as buttons.'
+    }
+  ]}
+  refType="HTMLDivElement"
+/>

--- a/docs/pages/components/SectionHeader.mdx
+++ b/docs/pages/components/SectionHeader.mdx
@@ -1,7 +1,7 @@
 ---
 heading: SectionHeader
 description: A header component for sections, providing a heading and optional actions.
-source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/SectionHeader/SectionHeader.tsx
+source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/SectionHeader/index.tsx
 ---
 
 import { SectionHeader, Button } from '@deque/cauldron-react';

--- a/docs/pages/components/SectionHeader.mdx
+++ b/docs/pages/components/SectionHeader.mdx
@@ -23,10 +23,7 @@ The `SectionHeader` component is used to display a header for sections, typicall
 ### With Actions
 
 ```jsx example
-<SectionHeader
-  heading="Section Title"
-  description="Optinal description text"
->
+<SectionHeader heading="Section Title" description="Optional description text">
   <div>
     <Button variant="primary">Save</Button>
     <Button variant="secondary">Cancel</Button>
@@ -37,9 +34,9 @@ The `SectionHeader` component is used to display a header for sections, typicall
 ### Custom Title
 
 ```jsx example
-<SectionHeader 
-  heading={<h3>Custom Section Title</h3>} 
-  description="Optinal description text"
+<SectionHeader
+  heading={<h3>Custom Section Title</h3>}
+  description="Optional description text"
 />
 ```
 
@@ -50,20 +47,19 @@ The `SectionHeader` component is used to display a header for sections, typicall
   props={[
     {
       name: 'heading',
-      type: ['string', 'ReactNode'],
+      type: 'React.ReactNode',
       description: 'The heading to display in the header.',
       required: true
     },
     {
       name: 'description',
-      type: ['ReactNode'],
+      type: 'React.ReactNode',
       description: 'Optional description to display below the heading.'
-    },
-    {
-      name: 'actions',
-      type: ['ReactNode'],
-      description: 'Optional actions to display in the header, such as buttons.'
     }
   ]}
   refType="HTMLDivElement"
 />
+
+## Related Components  
+
+- [PageHeader](./PageHeader)  

--- a/docs/pages/components/SectionHeader.mdx
+++ b/docs/pages/components/SectionHeader.mdx
@@ -24,10 +24,8 @@ The `SectionHeader` component is used to display a header for sections, typicall
 
 ```jsx example
 <SectionHeader heading="Section Title" description="Optional description text">
-  <div>
-    <Button variant="primary">Save</Button>
-    <Button variant="secondary">Cancel</Button>
-  </div>
+  <Button variant="primary">Save</Button>
+  <Button variant="secondary">Cancel</Button>
 </SectionHeader>
 ```
 
@@ -60,6 +58,6 @@ The `SectionHeader` component is used to display a header for sections, typicall
   refType="HTMLDivElement"
 />
 
-## Related Components  
+## Related Components
 
-- [PageHeader](./PageHeader)  
+- [PageHeader](./PageHeader)

--- a/packages/react/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.test.tsx
@@ -3,10 +3,20 @@ import { render, screen } from '@testing-library/react';
 import PageHeader from './';
 import axe from '../../axe';
 
+test('should support ref prop', () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <PageHeader heading="Page Title" ref={ref} data-testid="pageheader" />
+  );
+
+  expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  expect(ref.current).toEqual(screen.getByTestId('pageheader'));
+});
+
 test('should render heading', () => {
   render(<PageHeader heading="Page Title" />);
   expect(
-    screen.getByRole('heading', { name: 'Page Title' })
+    screen.getByRole('heading', { name: 'Page Title', level: 1 })
   ).toBeInTheDocument();
 });
 

--- a/packages/react/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.test.tsx
@@ -13,6 +13,13 @@ test('should support ref prop', () => {
   expect(ref.current).toEqual(screen.getByTestId('pageheader'));
 });
 
+test('should render when heading passed as element but not as a string', () => {
+  render(<PageHeader heading={<h2>Custom Page Title</h2>} />);
+  expect(
+    screen.getByRole('heading', { name: 'Custom Page Title', level: 2 })
+  ).toBeInTheDocument();
+});
+
 test('should render heading', () => {
   render(<PageHeader heading="Page Title" />);
   expect(

--- a/packages/react/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PageHeader from './';
+import axe from '../../axe';
+
+test('should render heading', () => {
+  render(<PageHeader heading="Page Title" />);
+  expect(
+    screen.getByRole('heading', { name: 'Page Title' })
+  ).toBeInTheDocument();
+});
+
+test('should render overline', () => {
+  render(<PageHeader heading="Page Title" overline="Overline Text" />);
+  expect(screen.getByText('Overline Text')).toBeInTheDocument();
+});
+
+test('should render description', () => {
+  render(<PageHeader heading="Page Title" description="Description Text" />);
+  expect(screen.getByText('Description Text')).toBeInTheDocument();
+});
+
+test('should render children', () => {
+  render(
+    <PageHeader heading="Page Title">
+      <button>Action</button>
+    </PageHeader>
+  );
+  expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
+});
+
+test('should support className prop', () => {
+  render(<PageHeader heading="Page Title" className="custom-class" />);
+  expect(
+    screen.getByRole('heading', { name: 'Page Title' }).closest('.PageHeader')
+  ).toHaveClass('custom-class');
+});
+
+test('should return no axe violations', async () => {
+  const { container } = render(
+    <PageHeader
+      heading="Page Title"
+      overline="Overline Text"
+      description="Description Text"
+    >
+      <button>Action</button>
+    </PageHeader>
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/packages/react/src/components/PageHeader/index.tsx
+++ b/packages/react/src/components/PageHeader/index.tsx
@@ -1,0 +1,57 @@
+import React, { forwardRef, ReactNode } from 'react';
+import classNames from 'classnames';
+
+export type PageHeaderProps = {
+  heading: string;
+  overline?: ReactNode;
+  description?: ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const PageHeader = forwardRef<HTMLDivElement, PageHeaderProps>(
+  (
+    {
+      className,
+      heading,
+      overline,
+      description,
+      children,
+      ...otherProps
+    }: PageHeaderProps,
+    ref
+  ) => {
+    return (
+      <div className="pageHeaderContainerContext">
+        <div
+          className={classNames('PageHeader', className)}
+          ref={ref}
+          {...otherProps}
+        >
+          <div className="PageHeader__textSection">
+            {overline && <div className="PageHeader__overline">{overline}</div>}
+
+            {typeof heading === 'string' ? (
+              <h1 className="PageHeader__heading">{heading}</h1>
+            ) : (
+              React.cloneElement(
+                heading as React.ReactElement<HTMLHeadingElement>,
+                {
+                  className: 'PageHeader__heading'
+                }
+              )
+            )}
+            {description && (
+              <div className="PageHeader__description">{description}</div>
+            )}
+          </div>
+          {children && <div className="PageHeader__actions">{children}</div>}
+        </div>
+      </div>
+    );
+  }
+);
+
+PageHeader.displayName = 'PageHeader';
+
+export default PageHeader;

--- a/packages/react/src/components/PageHeader/index.tsx
+++ b/packages/react/src/components/PageHeader/index.tsx
@@ -1,13 +1,12 @@
 import React, { forwardRef, ReactNode } from 'react';
+import SectionHeader from '../SectionHeader';
 import classNames from 'classnames';
 
-export type PageHeaderProps = {
-  heading: string;
+export interface PageHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  heading: ReactNode;
   overline?: ReactNode;
   description?: ReactNode;
-  children?: React.ReactNode;
-  className?: string;
-};
+}
 
 const PageHeader = forwardRef<HTMLDivElement, PageHeaderProps>(
   (
@@ -21,32 +20,20 @@ const PageHeader = forwardRef<HTMLDivElement, PageHeaderProps>(
     }: PageHeaderProps,
     ref
   ) => {
-    return (
-      <div className="pageHeaderContainerContext">
-        <div
-          className={classNames('PageHeader', className)}
-          ref={ref}
-          {...otherProps}
-        >
-          <div className="PageHeader__textSection">
-            {overline && <div className="PageHeader__overline">{overline}</div>}
+    if (typeof heading === 'string') {
+      heading = <h1>{heading}</h1>;
+    }
 
-            {typeof heading === 'string' ? (
-              <h1 className="PageHeader__heading">{heading}</h1>
-            ) : (
-              React.cloneElement(
-                heading as React.ReactElement<HTMLHeadingElement>,
-                {
-                  className: 'PageHeader__heading'
-                }
-              )
-            )}
-            {description && (
-              <div className="PageHeader__description">{description}</div>
-            )}
-          </div>
-          {children && <div className="PageHeader__actions">{children}</div>}
-        </div>
+    return (
+      <div
+        className={classNames('PageHeader', className)}
+        ref={ref}
+        {...otherProps}
+      >
+        {overline && <p>{overline}</p>}
+        <SectionHeader heading={heading} description={description}>
+          {children}
+        </SectionHeader>
       </div>
     );
   }

--- a/packages/react/src/components/PageHeader/index.tsx
+++ b/packages/react/src/components/PageHeader/index.tsx
@@ -30,7 +30,7 @@ const PageHeader = forwardRef<HTMLDivElement, PageHeaderProps>(
         ref={ref}
         {...otherProps}
       >
-        {overline && <p>{overline}</p>}
+        {overline && <div className="PageHeader__overline">{overline}</div>}
         <SectionHeader heading={heading} description={description}>
           {children}
         </SectionHeader>

--- a/packages/react/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/react/src/components/SectionHeader/SectionHeader.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SectionHeader from './';
+import axe from '../../axe';
+
+test('should render heading as h2 when string is passed', () => {
+  render(<SectionHeader heading="Section Title" />);
+  expect(
+    screen.getByRole('heading', { name: 'Section Title', level: 2 })
+  ).toBeInTheDocument();
+});
+
+test('should render heading as custom tag when ReactNode is passed', () => {
+  render(<SectionHeader heading={<h3>Custom Section Title</h3>} />);
+  expect(
+    screen.getByRole('heading', { name: 'Custom Section Title', level: 3 })
+  ).toBeInTheDocument();
+});
+
+test('should render description', () => {
+  render(
+    <SectionHeader heading="Section Title" description="Description Text" />
+  );
+  expect(screen.getByText('Description Text')).toBeInTheDocument();
+});
+
+test('should render children in actions section', () => {
+  render(
+    <SectionHeader heading="Section Title">
+      <button>Action Button</button>
+    </SectionHeader>
+  );
+  expect(
+    screen.getByRole('button', { name: 'Action Button' })
+  ).toBeInTheDocument();
+});
+
+test('should support className prop', () => {
+  render(<SectionHeader heading="Section Title" className="custom-class" />);
+  expect(
+    screen
+      .getByRole('heading', { name: 'Section Title' })
+      .closest('.SectionHeader')
+  ).toHaveClass('custom-class');
+});
+
+test('should return no axe violations', async () => {
+  const { container } = render(
+    <SectionHeader heading="Section Title" description="Description Text">
+      <button>Action Button</button>
+    </SectionHeader>
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/packages/react/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/react/src/components/SectionHeader/SectionHeader.test.tsx
@@ -3,6 +3,20 @@ import { render, screen } from '@testing-library/react';
 import SectionHeader from './';
 import axe from '../../axe';
 
+test('should support ref prop', () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <SectionHeader
+      heading="Section Title"
+      ref={ref}
+      data-testid="sectionheader"
+    />
+  );
+
+  expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  expect(ref.current).toEqual(screen.getByTestId('sectionheader'));
+});
+
 test('should render heading as h2 when string is passed', () => {
   render(<SectionHeader heading="Section Title" />);
   expect(

--- a/packages/react/src/components/SectionHeader/index.tsx
+++ b/packages/react/src/components/SectionHeader/index.tsx
@@ -19,12 +19,10 @@ const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
         {...otherProps}
       >
         <div className="SectionHeader__content">
-          <div className="SectionHeader__text-section">
-            {heading}
-            {description && (
-              <p className="SectionHeader__description">{description}</p>
-            )}
-          </div>
+          {heading}
+          {description && (
+            <p className="SectionHeader__description">{description}</p>
+          )}
           {children && <div className="SectionHeader__actions">{children}</div>}
         </div>
       </div>

--- a/packages/react/src/components/SectionHeader/index.tsx
+++ b/packages/react/src/components/SectionHeader/index.tsx
@@ -1,0 +1,44 @@
+import React, { forwardRef, ReactNode } from 'react';
+import classNames from 'classnames';
+
+export interface SectionHeaderProps {
+  heading: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}
+
+const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
+  ({ className, heading, description, children, ...otherProps }, ref) => {
+    return (
+      <div className="sectionHeaderContainerContext">
+        <div
+          className={classNames('SectionHeader', className)}
+          ref={ref}
+          {...otherProps}
+        >
+          <div className="SectionHeader__textSection">
+            {typeof heading === 'string' ? (
+              <h2 className="SectionHeader__heading">{heading}</h2>
+            ) : (
+              React.cloneElement(
+                heading as React.ReactElement<HTMLHeadingElement>,
+                {
+                  className: 'SectionHeader__heading'
+                }
+              )
+            )}
+            {description && (
+              <div className="SectionHeader__description">{description}</div>
+            )}
+          </div>
+          {children && <div className="SectionHeader__actions">{children}</div>}
+        </div>
+      </div>
+    );
+  }
+);
+
+SectionHeader.displayName = 'SectionHeader';
+
+export default SectionHeader;

--- a/packages/react/src/components/SectionHeader/index.tsx
+++ b/packages/react/src/components/SectionHeader/index.tsx
@@ -1,35 +1,28 @@
 import React, { forwardRef, ReactNode } from 'react';
 import classNames from 'classnames';
 
-export interface SectionHeaderProps {
+export interface SectionHeaderProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   heading: ReactNode;
   description?: ReactNode;
-  children?: ReactNode;
-  className?: string;
 }
 
 const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
   ({ className, heading, description, children, ...otherProps }, ref) => {
+    if (typeof heading === 'string') {
+      heading = <h2>{heading}</h2>;
+    }
     return (
-      <div className="sectionHeaderContainerContext">
-        <div
-          className={classNames('SectionHeader', className)}
-          ref={ref}
-          {...otherProps}
-        >
-          <div className="SectionHeader__textSection">
-            {typeof heading === 'string' ? (
-              <h2 className="SectionHeader__heading">{heading}</h2>
-            ) : (
-              React.cloneElement(
-                heading as React.ReactElement<HTMLHeadingElement>,
-                {
-                  className: 'SectionHeader__heading'
-                }
-              )
-            )}
+      <div
+        className={classNames('SectionHeader', className)}
+        ref={ref}
+        {...otherProps}
+      >
+        <div className="SectionHeader__content">
+          <div className="SectionHeader__text-section">
+            {heading}
             {description && (
-              <div className="SectionHeader__description">{description}</div>
+              <p className="SectionHeader__description">{description}</p>
             )}
           </div>
           {children && <div className="SectionHeader__actions">{children}</div>}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -133,6 +133,8 @@ export { default as CopyButton } from './components/CopyButton';
 export { default as Drawer } from './components/Drawer';
 export { default as BottomSheet } from './components/BottomSheet';
 export { default as AnchoredOverlay } from './components/AnchoredOverlay';
+export { default as PageHeader } from './components/PageHeader';
+export { default as SectionHeader } from './components/SectionHeader';
 
 /**
  * Helpers / Utils

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -50,3 +50,5 @@
 @import './impact-badge.css';
 @import './drawer.css';
 @import './bottom-sheet.css';
+@import './page-header.css';
+@import './section-header.css';

--- a/packages/styles/page-header.css
+++ b/packages/styles/page-header.css
@@ -6,7 +6,7 @@
   --page-header-overline-color: var(--accent-light);
 }
 
-.PageHeader > p {
+.PageHeader__overline {
   margin: 0 0 var(--space-smallest) 0;
   padding: 0;
   color: var(--page-header-overline-color);

--- a/packages/styles/page-header.css
+++ b/packages/styles/page-header.css
@@ -1,0 +1,63 @@
+:root {
+  --page-header-heading-font-weight: var(--font-weight-medium, 500);
+  --page-header-description-font-size: var(--text-size-base: 16px);
+  --page-header-overline-font-size: var(--text-size-base: 16px);
+  --page-header-overline-color: var(--gray-60);
+  --page-header-description-color: var(--gray-60);
+  --page-header-heading-color: var(--gray-90);
+}
+
+.cauldron--theme-dark {
+  --page-header-overline-color: var(--accent-light);
+  --page-header-description-color: var(--accent-light);
+  --page-header-heading-color: var(--white);
+}
+
+.pageHeaderContainerContext {
+  container-type: inline-size;
+}
+
+.PageHeader {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-bottom: var(--space-large, 24px);
+  gap: var(--space-small, 16px);
+}
+
+.PageHeader__textSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-smallest, 8px);
+  flex: 1;
+}
+
+.PageHeader__actions {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.PageHeader__overline {
+  color: var(--page-header-overline-color);
+  font-size: var(--page-header-overline-font-size);
+}
+
+.PageHeader__description {
+  color: var(--page-header-description-color);
+  font-size: var(--page-header-description-font-size);
+}
+
+.PageHeader .PageHeader__heading,
+.PageHeader .PageHeader__heading > :is(h1) {
+  color: var(--page-header-heading-color);
+  font-weight: var(--page-header-heading-font-weight);
+  margin: 0;
+  padding: 0;
+}
+
+@container (min-width: 48rem) {
+  .PageHeader {
+    flex-direction: row;
+  }
+}

--- a/packages/styles/page-header.css
+++ b/packages/styles/page-header.css
@@ -1,63 +1,14 @@
 :root {
-  --page-header-heading-font-weight: var(--font-weight-medium, 500);
-  --page-header-description-font-size: var(--text-size-base: 16px);
-  --page-header-overline-font-size: var(--text-size-base: 16px);
   --page-header-overline-color: var(--gray-60);
-  --page-header-description-color: var(--gray-60);
-  --page-header-heading-color: var(--gray-90);
 }
 
 .cauldron--theme-dark {
   --page-header-overline-color: var(--accent-light);
-  --page-header-description-color: var(--accent-light);
-  --page-header-heading-color: var(--white);
 }
 
-.pageHeaderContainerContext {
-  container-type: inline-size;
-}
-
-.PageHeader {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding-bottom: var(--space-large, 24px);
-  gap: var(--space-small, 16px);
-}
-
-.PageHeader__textSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-smallest, 8px);
-  flex: 1;
-}
-
-.PageHeader__actions {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-}
-
-.PageHeader__overline {
-  color: var(--page-header-overline-color);
-  font-size: var(--page-header-overline-font-size);
-}
-
-.PageHeader__description {
-  color: var(--page-header-description-color);
-  font-size: var(--page-header-description-font-size);
-}
-
-.PageHeader .PageHeader__heading,
-.PageHeader .PageHeader__heading > :is(h1) {
-  color: var(--page-header-heading-color);
-  font-weight: var(--page-header-heading-font-weight);
-  margin: 0;
+.PageHeader > p {
+  margin: 0 0 var(--space-smallest) 0;
   padding: 0;
-}
-
-@container (min-width: 48rem) {
-  .PageHeader {
-    flex-direction: row;
-  }
+  color: var(--page-header-overline-color);
+  font-size: var(--text-size-base);
 }

--- a/packages/styles/section-header.css
+++ b/packages/styles/section-header.css
@@ -1,0 +1,55 @@
+:root {
+  --section-header-heading-font-weight: var(--font-weight-medium, 500);
+  --section-header-description-font-size: var(--text-size-base: 16px);
+  --section-header-description-color: var(--gray-60);
+  --section-header-heading-color: var(--gray-90);
+}
+
+.cauldron--theme-dark {
+  --section-header-description-color: var(--accent-light);
+  --section-header-heading-color: var(--white);
+}
+
+.sectionHeaderContainerContext {
+  container-type: inline-size;
+}
+
+.SectionHeader {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-bottom: var(--space-large, 24px);
+  gap: var(--space-small, 16px);
+}
+
+.SectionHeader__textSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-smallest, 8px);
+  flex: 1;
+}
+
+.SectionHeader__actions {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.SectionHeader__description {
+  color: var(--section-header-description-color);
+  font-size: var(--section-header-description-font-size);
+}
+
+.SectionHeader .SectionHeader__heading,
+.SectionHeader .SectionHeader__heading > :is(h2, h3, h4, h5, h6) {
+  color: var(--section-header-heading-color);
+  font-weight: var(--section-header-heading-font-weight);
+  margin: 0;
+  padding: 0;
+}
+
+@container (min-width: 48rem) {
+  .SectionHeader {
+    flex-direction: row;
+  }
+}

--- a/packages/styles/section-header.css
+++ b/packages/styles/section-header.css
@@ -1,11 +1,9 @@
 :root {
   --section-header-description-color: var(--gray-60);
-  --section-header-heading-color: var(--gray-90);
 }
 
 .cauldron--theme-dark {
   --section-header-description-color: var(--accent-light);
-  --section-header-heading-color: #ffffff;
 }
 
 .SectionHeader {
@@ -13,35 +11,28 @@
 }
 
 .SectionHeader__content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding-bottom: var(--space-large);
-  gap: var(--space-small);
-}
-
-.SectionHeader__text-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-smallest);
-  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'heading'
+    'description'
+    'children';
 }
 
 .SectionHeader__actions {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
+  margin-top: var(--space-small);
+  grid-area: children;
 }
 
 .SectionHeader .SectionHeader__content .SectionHeader__description {
-  margin: 0;
+  margin: var(--space-smallest) 0 0 0;
   padding: 0;
   color: var(--section-header-description-color);
   font-size: var(--text-size-base);
+  grid-area: description;
 }
 
 .SectionHeader :is(h1, h2, h3, h4, h5, h6) {
-  color: var(--section-header-heading-color);
   font-weight: var(--font-weight-medium);
   margin: 0;
   padding: 0;
@@ -49,6 +40,16 @@
 
 @container (min-width: 48rem) {
   .SectionHeader__content {
-    flex-direction: row;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'heading children'
+      'description children';
+    align-items: start;
+  }
+
+  .SectionHeader__actions {
+    margin: 0;
+    align-self: center;
+    justify-self: end;
   }
 }

--- a/packages/styles/section-header.css
+++ b/packages/styles/section-header.css
@@ -1,31 +1,29 @@
 :root {
-  --section-header-heading-font-weight: var(--font-weight-medium, 500);
-  --section-header-description-font-size: var(--text-size-base: 16px);
   --section-header-description-color: var(--gray-60);
   --section-header-heading-color: var(--gray-90);
 }
 
 .cauldron--theme-dark {
   --section-header-description-color: var(--accent-light);
-  --section-header-heading-color: var(--white);
-}
-
-.sectionHeaderContainerContext {
-  container-type: inline-size;
+  --section-header-heading-color: #ffffff;
 }
 
 .SectionHeader {
+  container-type: inline-size;
+}
+
+.SectionHeader__content {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-bottom: var(--space-large, 24px);
-  gap: var(--space-small, 16px);
+  padding-bottom: var(--space-large);
+  gap: var(--space-small);
 }
 
-.SectionHeader__textSection {
+.SectionHeader__text-section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-smallest, 8px);
+  gap: var(--space-smallest);
   flex: 1;
 }
 
@@ -35,21 +33,22 @@
   flex-wrap: wrap;
 }
 
-.SectionHeader__description {
+.SectionHeader .SectionHeader__content .SectionHeader__description {
+  margin: 0;
+  padding: 0;
   color: var(--section-header-description-color);
-  font-size: var(--section-header-description-font-size);
+  font-size: var(--text-size-base);
 }
 
-.SectionHeader .SectionHeader__heading,
-.SectionHeader .SectionHeader__heading > :is(h2, h3, h4, h5, h6) {
+.SectionHeader :is(h1, h2, h3, h4, h5, h6) {
   color: var(--section-header-heading-color);
-  font-weight: var(--section-header-heading-font-weight);
+  font-weight: var(--font-weight-medium);
   margin: 0;
   padding: 0;
 }
 
 @container (min-width: 48rem) {
-  .SectionHeader {
+  .SectionHeader__content {
     flex-direction: row;
   }
 }

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -100,6 +100,7 @@
   --text-size-small: 15px;
   --text-size-smaller: 13px;
   --text-size-smallest: 12px;
+  --text-size-base: 16px;
 
   /* fonts */
   --base-font-family: 'Roboto', Helvetica, Arial, sans-serif;

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -100,7 +100,6 @@
   --text-size-small: 15px;
   --text-size-smaller: 13px;
   --text-size-smallest: 12px;
-  --text-size-base: 16px;
 
   /* fonts */
   --base-font-family: 'Roboto', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Closes: https://github.com/dequelabs/cauldron/issues/1812

This pull request introduces the new `PageHeader` and `SectionHeader` components in the `@deque/cauldron-react` library, along with their respective documentation, tests, and styles. These components are designed to provide consistent and customizable headers for pages and sections within the application.

**New Components:**
* `PageHeader` component: A header component for pages that includes a heading, optional overline, description, and actions.
* `SectionHeader` component: A header component for sections that includes a heading, optional description, and actions.

**Styles:**
* Added CSS styles for `PageHeader` to define layout, typography, and theme-specific colors.
* Added CSS styles for `SectionHeader` to define layout, typography, and theme-specific colors.
* Updated the global CSS variables to include a base text size.