### PR TITLE
chore: sync develop into main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-
   react:
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +50,7 @@ jobs:
           name: screenshot-test-results
           path: ./e2e/test-results
           retention-days: 14
-          
+
   a11y:
     runs-on: ubuntu-latest
     steps:
@@ -70,5 +69,6 @@ jobs:
       # See: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
       - run: |
           export CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox
+          sudo chown root /opt/google/chrome/chrome-sandbox
           sudo chmod 4755 /opt/google/chrome/chrome-sandbox
           yarn test:a11y


### PR DESCRIPTION
This is an attempt to address the release issue that surfaced recently where the a11y checks failed, preventing a release (see https://github.com/dequelabs/cauldron/actions/runs/16122564648/job/45491771015).

I think merging this into `master` should allow the current processes to run cleanly, but we'll have to cut an empty release if not.