### PR TITLE
fix(Toast): accessibility issue with long content + refactor + build fix

### DIFF
--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import AriaIsolate from '../../utils/aria-isolate';
@@ -7,192 +7,166 @@ import setRef from '../../utils/setRef';
 
 export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   type: 'confirmation' | 'caution' | 'error' | 'action-needed' | 'info';
-  onDismiss: () => void;
+  onDismiss?: () => void;
   dismissText?: string;
-  toastRef: React.Ref<HTMLDivElement>;
+  toastRef?: React.Ref<HTMLDivElement>;
   focus?: boolean;
   show?: boolean;
   dismissible?: boolean;
   children: React.ReactNode;
 }
 
-interface ToastState {
-  animationClass: string;
-  isolator?: AriaIsolate;
-}
-
 /**
  * The cauldron toast notification component
  */
-export default class Toast extends React.Component<ToastProps, ToastState> {
-  static defaultProps = {
-    dismissText: 'Dismiss',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    onDismiss: () => {},
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    toastRef: () => {},
-    focus: true,
-    show: false,
-    dismissible: true
+const Toast = ({
+  type,
+  children,
+  onDismiss,
+  dismissText = 'Dismiss',
+  toastRef,
+  focus = true,
+  show = false,
+  dismissible = true,
+  className,
+  ...otherProps
+}: ToastProps) => {
+  const [animationClass, setAnimationClass] = useState(
+    show ? 'FadeIn--flex' : 'is--hidden'
+  );
+
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const isolatorRef = useRef<AriaIsolate | undefined>(undefined);
+  const isFirstRenderRef = useRef(true);
+
+  // Keep refs to latest prop values to avoid stale closures in effects/callbacks
+  const typeRef = useRef(type);
+  const focusRef = useRef(focus);
+  const onDismissRef = useRef(onDismiss);
+  typeRef.current = type;
+  focusRef.current = focus;
+  onDismissRef.current = onDismiss;
+
+  const showToast = () => {
+    const el = elRef.current;
+    setAnimationClass('FadeIn--flex FadeIn');
+
+    if (typeRef.current === 'action-needed') {
+      const newIsolator = new AriaIsolate(el as HTMLDivElement);
+      tabIndexHandler(false, el);
+      isolatorRef.current = newIsolator;
+      newIsolator.activate();
+    }
+
+    if (el && focusRef.current) {
+      el.focus();
+    }
   };
 
-  static displayName = 'Toast';
+  const dismissToast = () => {
+    const el = elRef.current;
+    if (!el) return;
 
-  private el: HTMLDivElement | null;
+    setAnimationClass('FadeIn--flex');
 
-  constructor(props: ToastProps) {
-    super(props);
+    // Timeout because CSS display: none/block and opacity:
+    // 0/1 properties cannot be toggled in the same tick
+    // see: https://codepen.io/isnerms/pen/eyQaLP
+    setTimeout(() => {
+      if (typeRef.current === 'action-needed') {
+        tabIndexHandler(true, el);
+        isolatorRef.current?.deactivate();
+      }
 
-    this.state = {
-      animationClass: props.show ? 'FadeIn--flex' : 'is--hidden'
-    };
+      setAnimationClass('is--hidden');
+      onDismissRef.current?.();
+    });
+  };
 
-    this.dismissToast = this.dismissToast.bind(this);
-    this.showToast = this.showToast.bind(this);
-  }
-
-  componentDidMount() {
-    const { show } = this.props;
-
+  // Mount effect: if initially shown, trigger the show animation
+  useEffect(() => {
     if (show) {
       // Timeout because CSS display: none/block and opacity:
       // 0/1 properties cannot be toggled in the same tick
       // see: https://codepen.io/isnerms/pen/eyQaLP
-      setTimeout(this.showToast);
+      const id = setTimeout(showToast);
+      return () => clearTimeout(id);
     }
-  }
+  }, []);
 
-  componentDidUpdate(prevProps: ToastProps) {
-    const { show } = this.props;
-    if (prevProps.show !== show) {
-      if (show) {
-        this.setState({ animationClass: 'FadeIn--flex' }, () => {
-          setTimeout(this.showToast);
-        });
-      } else {
-        this.dismissToast();
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    const { isolator } = this.state;
-    isolator?.deactivate();
-  }
-
-  render() {
-    const { animationClass } = this.state;
-    const {
-      type,
-      children,
-      // prevent `onDismiss` from being passed-through to DOM
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onDismiss,
-      dismissText,
-      toastRef,
-      focus,
-      show,
-      dismissible,
-      className,
-      ...otherProps
-    } = this.props;
-    const scrim =
-      type === 'action-needed' && show ? (
-        <div className="Scrim--light Scrim--show Scrim--fade-in" />
-      ) : null;
-
-    const defaultProps: React.HTMLAttributes<HTMLDivElement> = {
-      tabIndex: -1,
-      className: classNames(
-        'Toast',
-        `Toast--${typeMap[type].className}`,
-        animationClass,
-        { 'Toast--non-dismissible': !dismissible },
-        className
-      )
-    };
-
-    if (!focus) {
-      defaultProps.role = 'alert';
-    }
-
-    return (
-      <React.Fragment>
-        <div
-          ref={(el) => {
-            this.el = el;
-            setRef(toastRef, el);
-          }}
-          {...defaultProps}
-          {...otherProps}
-        >
-          <div className="Toast__message">
-            <Icon type={typeMap[type].icon} />
-            <div className="Toast__message-content">{children}</div>
-          </div>
-          {type !== 'action-needed' && dismissible && (
-            <button
-              type="button"
-              className={'Toast__dismiss'}
-              aria-label={dismissText}
-              onClick={this.dismissToast}
-            >
-              <Icon type="close" />
-            </button>
-          )}
-        </div>
-        {scrim}
-      </React.Fragment>
-    );
-  }
-
-  dismissToast() {
-    if (!this.el) {
+  // Effect to handle `show` prop changes after mount
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
       return;
     }
-    const { onDismiss, type } = this.props;
-    const { isolator } = this.state;
 
-    this.setState(
-      {
-        animationClass: 'FadeIn--flex'
-      },
-      () => {
-        // Timeout because CSS display: none/block and opacity:
-        // 0/1 properties cannot be toggled in the same tick
-        // see: https://codepen.io/isnerms/pen/eyQaLP
-        setTimeout(() => {
-          if (type === 'action-needed') {
-            tabIndexHandler(true, this.el);
-            isolator?.deactivate();
-          }
+    if (show) {
+      setAnimationClass('FadeIn--flex');
+      const id = setTimeout(showToast);
+      return () => clearTimeout(id);
+    } else {
+      dismissToast();
+    }
+  }, [show]);
 
-          this.setState({ animationClass: 'is--hidden' }, onDismiss);
-        });
-      }
-    );
+  // Cleanup: deactivate aria isolate on unmount
+  useEffect(() => {
+    return () => {
+      isolatorRef.current?.deactivate();
+    };
+  }, []);
+
+  const scrim =
+    type === 'action-needed' && show ? (
+      <div className="Scrim--light Scrim--show Scrim--fade-in" />
+    ) : null;
+
+  const defaultProps: React.HTMLAttributes<HTMLDivElement> = {
+    tabIndex: -1,
+    className: classNames(
+      'Toast',
+      `Toast--${typeMap[type].className}`,
+      animationClass,
+      { 'Toast--non-dismissible': !dismissible },
+      className
+    )
+  };
+
+  if (!focus) {
+    defaultProps.role = 'alert';
   }
 
-  showToast() {
-    const { type, focus } = this.props;
+  return (
+    <React.Fragment>
+      <div
+        ref={(el) => {
+          elRef.current = el;
+          setRef(toastRef, el);
+        }}
+        {...defaultProps}
+        {...otherProps}
+      >
+        <div className="Toast__message">
+          <Icon type={typeMap[type].icon} />
+          <div className="Toast__message-content">{children}</div>
+        </div>
+        {type !== 'action-needed' && dismissible && (
+          <button
+            type="button"
+            className={'Toast__dismiss'}
+            aria-label={dismissText}
+            onClick={dismissToast}
+          >
+            <Icon type="close" />
+          </button>
+        )}
+      </div>
+      {scrim}
+    </React.Fragment>
+  );
+};
 
-    this.setState(
-      {
-        animationClass: 'FadeIn--flex FadeIn'
-      },
-      () => {
-        if (type === 'action-needed') {
-          const isolator = new AriaIsolate(this.el as HTMLDivElement);
-          tabIndexHandler(false, this.el);
-          this.setState({ isolator });
-          isolator.activate();
-        }
+Toast.displayName = 'Toast';
 
-        if (this.el && !!focus) {
-          // focus the toast
-          this.el.focus();
-        }
-      }
-    );
-  }
-}
+export default Toast;

--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -71,19 +71,21 @@
   border-color: var(--field-border-color-focus-hover);
 }
 
-/* autoprefixer: off */
+/* autoprefixer: ignore next */
 .Field__select--wrapper select:user-invalid,
 .Field--has-error select {
   border-width: 1px;
   border-color: var(--field-border-color-error);
 }
 
+/* autoprefixer: ignore next */
 .Field__select--wrapper select:user-invalid:hover,
 .Field__select--wrapper.Field--has-error select:hover {
   border-color: var(--field-border-color-error-hover);
   box-shadow: 0 0 0 1px var(--field-border-color-error-hover);
 }
 
+/* autoprefixer: ignore next */
 .Field__select--wrapper select:user-invalid:focus,
 .Field__select--wrapper.Field--has-error select:focus {
   border-color: var(--field-border-color-error);
@@ -93,8 +95,8 @@
     var(--field-border-color-error-focus-glow) 0 0 5px 0;
 }
 
+/* autoprefixer: ignore next */
 .Field__select--wrapper select:user-invalid:focus:hover,
 .Field__select--wrapper.Field--has-error select:focus:hover {
   border-color: var(--field-border-color-error-hover);
 }
-/* autoprefixer: on */

--- a/packages/styles/toast.css
+++ b/packages/styles/toast.css
@@ -10,15 +10,24 @@
   box-sizing: border-box;
   display: flex;
   padding: var(--space-smallest) var(--space-small);
+  max-height: calc(100vh - var(--top-bar-height));
 }
 
 .Toast.Toast--non-dismissible {
   position: static;
   margin-bottom: var(--space-small);
+  max-height: none;
 }
 
 .TopBar--thin .Toast {
   top: var(--top-bar-height-thin);
+  max-height: calc(100vh - var(--top-bar-height-thin));
+}
+
+.TopBar--thin .Toast .Toast__message-content {
+  max-height: calc(
+    100vh - var(--top-bar-height-thin) - 2 * var(--space-smallest)
+  );
 }
 
 .Toast.Toast--success {
@@ -43,6 +52,7 @@
   border: 0;
   height: calc(var(--text-size-small) + 9px);
   color: currentColor;
+  flex-shrink: 0;
 }
 
 .Toast__dismiss:focus {
@@ -59,10 +69,13 @@
 .Toast__message .Toast__message-content {
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
+  overflow-y: auto;
+  max-height: calc(100vh - var(--top-bar-height) - 2 * var(--space-smallest));
 }
 
 .Toast__message .Icon {
   margin-right: var(--space-smallest);
+  flex-shrink: 0;
 }
 
 .Toast__message .fa {


### PR DESCRIPTION
# Summary

- a11y Fix Toast content being clipped with no scroll on small screens — the icon and dismiss button always stay visible while only the message text scrolls
- Refactor Toast from a class component to a functional component using hooks
- Fix spurious Autoprefixer build warning in select.css

---

## Accessibility fix: Toast overflow on small screens

When Toast received a large amount of text, the content was silently cut off on small screens with no way to scroll to the rest — making it inaccessible to keyboard and AT users.

Example of scrollbar showing:

<img width="729" height="338" alt="image" src="https://github.com/user-attachments/assets/13cafcb4-b6e9-4927-9aa4-42d56b07c295" />

---

## Refactor: Toast → functional component

Rewrites `packages/react/src/components/Toast/index.tsx` from a class component to a hook-based functional component with no behavior changes.

---

## Fix: Autoprefixer build warning in Select styles

Autoprefixer v9 treats `/* autoprefixer: off/on */` as a block-scoped toggle, not a range toggle. Both comments lived at root scope (the same block), so the second one (on) was silently ignored and a warning was emitted on every build.

Replaced the off/on pair in `packages/styles/select.css` with four individual `/* autoprefixer: ignore next */` comments — one per `:user-invalid` rule — which is the correct API for per-rule suppression in this version.
