### PR TITLE
fix(TableHeader): remove sort announcement props as no needed and update aria-sort handling

### DIFF
--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,7 +1,6 @@
 import type { ColumnAlignment } from './Table';
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
-import Offscreen from '../Offscreen';
 import Icon from '../Icon';
 import { useTable } from './TableContext';
 import useTableGridStyles from './useTableGridStyles';
@@ -10,11 +9,15 @@ import useSharedRef from '../../utils/useSharedRef';
 // these match aria-sort's values
 type SortDirection = 'ascending' | 'descending' | 'none';
 
-interface TableHeaderProps
-  extends Omit<React.ThHTMLAttributes<HTMLTableHeaderCellElement>, 'align'> {
+interface TableHeaderProps extends Omit<
+  React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
+  'align'
+> {
   sortDirection?: SortDirection;
   onSort?: () => void;
+  /** @deprecated No longer used. Sort state is communicated via aria-sort. */
   sortAscendingAnnouncement?: string;
+  /** @deprecated No longer used. Sort state is communicated via aria-sort. */
   sortDescendingAnnouncement?: string;
   align?: ColumnAlignment;
   /* Only applies a visual style to the header, does not change semantics */
@@ -28,8 +31,8 @@ const TableHeader = forwardRef<HTMLTableHeaderCellElement, TableHeaderProps>(
       sortDirection,
       onSort,
       className,
-      sortAscendingAnnouncement = 'sorted ascending',
-      sortDescendingAnnouncement = 'sorted descending',
+      sortAscendingAnnouncement: _sortAscendingAnnouncement,
+      sortDescendingAnnouncement: _sortDescendingAnnouncement,
       align,
       variant = 'header',
       style,
@@ -46,16 +49,11 @@ const TableHeader = forwardRef<HTMLTableHeaderCellElement, TableHeaderProps>(
       layout
     });
 
-    // When the sort direction changes, we want to announce the change in a live region
-    // because changes to the sort value is not widely supported yet
-    // see: https://a11ysupport.io/tech/aria/aria-sort_attribute
-    const announcement =
-      sortDirection === 'ascending'
-        ? sortAscendingAnnouncement
-        : sortDirection === 'descending'
-          ? sortDescendingAnnouncement
-          : '';
-
+    // Sort state is communicated via the aria-sort attribute on <th>.
+    // A live region (Offscreen) was previously used as a workaround for
+    // limited aria-sort support, but it was removed because screen readers
+    // (e.g. NVDA) included the announcement text in the column header's
+    // accessible name, causing it to be read for every cell in the column.
     return (
       <th
         ref={tableHeaderRef}
@@ -89,11 +87,6 @@ const TableHeader = forwardRef<HTMLTableHeaderCellElement, TableHeaderProps>(
                 <Icon type="table-sort-descending" />
               )}
             </span>
-            <Offscreen>
-              <span role="status" aria-live="polite">
-                {announcement}
-              </span>
-            </Offscreen>
           </button>
         ) : (
           children

--- a/packages/react/src/components/Table/index.test.tsx
+++ b/packages/react/src/components/Table/index.test.tsx
@@ -204,8 +204,7 @@ test('should render sort button and icons with sortDirection and onSort in Table
   );
 
   expect(screen.getByRole('button')).toBeInTheDocument();
-  expect(screen.getByRole('status').closest('.Icon--sort-triangle'));
-  expect(screen.getByRole('status')).toHaveTextContent('');
+  expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'none');
 });
 
 test('should render className "TableHeader--sorting" when actively sorting', () => {
@@ -231,16 +230,12 @@ test('should render className "TableHeader--sorting" when actively sorting', () 
   );
 });
 
