### PR TITLE
fix(styles): add word-break for `SectionHeader`

### DIFF
--- a/packages/styles/section-header.css
+++ b/packages/styles/section-header.css
@@ -12,6 +12,7 @@
 
 .SectionHeader__content {
   display: grid;
+  word-break: break-word;
   grid-template-columns: 1fr;
   grid-template-areas:
     'heading'


### PR DESCRIPTION
Added word-break for `SectionHeader`. This prevents long words from overflowing in `SectionHeader` overline text.
Tested when the text is:
- one string `aaaaaaaaaaaaaaaaaaaa`
- words are written with a dash `123abcxyz-123abcxyz-123abcxyz-`
- words are written separated by spaces `123abcxyz 123abcxyz 123abcxyz `

<details><summary>Video: SectionHeader </summary>

https://github.com/user-attachments/assets/17250c50-1955-4097-916f-b566b24557ab


</details> 

The same fix as [here](https://github.com/dequelabs/cauldron/pull/2192).

Closes: Walnut [#13259](https://github.com/dequelabs/walnut/issues/13259), [#13261](https://github.com/dequelabs/walnut/issues/13261), [#13260](https://github.com/dequelabs/walnut/issues/13260)