### PR TITLE
fix(Link): remove `align-self` for link with icon

### DIFF
--- a/packages/styles/link.css
+++ b/packages/styles/link.css
@@ -28,10 +28,9 @@
 }
 
 .Link:where(:has(.Icon)) {
-  width: max-content;
+  max-width: max-content;
   display: inline-flex;
   align-items: center;
   gap: var(--space-half);
   flex-wrap: wrap;
-  align-self: flex-start;
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the link styling by removing the `align-self: flex-start;` property. This change will allow the link elements to follow the default alignment of their parent container rather than being forced to align to the start