### PR TITLE
feat: add Switch component

### DIFF
--- a/docs/pages/components/Switch.mdx
+++ b/docs/pages/components/Switch.mdx
@@ -1,7 +1,7 @@
 ---
 title: Switch
 description: A toggle control that allows users to switch between two states (on/off).
-source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Switch/index.tsx
+source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Switch/Switch.tsx
 ---
 
 import { useState } from 'react'

--- a/docs/pages/components/Switch.mdx
+++ b/docs/pages/components/Switch.mdx
@@ -1,0 +1,162 @@
+---
+title: Switch
+description: A toggle control that allows users to switch between two states (on/off).
+source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Switch/index.tsx
+---
+
+import { useState } from 'react'
+import { Switch, FieldWrap } from '@deque/cauldron-react'
+
+```js
+import { Switch } from '@deque/cauldron-react'
+```
+
+<Note>
+  Input components _should_ be wrapped in a [FieldWrap](./FieldWrap). The
+  `Switch` component has been designed specifically to meet color contrast
+  requirements against a `FieldWrap` background.
+</Note>
+
+## Examples
+
+### Default (Unchecked)
+
+```jsx example
+function SwitchExample() {
+  const [checked, setChecked] = useState(false);
+  return (
+    <FieldWrap>
+      <Switch
+        id="switch-default"
+        label="Notifications"
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+      />
+    </FieldWrap>
+  );
+}
+```
+
+### Checked
+
+```jsx example
+<FieldWrap>
+  <Switch
+    id="switch-checked"
+    label="Notifications"
+    checked
+    onChange={() => {}}
+  />
+</FieldWrap>
+```
+
+### Disabled
+
+```jsx example
+<FieldWrap>
+  <Switch
+    id="switch-disabled"
+    label="Notifications (disabled)"
+    disabled
+  />
+</FieldWrap>
+```
+
+### Disabled Checked
+
+```jsx example
+<FieldWrap>
+  <Switch
+    id="switch-disabled-checked"
+    label="Notifications (disabled, on)"
+    checked
+    disabled
+    onChange={() => {}}
+  />
+</FieldWrap>
+```
+
+### With Description
+
+```jsx example
+<FieldWrap>
+  <Switch
+    id="switch-description"
+    label="Email Notifications"
+    labelDescription="Receive updates about your account activity."
+  />
+</FieldWrap>
+```
+
+### With Error
+
+```jsx example
+<FieldWrap>
+  <Switch
+    id="switch-error"
+    label="Terms of Service"
+    error="You must accept the terms to continue."
+  />
+</FieldWrap>
+```
+
+## Props
+
+<ComponentProps
+  className={true}
+  refType="HTMLInputElement"
+  props={[
+    {
+      name: 'id',
+      type: 'string',
+      required: true,
+      description: 'The id to be set on the input element.'
+    },
+    {
+      name: 'label',
+      type: 'React.ReactNode',
+      required: true,
+      description: 'Label displayed next to the switch.'
+    },
+    {
+      name: 'checked',
+      type: 'boolean',
+      defaultValue: 'false',
+      description: 'Controlled checked state of the switch.'
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      defaultValue: 'false',
+      description: 'Disables the switch.'
+    },
+    {
+      name: 'labelDescription',
+      type: 'React.ReactNode',
+      description: 'Additional description text below the switch label.'
+    },
+    {
+      name: 'error',
+      type: 'React.ReactNode',
+      description: 'Error message displayed below the switch.'
+    },
+    {
+      name: 'switchRef',
+      type: 'React.RefObject<HTMLInputElement>',
+      description: 'Named ref forwarded to the input element. Using ref is preferred.'
+    }
+  ]}
+/>
+
+## Accessibility
+
+- Renders as `<input type="checkbox" role="switch">` for correct assistive technology semantics.
+- The label is associated via `htmlFor` / `id`.
+- Focus ring meets WCAG 2.1 visibility requirements using the design system focus color.
+- Use the `error` or `labelDescription` props to associate additional context via `aria-describedby`.
+- Use for immediate settings changes that do not require form submission. For settings that require a save action, prefer [Checkbox](./Checkbox).
+
+## Related Components
+
+- [Checkbox](./Checkbox)
+- [FieldWrap](./FieldWrap)

