### PR TITLE
ci(browserlist): change author to github actions bot

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           add-paths: |
             yarn.lock
             packages/*/yarn.lock


### PR DESCRIPTION
Prevent Jason from getting notifications about the browserlist update PRs as author.

https://github.com/dequelabs/cauldron/actions/runs/21556367250/job/62648649957#step:4:45

https://github.com/peter-evans/create-pull-request
> The author name and email address in the format Display Name <email@address.com>. Defaults to the user who triggered the workflow run.