### PR TITLE
fix: remove expand collapse trigger icon styles

### DIFF
--- a/packages/react/src/components/ExpandCollapsePanel/index.css
+++ b/packages/react/src/components/ExpandCollapsePanel/index.css
@@ -3,7 +3,6 @@
   --expandcollapse-trigger-color: var(--gray-90);
   --expandcollapse-panel-background-color: transparent;
   --expandcollapse-panel-color: var(--gray-90);
-  --expandcollapse-trigger-icon-offset: 0;
 }
 
 .ExpandCollapse__trigger {
@@ -21,11 +20,6 @@
 .ExpandCollapse__trigger-title {
   flex-grow: 1;
   text-align: left;
-}
-
-.ExpandCollapse__trigger > .Icon:last-child {
-  position: relative;
-  right: var(--expandcollapse-trigger-icon-offset);
 }
 
 .ExpandCollapse__panel {

--- a/packages/styles/density.css
+++ b/packages/styles/density.css
@@ -48,9 +48,6 @@
   /* Field select: constrained width */
   --select-width: clamp(0px, 25rem, 100%);
 
-  /* ExpandCollapse: adjust trigger icon position */
-  --expandcollapse-trigger-icon-offset: -8px;
-
   /* Code: inline compact display */
   --code-display: inline;
   --code-padding: var(--space-quarter) var(--space-half);


### PR DESCRIPTION
Added in https://github.com/dequelabs/cauldron/commit/c30b80bc5bc8f86e2148432738a9eb39fff41165 from extension overrides but the extension does not need it.

https://github.com/dequelabs/cauldron/commit/c30b80bc5bc8f86e2148432738a9eb39fff41165#diff-04d9532337a722882bce6c936b50ef2bd02f0ae60d0c728a19a1b01fad5a2c43R6-R30

