### PR TITLE
ci(browserlist): trigger workflow on demand

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -5,6 +5,7 @@ on:
     # run on the 1st of every month
     - cron: '15 3 1 * *'
   workflow_call:
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Allow the browserlist workflow to be triggered manually.