### PR TITLE
ci: bump setup-node to v6

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -21,7 +21,8 @@ runs:
         cache-dependency-path: '**/yarn.lock'
         registry-url: 'https://registry.npmjs.org'
     # We need npm 11.5.1+ for OIDC-based publishing support
-    - run: npm install -g npm@11
+    # Installing npm 11.11.0 as a workaround for https://github.com/npm/cli/issues/9151
+    - run: npm install -g npm@11.11.0
       shell: bash
     - run: npm install -g yarn # Required since we reinstalled npm
       shell: bash


### PR DESCRIPTION
Node 20 actions are deprecated and setup-node needed to be bumped to v6. We also needed to install npm 11.11.0 as a workaround for https://github.com/npm/cli/issues/9151 to solve this error in the tests workflow:

```
Cache restored from key: node-cache-Linux-x64-yarn-beccfe5af28cc96bd64a05ea052337259cfa8f2bbdf2910b13a9000c862c59ce
Run npm install -g npm@11
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-output.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-finish.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/commands/install.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/npm.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli/entry.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/bin/npm-cli.js
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-02T20_11_37_417Z-debug-0.log
```