### PR TITLE
fix: revert dialog Field styles and z-index from density preset

### DIFF
--- a/packages/styles/dialog.css
+++ b/packages/styles/dialog.css
@@ -15,7 +15,6 @@
   --dialog-vertical-offset: 6.25rem;
   --dialog-bottom-spacing: 1.875rem;
   --dialog-content-line-height: inherit;
-  --dialog-z-index: auto;
 }
 
 .cauldron--theme-dark {
@@ -33,7 +32,6 @@
   overflow-x: auto;
   position: fixed;
   top: 0;
-  z-index: var(--dialog-z-index);
   background-color: var(--scrim-background-color);
 }
 
@@ -140,10 +138,6 @@
 
 .Dialog__content p:last-child {
   margin-bottom: 0;
-}
-
-.Dialog__content .Field {
-  width: 100%;
 }
 
 .Dialog__footer {


### PR DESCRIPTION
## Summary

- Removes `.Dialog__content .Field { width: 100% }` rule introduced in #2287 that forced Field elements to full width inside Dialogs
- Removes `--dialog-z-index` custom property and `z-index` declaration on `.Dialog` added in #2287

## Test plan
- [x] Verify Field elements inside Dialogs are no longer forced to `width: 100%`