### PR TITLE
fix(styles): fix specificity with icon behaviors inside of links

### DIFF
--- a/packages/styles/link.css
+++ b/packages/styles/link.css
@@ -27,7 +27,7 @@
   outline-offset: 0;
 }
 
-.Link:has(.Icon) {
+.Link:where(:has(.Icon)) {
   display: inline-flex;
   align-items: center;
   gap: var(--space-half);


### PR DESCRIPTION
closes #1970

The specificity of the default styles was overriding the layout set within the Action List. Reducing the specificity will allow for the action list to override the display layout where needed.