### PR TITLE
fix: apply styling amendments to the `SectionHeader` component

### DIFF
--- a/packages/styles/section-header.css
+++ b/packages/styles/section-header.css
@@ -22,7 +22,6 @@
 .SectionHeader__actions {
   margin-top: var(--space-small);
   grid-area: children;
-  align-self: start;
 }
 
 .SectionHeader .SectionHeader__content .SectionHeader__description {


### PR DESCRIPTION
This patch adds various style updates to the `SectionHeader` component.

<details><summary>Before</summary>

<img width="1708" height="566" alt="image" src="https://github.com/user-attachments/assets/0a90e830-4122-4ecc-bfe8-3a5475e8017a" />

</details> 

<details><summary>After</summary>

<img width="1720" height="552" alt="image" src="https://github.com/user-attachments/assets/a79f7658-a813-4aa9-b83b-7214e396a053" />

</details> 