### PR TITLE
ci: stop warnings from showing when generating screenshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:a11y": "ts-node e2e/accessibility.ts",
     "postinstall": "if [ -z \"$CI\" ]; then yarn --cwd=packages/styles && yarn --cwd=packages/react; fi",
     "screenshots": "docker run --rm --ipc=host -v $(pwd)/playwright-ct.config.ts:/app/playwright-ct.config.ts -v $(pwd)/packages:/app/packages -v $(pwd)/e2e:/app/e2e cauldron-playwright-e2e-screenshots",
-    "screenshots:docker": "docker build . -t cauldron-playwright-e2e-screenshots -f e2e/Dockerfile --build-arg playwright_version=$(npm list --depth=0 playwright | grep playwright | cut -f2 -d '@')",
+    "screenshots:docker": "docker build . -t cauldron-playwright-e2e-screenshots -f e2e/Dockerfile --build-arg playwright_version=$(node -p \"require('playwright/package.json').version\")",
     "release": "./scripts/release.sh",
     "precommit": "lint-staged",
     "prepare": "husky"


### PR DESCRIPTION
## Summary

- Replace `npm list` pipeline with `node -p "require('playwright/package.json').version"` in `screenshots:docker` script
- Avoids yarn's `npm_config_*` environment variables triggering unknown env config warnings from npm
- Prevents future breakage when npm turns these warnings into errors

Closes #2317