### PR TITLE
fix: remove progress bar thin styles from density.css

### DIFF
--- a/packages/styles/density.css
+++ b/packages/styles/density.css
@@ -32,13 +32,6 @@
   --dialog-vertical-offset: clamp(8px, calc(18vh - 50px), 100px);
   --dialog-content-line-height: 1.4;
 
-  /* ProgressBar: thinner default */
-  --progress-bar-padding: 3px;
-  --progress-bar-border-radius: 3px;
-  --progress-bar-fill-height: var(--space-half);
-  --progress-bar-fill-border-radius: 1px;
-  --progress-bar-fill-min-width: 1px;
-
   /* OptionsMenu: auto-width for narrow viewports */
   --options-menu-width: auto;
 


### PR DESCRIPTION
The `thin` prop for the `ProgressBar` can be used instead of duplicating these styles in `density.css`.