-test('should render triangle up Icon and ascending message when sortDirection is ascending', () => {
+test('should render triangle up Icon and set aria-sort when sortDirection is ascending', () => {
   render(
     <Table>
       <TableHead>
         <TableRow>
-          <TableHeader
-            sortDirection={'ascending'}
-            sortAscendingAnnouncement={'up and away'}
-            onSort={() => null}
-          >
+          <TableHeader sortDirection={'ascending'} onSort={() => null}>
             Sortable Header
           </TableHeader>
         </TableRow>
@@ -248,20 +243,18 @@ test('should render triangle up Icon and ascending message when sortDirection is
     </Table>
   );
 
-  expect(screen.getByRole('status')).toHaveTextContent('up and away');
-  expect(screen.getByRole('status').closest('.Icon--table-sort-ascending'));
+  expect(screen.getByRole('columnheader')).toHaveAttribute(
+    'aria-sort',
+    'ascending'
+  );
 });
 
-test('should render triangle down Icon and descending message when sortDirection is descending', () => {
+test('should render triangle down Icon and set aria-sort when sortDirection is descending', () => {
   render(
     <Table>
       <TableHead>
         <TableRow>
-          <TableHeader
-            sortDirection={'descending'}
-            sortDescendingAnnouncement={'down below'}
-            onSort={() => null}
-          >
+          <TableHeader sortDirection={'descending'} onSort={() => null}>
             Sortable Header
           </TableHeader>
         </TableRow>
@@ -269,8 +262,10 @@ test('should render triangle down Icon and descending message when sortDirection
     </Table>
   );
 
-  expect(screen.getByRole('status')).toHaveTextContent('down below');
-  expect(screen.getByRole('status').closest('.Icon--table-sort-descending'));
+  expect(screen.getByRole('columnheader')).toHaveAttribute(
+    'aria-sort',
+    'descending'
+  );
 });
 
 test('should call onSort when sort button is clicked', async () => {


### PR DESCRIPTION
## Summary

Fix NVDA screen reader announcing sort state on every table row cell.

**Problem:** 
NVDA was reading "Rule sorted ascending" (or similar) for every cell in a sortable column, not just the column header.

For example:
row 2  RuleRule sorted ascending  column 1  link   and elements...
row 3  RuleRule sorted ascending  column 1  link  All page content...

**Root cause:** 
`TableHeader` rendered an `Offscreen` live region
(`role="status" aria-live="polite"`) inside the sort `<button>`. Because it
was inside the button, screen readers included the announcement text in the
column header's accessible name. NVDA then repeated that name for every cell
in the column.

**Fix:**
Removed the `Offscreen` live region entirely. Sort state is now
communicated solely via the `aria-sort` attribute on `<th>`, which is the
standard ARIA mechanism and is well-supported in modern screen readers (NVDA, JAWS, VoiceOver).

## Changes

- `packages/react/src/components/Table/TableHeader.tsx` — removed `Offscreen`
  live region from inside the sort button; marked `sortAscendingAnnouncement`
  and `sortDescendingAnnouncement` props as `@deprecated` for backwards compatibility

- `packages/react/src/components/Table/index.test.tsx` — updated three tests
  to assert on `aria-sort` attribute instead of the removed live region content

## Before / After (NVDA)

**Before:**
row 2  RuleRule sorted ascending  column 1  link  ...
row 3  RuleRule sorted ascending  column 1  link  ...
<details><summary>Screenshot:</summary>

![photo_2026-04-09 13 19 04](https://github.com/user-attachments/assets/0774c5df-3e41-4d83-bcee-ae2a1f35623d)

</details>

**After:**
row 1  column 1  sorted ascending  Rule  button
row 2  First Name  column 1  Frank
row 3  First Name  column 1  Jimmy
<details><summary>Screenshot:</summary>

![photo_2026-04-09 13 19 07](https://github.com/user-attachments/assets/bcf5a08a-7df5-457c-8557-e87aa6d59816)

</details>

**DebHub verification:**

![photo_2026-04-09 13 19 10](https://github.com/user-attachments/assets/915d6925-d190-4171-8e68-1a768c1551f5)

Closes: [Walnut #13951](https://github.com/dequelabs/walnut/issues/13951)