### PR TITLE
fix(styles): set default max-height of action menus to prevent excessive overflow

### DIFF
--- a/packages/react/src/components/ActionMenu/screenshots.e2e.tsx
+++ b/packages/react/src/components/ActionMenu/screenshots.e2e.tsx
@@ -18,6 +18,8 @@ test('should have screenshot for ActionMenu', async ({ mount, page }) => {
     content: `.ActionMenu {
       position: relative !important;
       transform: translateY(2px) !important;
+      /* view full height of menu */
+      --action-menu-max-height: none;
     }`
   });
   const component = await mount(
@@ -97,6 +99,8 @@ test('should have screenshot for ActionMenu selections', async ({
     content: `.ActionMenu {
       position: relative !important;
       transform: translateY(2px) !important;
+      /* view full height of menu */
+      --action-menu-max-height: none;
     }`
   });
   const component = await mount(
@@ -179,6 +183,8 @@ test('should have screenshot for ActionMenu mixed', async ({ mount, page }) => {
     content: `.ActionMenu {
       position: relative !important;
       transform: translateY(2px) !important;
+      /* view full height of menu */
+      --action-menu-max-height: none;
     }`
   });
   const component = await mount(

--- a/packages/styles/action-menu.css
+++ b/packages/styles/action-menu.css
@@ -14,7 +14,7 @@
   border-radius: 8px;
   width: var(--action-menu-width);
   min-width: var(--action-menu-min-width, 10rem);
-  max-height: var(--action-menu-height);
+  max-height: var(--action-menu-max-height, 80vh);
   box-shadow: var(--drop-shadow-overlay);
   overflow-y: auto;
 }


### PR DESCRIPTION
closes #2068 