### PR TITLE
chore: update pr reviewers for sync branches

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -14,5 +14,5 @@ jobs:
           github-token: ${{ secrets.MACHINE_USER_PAT }}
           pr-title: "chore: merge master into develop"
           pr-body: "Remember to _merge_ (rather than squash) this PR!"
-          pr-reviewers: anastasialanz
+          pr-team-reviewers: cauldron-codeowners
           head: master


### PR DESCRIPTION
The sync-branches workflow is failing because scurker is not a collaborator anymore.

https://github.com/dequelabs/cauldron/actions/runs/18878843307/job/53875949065