### PR TITLE
chore: fix code coverage

### DIFF
--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -13,8 +13,17 @@ const config: Config = {
     '<rootDir>/src/components/**/*.{tsx,ts}',
     '<rootDir>/src/utils/**/*.{tsx,ts}',
     '<rootDir>/src/contexts/**/*.{tsx,ts}',
-    '!<rootDir>/src/utils/polymorphicComponent.test.tsx'
-  ]
+    '!<rootDir>/src/utils/polymorphicComponent.test.tsx',
+    '!<rootDir>/**/*.e2e.tsx'
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 85,
+      statements: 90,
+      lines: 90,
+      functions: 85
+    }
+  }
 };
 
 export default config;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,22 +79,5 @@
   "peerDependencies": {
     "react": ">=16.6 <= 18",
     "react-dom": ">=16.6 <= 18"
-  },
-  "nyc": {
-    "checkCoverage": true,
-    "reporter": [
-      "text-summary",
-      "html"
-    ],
-    "statements": 85,
-    "branches": 78,
-    "functions": 85,
-    "lines": 85,
-    "exclude": [
-      "lib",
-      "coverage",
-      "test/**/*.js",
-      "test/**/*.e2e.tsx"
-    ]
   }
 }


### PR DESCRIPTION
I noticed we didn't have code coverage setup/configured correctly as it was including screenshots as part of coverage and wasn't failing if below the threshold. Just a quick fix to actually enforce coverage with jest configuration and to ensure we're covering the right things.