### PR TITLE
fix: revert font-family on heading elements

### DIFF
--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -1,7 +1,6 @@
 :root {
   --workspace-background-color: #f0f2f5;
   --heading-text-color: var(--header-text-color-dark);
-  --heading-font-family: var(--base-font-family);
 }
 
 .cauldron--theme-dark {
@@ -52,7 +51,6 @@ h5,
 h6,
 [role='heading'] {
   color: var(--heading-text-color);
-  font-family: var(--heading-font-family);
 }
 
 ul {


### PR DESCRIPTION
## Summary
- Removes the `--heading-font-family` CSS custom property and `font-family` rule on heading elements introduced in #2287
- Headings will now inherit `font-family` from `body` instead of being explicitly set via a custom property

## Test plan
- [ ] Verify heading elements render with the correct inherited font-family
- [ ] Confirm no visual regressions in light and dark themes