### PR TITLE
chore: update design team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 * @dequelabs/cauldron-codeowners
 
 # Request a review from either design team or codeowner for screenshots
-/e2e/screenshots/*.png @dequelabs/cauldron-codeowners @dequelabs/cauldron-design
+/e2e/screenshots/*.png @dequelabs/cauldron-codeowners @dequelabs/design-team
 
 # Request a review from cauldron team on docs PRs
 /docs/ @dequelabs/cauldron

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ Cauldron aims to avoid shipping [breaking changes](#breaking-changes) on a regul
 
 We aim to review pull requests within a day or two. If your changes are time-sensitive, feel free to request an expedited review on GitHub or reach out in the private `#cauldron` slack channel.
 
-New components that have visual components or PRs that include visual changes to [component snapshot testing screenshots](https://github.com/dequelabs/cauldron/blob/develop/e2e/readme.md#snapshot-testing) should have an approval from [@dequelabs/cauldron-design](https://github.com/orgs/dequelabs/teams/cauldron-design).
+New components that have visual components or PRs that include visual changes to [component snapshot testing screenshots](https://github.com/dequelabs/cauldron/blob/develop/e2e/readme.md#snapshot-testing) should have an approval from [@dequelabs/design-team](https://github.com/orgs/dequelabs/teams/design-team).
 
 Once approved by a member of the Cauldron team, your pull request can be merged at any time but _must_ be squash merged.
 


### PR DESCRIPTION
Using a unified design team, no special team for cauldron needed.