### PR TITLE
fix: remove passthrough key property in ActionListLinkItem

### DIFF
--- a/packages/react/src/components/ActionList/ActionListLinkItem.tsx
+++ b/packages/react/src/components/ActionList/ActionListLinkItem.tsx
@@ -15,7 +15,6 @@ const ActionListLinkItem = forwardRef<
 >(
   (
     {
-      key,
       className,
       // ActionListLinkItem should not be able to be "selected"
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -42,7 +41,6 @@ const ActionListLinkItem = forwardRef<
 
     return (
       <ActionListItem
-        key={key}
         ref={ref}
         className={classnames('Link ActionListLinkItem', className)}
         as="a"


### PR DESCRIPTION
The `key` property was causing a react runtime error to be thrown:

> react-jsx-runtime.development.js:124 Warning: [object Object]: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
    in ActionListLinkItem (created by NavBarProductSwitcher)
    in ActionListProvider (created by ActionList)
    in ListboxProvider (created by Listbox)
    in ul (created by Listbox)
    in Listbox (created by ActionList)
    in ActionList (created by ActionMenu)
    in div (created by AnchoredOverlay)
    in AnchoredOverlay (created by ActionMenu)