### PR TITLE
fix(styles): move ActionMenu to top most z-index layer

### DIFF
--- a/packages/styles/action-menu.css
+++ b/packages/styles/action-menu.css
@@ -18,6 +18,7 @@
   max-width: var(--action-menu-max-width, 31rem);
   box-shadow: var(--drop-shadow-overlay);
   overflow-y: auto;
+  z-index: var(--z-index-listbox);
 }
 
 :where(.cauldron--theme-dark) .ActionMenu .ActionListItem--danger {

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -123,12 +123,12 @@
   --z-index-side-bar: 9;
   --z-index-toast: 8;
   --z-index-toast-action-needed: 24;
-  --z-index-listbox: 6;
   /* ensure this is a higher value than the rest (above)! */
   --z-index-top-bar: 25;
-  /* ensure this is 1 higher than the top bar z-index */
+  /* ensure these are 1 higher than the top bar z-index */
   --z-index-skip-container: calc(var(--z-index-top-bar) + 1);
   --z-index-drawer: calc(var(--z-index-top-bar) + 1);
+  --z-index-listbox: calc(var(--z-index-top-bar) + 1);
 
   /* radio card */
   --radio-card-width: 255px;


### PR DESCRIPTION
closes #2108 

Example of the action menu now appearing above the topbar menu: 
<img width="258" height="235" alt="" src="https://github.com/user-attachments/assets/4efae313-ce29-4ff8-8181-1e9a87d450c6" />
