### PR TITLE
fix(a11y): fix focus issue when focusable item is contained within a collapsed description list

### DIFF
--- a/packages/styles/description-list.css
+++ b/packages/styles/description-list.css
@@ -89,6 +89,10 @@
   overflow: hidden;
 }
 
+.DescriptionList--collapsed .DescriptionList__details {
+  overflow: auto;
+}
+
 .DescriptionList__term,
 .DescriptionList__details {
   padding: var(--data-list-space) var(--space-small);


### PR DESCRIPTION
close TBD