### PR TITLE
fix: remove default ul style from Toast component

### DIFF
--- a/packages/styles/density.css
+++ b/packages/styles/density.css
@@ -44,7 +44,6 @@
 
   /* Toast: static positioning (no fixed TopBar to anchor to) */
   --toast-position: static;
-  --toast-list-margin-left: 1.5em;
 
   /* Field select: constrained width */
   --select-width: clamp(0px, 25rem, 100%);

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -87,10 +87,6 @@
   color: var(--accent-medium);
 }
 
-.Toast ul {
-  margin-left: var(--toast-list-margin-left, 0);
-}
-
 .Toast:focus {
   outline: 0;
 }


### PR DESCRIPTION
## Summary
- Removes the `.Toast ul` CSS rule that set `margin-left` on unordered lists inside toasts, allowing lists to inherit default styling instead of being overridden by the toast component.

## Test plan
- [ ] Verify toast components with list content render correctly without extra left margin
- [ ] Confirm no visual regression on existing toasts without lists