### PR TITLE
fix(style): prevent platform tooltip from appearing on ellipsized text in Safari

### DIFF
--- a/packages/styles/text-ellipsis.css
+++ b/packages/styles/text-ellipsis.css
@@ -5,6 +5,9 @@
   overflow: hidden;
 }
 
+/* Try and prevent Safari from showing a platform
+ * tooltip when visible text is truncated
+ * see: https://github.com/dequelabs/cauldron/issues/1926
 .TextEllipsis:after {
   content: '';
   display: block;

--- a/packages/styles/text-ellipsis.css
+++ b/packages/styles/text-ellipsis.css
@@ -5,6 +5,11 @@
   overflow: hidden;
 }
 
+.TextEllipsis:after {
+  content: '';
+  display: block;
+}
+
 .TextEllipsis:where([role='button']) {
   text-align: inherit;
   user-select: inherit;


### PR DESCRIPTION
closes #1926 