### PR TITLE
fix(style): update tab panel background colors for light and dark themes

### DIFF
--- a/packages/styles/tabs.css
+++ b/packages/styles/tabs.css
@@ -3,6 +3,7 @@
   --tab-shadow-color: var(--accent-primary);
   --tab-inactive-background-color: #fff;
   --tab-inactive-text-color: var(--gray-60);
+  --tab-panel-background-color: #fff;
   --tab-active-background-color: #fff;
   --tab-hover-background-color: var(--gray-20);
   --tab-panel-color: var(--gray-80);
@@ -15,6 +16,7 @@
 .cauldron--theme-dark {
   --tabs-border-color: var(--accent-dark);
   --tab-shadow-color: var(--accent-info);
+  --tab-panel-background-color: var(--accent-medium);
   --tab-inactive-background-color: var(--accent-medium);
   --tab-inactive-text-color: var(--accent-light);
   --tab-active-background-color: var(--accent-medium);
@@ -111,7 +113,7 @@
 .TabPanel {
   overflow-wrap: break-word;
   color: var(--tab-panel-color);
-  background-color: var(--tab-active-background-color);
+  background-color: var(--tab-panel-background-color);
 }
 
 .TabPanel > * {


### PR DESCRIPTION
Closes: https://github.com/dequelabs/cauldron/issues/2098

This pull request updates the tab panel styling in `packages/styles/tabs.css` to improve visual consistency and theme support. The most important changes are grouped below:

**Theme Variable Updates:**

* Added a new CSS variable `--tab-panel-background-color` for both light and dark themes, allowing distinct background colors for tab panels. [[1]](diffhunk://#diff-dbc8cbb7e8cb0112a62b580b701c9f621255ee937a80703b105476777415e0c2R6) [[2]](diffhunk://#diff-dbc8cbb7e8cb0112a62b580b701c9f621255ee937a80703b105476777415e0c2R19)

**Tab Panel Styling:**

* Updated the `.TabPanel` background color to use the new `--tab-panel-background-color` variable instead of `--tab-active-background-color`, ensuring better separation between active tab and panel backgrounds.