### PR TITLE
fix(react): remove false ellipsis when text fits in Chrome

### DIFF
--- a/packages/styles/text-ellipsis.css
+++ b/packages/styles/text-ellipsis.css
@@ -8,8 +8,9 @@
 /* Try and prevent Safari from showing a platform
  * tooltip when visible text is truncated
  * see: https://github.com/dequelabs/cauldron/issues/1926
+ * Only apply to single-line ellipsis to avoid Chrome false ellipsis bug
  */
-.TextEllipsis:after {
+.TextEllipsis:not(.TextEllipsis--multiline):after {
   content: '';
   display: block;
 }


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                     
Chrome incorrectly displayed ellipsis ("...") for `TextEllipsis` component with `maxLines` prop, even when text fit within the specified number of lines. This was particularly noticeable with short text using `maxLines={2}` or higher.                                                                                                                                                                                                                    

## Root Cause                                                                                                                                                                                                                  
The `.TextEllipsis:after` pseudo-element with `display: block` (added in #1926 as a Safari workaround) caused Chrome to miscalculate overflow when combined with `-webkit-line-clamp` in multiline mode.                       

## Solution                                                                                                                                                                                                                    
Changed the CSS selector from `.TextEllipsis:after` to `.TextEllipsis:not(.TextEllipsis--multiline):after` to apply the Safari workaround only to single-line ellipsis. This prevents the Chrome rendering bug while preserving the original Safari fix.                                                                                                                                                                                                      

## Result                                                                                                                                                                                                                      

  - ✅ Ellipsis now displays only when text genuinely exceeds the line count                                                                                                                                                     
  - ✅ Safari native tooltip workaround preserved for single-line mode                                                                                                                                                           

### Video
<details><summary>Video: fix in Chrome and Safari </summary>

https://github.com/user-attachments/assets/76ad41c0-3577-474b-a27d-b370a36c15f6


</details> 

<details><summary>Video: responsiveness </summary>

https://github.com/user-attachments/assets/a6bda827-13fa-40a3-820b-ae1e8b5c3123


</details> 

Closes: Walnut [#13167](https://github.com/dequelabs/walnut/issues/13167)