### PR TITLE
fix(Stepper): fixed types for Stepper component

### DIFF
--- a/packages/react/src/components/Stepper/index.tsx
+++ b/packages/react/src/components/Stepper/index.tsx
@@ -103,7 +103,7 @@ export const Step = (props: StepProps) => {
 
 Step.displayName = 'Step';
 
-interface StepperProps extends React.HTMLAttributes<HTMLOListElement> {
+interface StepperProps extends React.OlHTMLAttributes<HTMLOListElement> {
   children: React.ReactNode;
   className?: string;
 }


### PR DESCRIPTION
Close: https://github.com/dequelabs/walnut/issues/11181

This pull request includes a minor update to the `Stepper` component in the `packages/react` library. The `StepperProps` interface has been updated to use `React.OlHTMLAttributes` instead of `React.HTMLAttributes` for better type specificity.

* [`packages/react/src/components/Stepper/index.tsx`](diffhunk://#diff-113f83d3733fab97a662b2ea4f3e74bb9b689d7c21ad137c1d92a137b5122c21L106-R106): Replaced `React.HTMLAttributes<HTMLOListElement>` with `React.OlHTMLAttributes<HTMLOListElement>` in the `StepperProps` interface to ensure the attributes are specific to ordered lists.