### PR TITLE
fix(styles): Fixed `Link` component with Icon to stretch inside flex container

### DIFF
--- a/packages/styles/link.css
+++ b/packages/styles/link.css
@@ -28,8 +28,10 @@
 }
 
 .Link:where(:has(.Icon)) {
+  width: max-content;
   display: inline-flex;
   align-items: center;
   gap: var(--space-half);
   flex-wrap: wrap;
+  align-self: flex-start;
 }


### PR DESCRIPTION
Fixed Link component with Icon stretching to full width inside flex containers

  - `align-self: flex-start` - prevents cross-axis stretching in flex containers;
  - `width: max-content` - ensures width is constrained to content size;

<details><summary>Before (stretched to the full width)</summary>
<img width="1252" height="98" alt="image" src="https://github.com/user-attachments/assets/f7f21e75-527e-4693-b884-84a64a07d209" />
</details> 

<details><summary>After (content sized)</summary>
<img width="1261" height="99" alt="image" src="https://github.com/user-attachments/assets/0c8d3917-0257-4c7c-91f9-5e286e88f2cc" />
</details> 

Closes: https://github.com/dequelabs/walnut/issues/13196