### PR TITLE
fix: useSharedRef stale reference after unmount

### DIFF
--- a/packages/react/src/utils/useSharedRef.test.tsx
+++ b/packages/react/src/utils/useSharedRef.test.tsx
@@ -56,3 +56,34 @@ test('it supports undefined parent ref', () => {
     internalRefCallback.firstCall.args[0].current?.tagName.toLowerCase()
   ).toEqual('span');
 });
+
+test('it nulls the external functional ref on unmount', () => {
+  let refEl: HTMLSpanElement | null = null;
+  const internalRefCallback = spy();
+
+  const { unmount } = render(
+    <ComponentWithSharedRef
+      ref={(el) => (refEl = el)}
+      callback={internalRefCallback}
+    />
+  );
+
+  expect(refEl).not.toBeNull();
+  unmount();
+  expect(refEl).toBeNull();
+});
+
+test('it nulls the external mutable ref on unmount', () => {
+  const fakeRef: React.MutableRefObject<HTMLSpanElement | null> = {
+    current: null
+  };
+  const internalRefCallback = spy();
+
+  const { unmount } = render(
+    <ComponentWithSharedRef ref={fakeRef} callback={internalRefCallback} />
+  );
+
+  expect(fakeRef.current).not.toBeNull();
+  unmount();
+  expect(fakeRef.current).toBeNull();
+});

--- a/packages/react/src/utils/useSharedRef.ts
+++ b/packages/react/src/utils/useSharedRef.ts
@@ -19,6 +19,7 @@ export default function useSharedRef<T>(ref: Ref<T>): MutableRefObject<T> {
   const internalRef = useRef<T>();
   useEffect(() => {
     setRef(ref, internalRef.current);
+    return () => setRef(ref, null);
   }, [ref]);
   return internalRef as MutableRefObject<T>;
 }


### PR DESCRIPTION
## What

Fix `useSharedRef` so that a forwarded parent ref is set to `null` when the host component unmounts (or when the parent ref identity changes).

## Why

Ref: #2358 

`useSharedRef` forwarded the internal element to the parent ref via a `useEffect` keyed on `[ref]` but had no cleanup. On unmount, React detaches the internal JSX-attached ref but the parent's ref (function ref or `MutableRefObject<T>`) was never updated — so any consumer relying on `if (ref.current)` for lifecycle tracking saw a falsy-positive pointing at a detached DOM node. This breaks parity with a class-style inline ref callback (`ref={(el) => setRef(parent, el)}`), which gets called with `null` on unmount.

Affects every component that uses `useSharedRef`: Toast, Drawer, Dialog, Combobox, ComboboxOption, Listbox, ListboxOption, AnchoredOverlay, LoaderOverlay, CopyButton, TextEllipsis. Surfaced during review of #2349 and originally raised by Copilot on that PR.

## Changes

 - `packages/react/src/utils/useSharedRef.ts` — return a cleanup from the forwarding effect that calls `setRef(ref, null)`. Also covers the `[ref]` identity-change case: previous parent gets `null`, new parent gets the current element.
 - `packages/react/src/utils/useSharedRef.test.tsx` — add two tests asserting the parent ref reads `null` after `unmount()`, one covering function refs and one covering mutable refs.

No consumer components needed changes — they all read the *internal* returned ref from `useSharedRef`, not the parent ref, so the new cleanup is purely additive for them. Verified by running the suites for all 11 affected components (245 tests passing) plus the hook's own tests.

## Note for downstream consumers

This is a behavior change in the contract between cauldron components and any caller that passes a ref into `Toast`/`Drawer`/`Dialog`/etc. Callers that previously read `ref.current` after the component unmounted observed a stale element; they will now correctly observe `null`, matching React's documented ref contract.

