### PR TITLE
feat(IconButton)!: remove deprecated tooltip props

### DIFF
--- a/docs/pages/components/IconButton.mdx
+++ b/docs/pages/components/IconButton.mdx
@@ -124,27 +124,6 @@ If there are multiple icon buttons with the same label, the visible label text c
       description: 'Props to pass and configure the displayed tooltip.'
     },
     {
-      name: 'tooltipPlacement',
-      type: 'string',
-      deprecated: true,
-      defaultValue: 'auto',
-      description: 'Deprecated, use "tooltipProps.placement" instead.'
-    },
-    {
-      name: 'tooltipVariant',
-      type: ['info', 'text', 'big'],
-      deprecated: true,
-      defaultValue: 'text',
-      description: 'Deprecated, use "tooltipProps.variant" instead.'
-    },
-    {
-      name: 'tooltipPortal',
-      type: ['React.Ref', 'HTMLElement'],
-      deprecated: true,
-      defaultValue: 'document.body',
-      description: 'Deprecated, use "tooltipProps.portal" instead.'
-    },
-    {
       name: 'large',
       type: 'boolean',
       defaultValue: 'false',

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -22,18 +22,6 @@ export interface IconButtonProps
   label: React.ReactNode;
   tooltipProps?: Omit<TooltipProps, 'children' | 'target'>;
   disabled?: boolean;
-  /**
-   * @deprecated use `tooltipProps.placement` instead
-   */
-  tooltipPlacement?: TooltipProps['placement'];
-  /**
-   * @deprecated use `tooltipProps.variant` instead
-   */
-  tooltipVariant?: TooltipProps['variant'];
-  /**
-   * @deprecated use `tooltipProps.portal` instead
-   */
-  tooltipPortal?: TooltipProps['portal'];
   variant?: 'primary' | 'secondary' | 'tertiary' | 'error';
   large?: boolean;
 }
@@ -50,9 +38,6 @@ const IconButton = forwardRef(
       as: Component = 'button',
       icon,
       label,
-      tooltipPlacement,
-      tooltipVariant,
-      tooltipPortal,
       tooltipProps: tooltipPropsProp = {},
       className,
       variant = 'secondary',
@@ -81,21 +66,8 @@ const IconButton = forwardRef(
       }
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (!!tooltipPlacement || !!tooltipVariant || !!tooltipPortal) {
-        React.useEffect(() => {
-          console.warn(
-            '[IconButton] The following props are deprecated: tooltipPlacement, tooltipVariant, tooltipPortal. ' +
-              'See https://cauldron.dequelabs.com/components/IconButton for recommended replacement.'
-          );
-        }, []);
-      }
-    }
-
     const tooltipProps: Omit<TooltipProps, 'children' | 'target'> = {
-      placement: tooltipPlacement || 'auto',
-      variant: tooltipVariant,
-      portal: tooltipPortal,
+      placement: 'auto',
       association: 'aria-labelledby',
       hideElementOnHidden: true,
       ...tooltipPropsProp


### PR DESCRIPTION
## Summary

- Removes the deprecated `tooltipPlacement`, `tooltipVariant`, and `tooltipPortal` props from `IconButton`, along with the dev-only `console.warn` that warned on their use. Consumers should use `tooltipProps.placement`, `tooltipProps.variant`, and `tooltipProps.portal` instead.
- Drops the corresponding deprecated rows from the `IconButton` docs props table.

These props were deprecated in #1465 (April 2024) — well past the two-month deprecation window required by [CONTRIBUTING.md](https://github.com/dequelabs/cauldron/blob/develop/CONTRIBUTING.md#deprecating).

The commit uses a `feat!:` prefix with a `BREAKING CHANGE:` footer so `standard-version` will surface the removal in the changelog.

## Test plan

- [x] `yarn test` — IconButton suite (17 tests) passes
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] CI green