--- a/packages/react/src/components/Switch/Switch.test.tsx
+++ b/packages/react/src/components/Switch/Switch.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import Switch from './';
 
 describe('Switch', () => {
@@ -114,5 +115,49 @@ describe('Switch', () => {
   test('has role switch', () => {
     render(<Switch id="test" label="Toggle" />);
     expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  test('should have no axe violations when unchecked', async () => {
+    const { container } = render(<Switch id="test" label="Toggle" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have no axe violations when checked', async () => {
+    const { container } = render(
+      <Switch id="test" label="Toggle" checked onChange={jest.fn()} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have no axe violations when disabled', async () => {
+    const { container } = render(<Switch id="test" label="Toggle" disabled />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have no axe violations when disabled and checked', async () => {
+    const { container } = render(
+      <Switch id="test" label="Toggle" disabled checked onChange={jest.fn()} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have no axe violations with error', async () => {
+    const { container } = render(
+      <Switch id="test" label="Toggle" error="This field is required" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have no axe violations with label description', async () => {
+    const { container } = render(
+      <Switch id="test" label="Toggle" labelDescription="Additional info" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/react/src/components/Switch/Switch.test.tsx
+++ b/packages/react/src/components/Switch/Switch.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import Switch from './';
@@ -38,33 +38,62 @@ describe('Switch', () => {
     expect(container.querySelector('.Switch.custom-class')).toBeInTheDocument();
   });
 
-  test('calls onChange when toggled', () => {
+  test('has role switch', () => {
+    render(<Switch id="test" label="Toggle" />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  test('calls onChange when toggled', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     render(<Switch id="test" label="Toggle" onChange={onChange} />);
-    fireEvent.click(screen.getByRole('switch'));
+    await user.click(screen.getByRole('switch'));
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   test('does not call onChange when disabled', async () => {
-    const onChange = jest.fn();
     const user = userEvent.setup();
+    const onChange = jest.fn();
     render(<Switch id="test" label="Toggle" disabled onChange={onChange} />);
     await user.click(screen.getByRole('switch'));
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  test('calls onFocus when focused', () => {
+  test('toggles checked state on click', async () => {
+    const user = userEvent.setup();
+    render(<Switch id="test" label="Toggle" />);
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).not.toBeChecked();
+    await user.click(switchEl);
+    expect(switchEl).toBeChecked();
+    await user.click(switchEl);
+    expect(switchEl).not.toBeChecked();
+  });
+
+  test('calls onFocus when focused', async () => {
+    const user = userEvent.setup();
     const onFocus = jest.fn();
     render(<Switch id="test" label="Toggle" onFocus={onFocus} />);
-    fireEvent.focus(screen.getByRole('switch'));
+    await user.tab();
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
 
-  test('calls onBlur when blurred', () => {
+  test('calls onBlur when blurred', async () => {
+    const user = userEvent.setup();
     const onBlur = jest.fn();
     render(<Switch id="test" label="Toggle" onBlur={onBlur} />);
-    fireEvent.blur(screen.getByRole('switch'));
+    await user.tab();
+    await user.tab();
     expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('toggles via Space key', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<Switch id="test" label="Toggle" onChange={onChange} />);
+    await user.tab();
+    await user.keyboard(' ');
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   test('syncs with controlled checked prop', () => {
@@ -112,9 +141,15 @@ describe('Switch', () => {
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
   });
 
-  test('has role switch', () => {
-    render(<Switch id="test" label="Toggle" />);
-    expect(screen.getByRole('switch')).toBeInTheDocument();
+  test('forwards switchRef to input element', () => {
+    const switchRef = React.createRef<HTMLInputElement>();
+    render(<Switch id="test" label="Toggle" switchRef={switchRef} />);
+    expect(switchRef.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  test('renders without errors when no optional props are provided', () => {
+    const { container } = render(<Switch id="test" label="Toggle" />);
+    expect(container.querySelector('.Switch')).toBeInTheDocument();
   });
 
   test('should have no axe violations when unchecked', async () => {

--- a/packages/react/src/components/Switch/Switch.test.tsx
+++ b/packages/react/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Switch from './';
+
+describe('Switch', () => {
+  test('renders with label', () => {
+    render(<Switch id="test" label="Toggle me" />);
+    expect(screen.getByLabelText('Toggle me')).toBeInTheDocument();
+  });
+
+  test('is unchecked by default', () => {
+    render(<Switch id="test" label="Toggle" />);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+
+  test('renders checked state', () => {
+    render(<Switch id="test" label="Toggle" checked />);
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  test('renders disabled state', () => {
+    render(<Switch id="test" label="Toggle" disabled />);
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  test('renders disabled checked state', () => {
+    render(<Switch id="test" label="Toggle" disabled checked />);
+    expect(screen.getByRole('switch')).toBeDisabled();
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  test('passes className to wrapper div', () => {
+    const { container } = render(
+      <Switch id="test" label="Toggle" className="custom-class" />
+    );
+    expect(container.querySelector('.Switch.custom-class')).toBeInTheDocument();
+  });
+
+  test('calls onChange when toggled', () => {
+    const onChange = jest.fn();
+    render(<Switch id="test" label="Toggle" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onChange when disabled', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(<Switch id="test" label="Toggle" disabled onChange={onChange} />);
+    await user.click(screen.getByRole('switch'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('calls onFocus when focused', () => {
+    const onFocus = jest.fn();
+    render(<Switch id="test" label="Toggle" onFocus={onFocus} />);
+    fireEvent.focus(screen.getByRole('switch'));
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onBlur when blurred', () => {
+    const onBlur = jest.fn();
+    render(<Switch id="test" label="Toggle" onBlur={onBlur} />);
+    fireEvent.blur(screen.getByRole('switch'));
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('syncs with controlled checked prop', () => {
+    const { rerender } = render(
+      <Switch id="test" label="Toggle" checked={false} onChange={jest.fn()} />
+    );
+    expect(screen.getByRole('switch')).not.toBeChecked();
+    rerender(
+      <Switch id="test" label="Toggle" checked={true} onChange={jest.fn()} />
+    );
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  test('renders error message', () => {
+    render(<Switch id="test" label="Toggle" error="This field is required" />);
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  test('renders label description', () => {
+    render(
+      <Switch id="test" label="Toggle" labelDescription="Additional info" />
+    );
+    expect(screen.getByText('Additional info')).toBeInTheDocument();
+  });
+
+  test('associates error with input via aria-describedby', () => {
+    render(<Switch id="test" label="Toggle" error="Error message" />);
+    const input = screen.getByRole('switch');
+    const errorEl = screen.getByText('Error message');
+    expect(input.getAttribute('aria-describedby')).toContain(errorEl.id);
+  });
+
+  test('associates label description with input via aria-describedby', () => {
+    render(
+      <Switch id="test" label="Toggle" labelDescription="Description text" />
+    );
+    const input = screen.getByRole('switch');
+    const descEl = screen.getByText('Description text');
+    expect(input.getAttribute('aria-describedby')).toContain(descEl.id);
+  });
+
+  test('forwards ref to input element', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Switch id="test" label="Toggle" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  test('has role switch', () => {
+    render(<Switch id="test" label="Toggle" />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -158,3 +158,4 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>(
 Switch.displayName = 'Switch';
 
 export default Switch;
+export { Switch };

--- a/packages/react/src/components/Switch/index.ts
+++ b/packages/react/src/components/Switch/index.ts
@@ -1,0 +1,2 @@
+export { default, Switch } from './Switch';
+export type { SwitchProps } from './Switch';

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -1,0 +1,160 @@
+import React, {
+  InputHTMLAttributes,
+  forwardRef,
+  useState,
+  useEffect,
+  useRef,
+  useMemo
+} from 'react';
+import classNames from 'classnames';
+import nextId from 'react-id-generator';
+import Icon from '../Icon';
+import { addIdRef } from '../../utils/idRefs';
+
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
+  id: string;
+  label: React.ReactNode;
+  labelDescription?: React.ReactNode;
+  error?: React.ReactNode;
+  switchRef?: React.ForwardedRef<HTMLInputElement>;
+}
+
+const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  (
+    {
+      id,
+      label,
+      labelDescription,
+      error,
+      switchRef,
+      className,
+      onChange,
+      onFocus,
+      onBlur,
+      'aria-describedby': ariaDescribedby,
+      disabled = false,
+      checked = false,
+      ...other
+    }: SwitchProps,
+    ref
+  ): React.JSX.Element => {
+    const [isChecked, setIsChecked] = useState(checked);
+    const [focused, setFocused] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      setIsChecked(checked);
+    }, [checked]);
+
+    const refProp = ref || switchRef;
+
+    if (typeof refProp === 'function') {
+      refProp(inputRef.current);
+    }
+
+    const { errorId, labelDescriptionId } = useMemo(() => {
+      return {
+        labelDescriptionId: nextId(),
+        errorId: nextId()
+      };
+    }, []);
+
+    let ariaDescribedbyId = ariaDescribedby;
+
+    if (error) {
+      ariaDescribedbyId = addIdRef(ariaDescribedbyId, errorId);
+    }
+
+    if (labelDescription) {
+      ariaDescribedbyId = addIdRef(ariaDescribedbyId, labelDescriptionId);
+    }
+
+    return (
+      <div className="Switch__wrap">
+        <div
+          className={classNames('Switch', className, {
+            'Switch--checked': isChecked,
+            'Switch--disabled': disabled
+          })}
+        >
+          <input
+            id={id}
+            ref={typeof refProp === 'function' || !refProp ? inputRef : refProp}
+            type="checkbox"
+            role="switch"
+            checked={isChecked}
+            disabled={disabled}
+            aria-describedby={ariaDescribedbyId}
+            onFocus={(e): void => {
+              setFocused(true);
+              if (typeof onFocus === 'function') {
+                onFocus(e);
+              }
+            }}
+            onBlur={(e): void => {
+              setFocused(false);
+              if (typeof onBlur === 'function') {
+                onBlur(e);
+              }
+            }}
+            onChange={(e): void => {
+              setIsChecked(e.target.checked);
+              if (onChange) {
+                onChange(e);
+              }
+            }}
+            {...other}
+          />
+          <span
+            className={classNames('Switch__track', {
+              'Switch__track--focused': focused
+            })}
+            aria-hidden="true"
+            onClick={(): void => {
+              if (refProp && typeof refProp !== 'function') {
+                refProp.current?.click();
+              } else {
+                inputRef.current?.click();
+              }
+            }}
+          >
+            <span className="Switch__handle">
+              {isChecked && (
+                <Icon
+                  type="check-circle"
+                  className="Switch__icon"
+                  aria-hidden="true"
+                />
+              )}
+            </span>
+          </span>
+          <label
+            className={classNames('Switch__label', {
+              'Field__label--disabled': disabled
+            })}
+            htmlFor={id}
+          >
+            {label}
+          </label>
+        </div>
+        {labelDescription && (
+          <span id={labelDescriptionId} className="Field__labelDescription">
+            {labelDescription}
+          </span>
+        )}
+        {error && (
+          <div id={errorId} className="Error">
+            {error}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+Switch.displayName = 'Switch';
+
+export default Switch;

--- a/packages/react/src/components/Switch/screenshots.e2e.tsx
+++ b/packages/react/src/components/Switch/screenshots.e2e.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { test, expect } from '../../../../../e2e/screenshots';
+import { setActive, setTheme } from '../../../../../e2e/helpers/playwright';
+import { Switch, FieldWrap } from '../../../';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+test('should have screenshot for Switch', async ({ mount, page }) => {
+  const component = await mount(
+    <FieldWrap>
+      <Switch id="switch" label="Switch" />
+      <Switch id="switch-hover" label="Hover" />
+      <Switch id="switch-focus" label="Focus" />
+      <Switch id="switch-active" label="Active" />
+      <Switch id="switch-disabled" label="Disabled" disabled />
+    </FieldWrap>
+  );
+
+  await component.getByRole('switch', { name: 'Focus' }).focus();
+  await component.getByText('Hover').hover();
+  setActive(
+    await component.locator('.Switch__wrap:nth-child(4) .Switch__track')
+  );
+
+  await expect(component).toHaveScreenshot('switch');
+  await setTheme(page, 'dark');
+  await expect(component).toHaveScreenshot('dark--switch');
+});
+
+test('should have screenshot for Switch[checked]', async ({ mount, page }) => {
+  const component = await mount(
+    <FieldWrap>
+      <Switch id="switch" label="Switch" checked onChange={noop} />
+      <Switch id="switch-hover" label="Hover" checked onChange={noop} />
+      <Switch id="switch-focus" label="Focus" checked onChange={noop} />
+      <Switch id="switch-active" label="Active" checked onChange={noop} />
+      <Switch
+        id="switch-disabled"
+        label="Disabled"
+        checked
+        disabled
+        onChange={noop}
+      />
+    </FieldWrap>
+  );
+
+  await component.getByRole('switch', { name: 'Focus' }).focus();
+  await component.getByText('Hover').hover();
+  setActive(
+    await component.locator('.Switch__wrap:nth-child(4) .Switch__track')
+  );
+
+  await expect(component).toHaveScreenshot('switch[checked]');
+  await setTheme(page, 'dark');
+  await expect(component).toHaveScreenshot('dark--switch[checked]');
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -61,6 +61,7 @@ export {
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as RadioCardGroup } from './components/RadioCardGroup';
 export { default as Checkbox } from './components/Checkbox';
+export { default as Switch } from './components/Switch';
 export {
   default as Tooltip,
   TooltipHead,

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -17,6 +17,7 @@
 @import './side-bar.css';
 @import './radio-card.css';
 @import './toast.css';
+@import './switch.css';
 @import './tooltip.css';
 @import './tooltip-tabstop.css';
 @import './top-bar.css';

--- a/packages/styles/switch.css
+++ b/packages/styles/switch.css
@@ -1,0 +1,176 @@
+:root {
+  --switch-track-color: var(--gray-90);
+  --switch-track-color-checked: var(--accent-primary);
+  --switch-track-color-disabled: var(--gray-40);
+  --switch-track-color-checked-disabled: var(
+    --accent-primary-disabled,
+    #78a6d8
+  );
+  --switch-handle-color: var(--gray-90);
+  --switch-handle-color-disabled: var(--gray-40);
+  --switch-focus-color: var(--focus-light);
+  --switch-label-color: var(--gray-90);
+}
+
+.cauldron--theme-dark {
+  --switch-track-color: var(--white);
+  --switch-track-color-checked: var(--accent-light);
+  --switch-track-color-checked-disabled: var(--stroke-dark);
+  --switch-handle-color: var(--white);
+  --switch-handle-color-disabled: var(--stroke-dark);
+  --switch-focus-color: var(--focus-dark);
+  --switch-label-color: var(--white);
+}
+
+.Switch__wrap {
+  margin-bottom: var(--space-smallest);
+}
+
+.Switch__wrap:last-of-type {
+  margin-bottom: 0;
+}
+
+.Switch {
+  display: flex;
+  align-items: center;
+  gap: var(--space-smallest);
+  flex-wrap: nowrap;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.Switch input[type='checkbox'] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  appearance: none;
+}
+
+/* Track */
+
+.Switch__track {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 44px;
+  height: 24px;
+  border: 2px solid var(--switch-track-color);
+  border-radius: 999px;
+  padding: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+}
+
+/* Hover ring */
+
+.Switch__track::before {
+  content: '';
+  position: absolute;
+  inset: -5px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.Switch:not(.Switch--disabled):hover .Switch__track::before {
+  border-color: var(--switch-track-color);
+}
+
+.Switch--checked:not(.Switch--disabled):hover .Switch__track::before {
+  border-color: var(--switch-track-color-checked);
+}
+
+/* Focus ring */
+
+.Switch__track::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.Switch__track--focused::after {
+  border-color: var(--switch-focus-color);
+}
+
+/* Checked state */
+
+.Switch--checked .Switch__track {
+  border-color: var(--switch-track-color-checked);
+  justify-content: flex-end;
+}
+
+/* Handle */
+
+.Switch__handle {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background-color: var(--switch-handle-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.Switch--checked .Switch__handle {
+  background-color: transparent;
+}
+
+/* Icon */
+
+.Switch__icon {
+  --icon-size: 16px;
+  display: none;
+  color: var(--switch-track-color-checked);
+}
+
+.Switch__icon svg {
+  pointer-events: none;
+  height: 16px;
+  width: 16px;
+}
+
+.Switch--checked .Switch__icon {
+  display: block;
+}
+
+/* Disabled */
+
+.Switch--disabled .Switch__track {
+  border-color: var(--switch-track-color-disabled);
+  cursor: default;
+}
+
+.Switch--disabled .Switch__handle {
+  background-color: var(--switch-handle-color-disabled);
+}
+
+.Switch--checked.Switch--disabled .Switch__track {
+  border-color: var(--switch-track-color-checked-disabled);
+}
+
+.Switch--checked.Switch--disabled .Switch__handle {
+  background-color: transparent;
+}
+
+.Switch--checked.Switch--disabled .Switch__icon {
+  color: var(--switch-track-color-checked-disabled);
+  opacity: 0.5;
+}
+
+/* Label */
+
+.Switch__label {
+  font-size: var(--text-size-small);
+  font-weight: var(--font-weight-medium);
+  color: var(--switch-label-color);
+  cursor: default;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- Add a new accessible `Switch` toggle component with full ARIA `role="switch"` support
- Include controlled/uncontrolled state management, disabled state, error messages, and label descriptions
- Add CSS styles with dark/light theme support via custom properties
- Add comprehensive test suite and MDX documentation with live examples

## Test plan
- [ ] Run `yarn test` and verify all Switch tests pass
- [ ] Run `yarn dev` and verify the Switch docs page renders at `/components/Switch`
- [ ] Test keyboard navigation (Space/Enter to toggle, Tab to focus)
- [ ] Verify screen reader announces switch state correctly
- [ ] Check dark and light theme rendering