### PR TITLE
fix(styles): use correct overflow value for description list

### DIFF
--- a/packages/styles/description-list.css
+++ b/packages/styles/description-list.css
@@ -90,7 +90,7 @@
 }
 
 .DescriptionList--collapsed .DescriptionList__details {
-  overflow: auto;
+  overflow: visible;
 }
 
 .DescriptionList__term,


### PR DESCRIPTION
ref #2026

The overflow value is fixed, but this is still displaying a scrollbar in some instances. The change here ensures that the element still remains visible with no visible scrollbar.