### PR TITLE
fix(Tooltip): cancel hide timeout on unmount

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -222,26 +222,30 @@ test('should cancel the pending hide timeout when unmounted during the hide dela
   const hideEvent = spy();
   button.addEventListener('cauldron:tooltip:hide', hideEvent);
 
-  const ShowTooltip = ({ show = true }: { show?: boolean }) =>
-    show ? (
-      <Tooltip target={button} defaultShow={false}>
-        Hello Tooltip
-      </Tooltip>
-    ) : null;
+  try {
+    const ShowTooltip = ({ show = true }: { show?: boolean }) =>
+      show ? (
+        <Tooltip target={button} defaultShow={false}>
+          Hello Tooltip
+        </Tooltip>
+      ) : null;
 
-  const { rerender } = render(<ShowTooltip />);
-  await fireEvent.focusIn(button);
-  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+    const { rerender } = render(<ShowTooltip />);
+    await fireEvent.focusIn(button);
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 
-  // Schedule the 100ms hide timeout, then unmount before it fires.
-  await fireEvent.focusOut(button);
-  rerender(<ShowTooltip show={false} />);
+    // Schedule the 100ms hide timeout, then unmount before it fires.
+    await fireEvent.focusOut(button);
+    rerender(<ShowTooltip show={false} />);
 
-  // Wait past TIP_HIDE_DELAY so a leaked timeout would have fired.
-  await new Promise((resolve) => setTimeout(resolve, 150));
+    // Wait past TIP_HIDE_DELAY so a leaked timeout would have fired.
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-  expect(hideEvent.called).toBe(false);
-  button.remove();
+    expect(hideEvent.called).toBe(false);
+  } finally {
+    button.removeEventListener('cauldron:tooltip:hide', hideEvent);
+    button.remove();
+  }
 });
 
 test('should return no axe violations with default variant', async () => {

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -215,6 +215,35 @@ test('should clean up association when tooltip is no longer rendered', async () 
   ).not.toContain('tooltip');
 });
 
+test('should cancel the pending hide timeout when unmounted during the hide delay', async () => {
+  const button = document.createElement('button');
+  button.textContent = 'button';
+  document.body.appendChild(button);
+  const hideEvent = spy();
+  button.addEventListener('cauldron:tooltip:hide', hideEvent);
+
+  const ShowTooltip = ({ show = true }: { show?: boolean }) =>
+    show ? (
+      <Tooltip target={button} defaultShow={false}>
+        Hello Tooltip
+      </Tooltip>
+    ) : null;
+
+  const { rerender } = render(<ShowTooltip />);
+  await fireEvent.focusIn(button);
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+  // Schedule the 100ms hide timeout, then unmount before it fires.
+  await fireEvent.focusOut(button);
+  rerender(<ShowTooltip show={false} />);
+
+  // Wait past TIP_HIDE_DELAY so a leaked timeout would have fired.
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  expect(hideEvent.called).toBe(false);
+  button.remove();
+});
+
 test('should return no axe violations with default variant', async () => {
   const { container } = renderTooltip();
   waitFor(() => {

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -234,14 +234,19 @@ test('should cancel the pending hide timeout when unmounted during the hide dela
     await fireEvent.focusIn(button);
     expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 
-    // Schedule the 100ms hide timeout, then unmount before it fires.
-    await fireEvent.focusOut(button);
-    rerender(<ShowTooltip show={false} />);
+    jest.useFakeTimers();
+    try {
+      // Schedule the 100ms hide timeout, then unmount before it fires.
+      await fireEvent.focusOut(button);
+      rerender(<ShowTooltip show={false} />);
 
-    // Wait past TIP_HIDE_DELAY so a leaked timeout would have fired.
-    await new Promise((resolve) => setTimeout(resolve, 150));
+      // Advance past TIP_HIDE_DELAY so a leaked timeout would have fired.
+      jest.advanceTimersByTime(150);
 
-    expect(hideEvent.called).toBe(false);
+      expect(hideEvent.called).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
   } finally {
     button.removeEventListener('cauldron:tooltip:hide', hideEvent);
     button.remove();

--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -85,11 +85,18 @@ export default function Tooltip({
         fireCustomEvent(false, targetElement);
       }, TIP_HIDE_DELAY);
     }
-
-    return () => {
-      clearTimeout(hideTimeoutRef.current as unknown as number);
-    };
   }, [target]);
+
+  // Cancel any pending hide timeout when the Tooltip unmounts so it
+  // does not fire setShowTooltip on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof showProp === 'boolean') {


### PR DESCRIPTION
## Summary

`Tooltip` schedules a 100 ms `setTimeout` in its `hide` handler that calls `setShowTooltip(false)` when it fires. If the Tooltip unmounts during that 100 ms window — e.g. a parent flips a `{condition && <Tooltip />}` gate while the user is mousing or blurring away from the target — the timeout still fires and runs `setShowTooltip` on an unmounted component, producing the React warning:

> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak…

The existing `hide` callback returned a cleanup function, but [`useCallback` never invokes the return value of the memoized function](https://react.dev/reference/react/useCallback) — so that cleanup never ran.

This PR:
- Drops the dead `return () => clearTimeout(...)` from the `hide` `useCallback`.
- Adds a `useEffect` whose unmount cleanup clears `hideTimeoutRef.current`, so a pending hide timeout cannot fire after the component is gone.
- Adds a regression test that fails on `develop` and passes with this change. The test asserts the side effect itself (the `cauldron:tooltip:hide` custom event is **not** dispatched after unmount) rather than relying on a console warning, since React 18 no longer emits that warning.

Reproduced in a downstream consumer (axe-extension) where `<LockTooltip>` is conditionally rendered behind auth/license flags that flip frequently.

<img width="947" height="205" alt="" src="https://github.com/user-attachments/assets/db364e95-eda0-4c96-b0d3-cb95947679ce" />

Results in this error upstream in the extension

## Test plan

- [x] `npx jest src/components/Tooltip/Tooltip.test.tsx` — full Tooltip suite passes (19/19)
- [x] New test fails on `develop` (verified by stashing the `index.tsx` change and re-running) and passes with the fix
- [ ] CI green