### PR TITLE
chore: ignore major version updates for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,6 @@ updates:
         versions: ['>=5.0.0']
       - dependency-name: 'chalk'
         versions: ['>=5.0.0']
+      # Ignore new major versions of @types/node until we are ready to upgrade
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary
- Adds a dependabot ignore rule to skip major version updates for `@types/node`
- Minor and patch updates will continue as normal
- This prevents disruptive PRs until we are ready to upgrade to a new major version

## Test plan
- [ ] Verify dependabot no longer opens PRs for major `@types/node` bumps
- [ ] Confirm minor/patch `@types/node` updates still come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)