### PR TITLE
chore: updated `prismjs` to get rid of vulnerability

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,5 +79,8 @@
   "peerDependencies": {
     "react": ">=16.6 <= 18",
     "react-dom": ">=16.6 <= 18"
+  },
+  "resolutions": {
+    "**/refractor/prismjs": "^1.30.0"
   }
 }

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -4718,15 +4718,10 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
 
-prismjs@^1.27.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
-
-prismjs@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+prismjs@^1.27.0, prismjs@^1.30.0, prismjs@~1.27.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Ref: https://github.com/dequelabs/auth-service/issues/609

Note: I’ve added `resolutions` to enforce the required version, as directly updating [prismjs](https://www.npmjs.com/package/prismjs) that comes from `react-syntax-highlighter#refractor#prismjs` isn’t possible. The latest version of [react-syntax-highlighter](https://www.npmjs.com/package/react-syntax-highlighter) still uses refractor v3.x, which pins prismjs to ~1.27.0.