### PR TITLE
Revert "ci(browserlist): change author to github actions bot (#2232)"

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           add-paths: |
             yarn.lock
             packages/*/yarn.lock


### PR DESCRIPTION
This reverts commit 5911d50819cf089cde02cd0023d65ba5e087d981.

Now that the workflow can be triggered manually, I believe this should have me as the author since I was the last one to trigger it.