### PR TITLE
fix(styles): limit the default max-width of action menus to 31rem

### DIFF
--- a/packages/styles/action-menu.css
+++ b/packages/styles/action-menu.css
@@ -15,6 +15,7 @@
   width: var(--action-menu-width);
   min-width: var(--action-menu-min-width, 10rem);
   max-height: var(--action-menu-max-height, 80vh);
+  max-width: var(--action-menu-max-width, 31rem);
   box-shadow: var(--drop-shadow-overlay);
   overflow-y: auto;
 }


### PR DESCRIPTION
closes #2097 