### PR TITLE
fix: remove unneeded autoprefixer comments

### DIFF
--- a/packages/styles/select.css
+++ b/packages/styles/select.css
@@ -71,7 +71,6 @@
   border-color: var(--field-border-color-focus-hover);
 }
 
-/* autoprefixer: off */
 .Field__select--wrapper select:user-invalid,
 .Field--has-error select {
   border-width: 1px;
@@ -97,4 +96,3 @@
 .Field__select--wrapper.Field--has-error select:focus:hover {
   border-color: var(--field-border-color-error-hover);
 }
-/* autoprefixer: on */


### PR DESCRIPTION
When running the docs site locally, these were causing a compile warning to appear. We don't need to turn off auto-prefixing for these.

<img width="981" height="478" alt="Screenshot 2026-04-28 at 1 59 21 PM" src="https://github.com/user-attachments/assets/0c379694-8078-432a-a930-4b212e504895" />


```
 ⚠  Second Autoprefixer control comment was ignored. Autoprefixer applies control comment to whole block, not to next rules. [autoprefixer]
 ```

https://github.com/postcss/autoprefixer#control-comments