### PR TITLE
chore(Toast): align with forwardRef convention, deprecate toastRef

### DIFF
--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -1,15 +1,25 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import AriaIsolate from '../../utils/aria-isolate';
 import { typeMap, tabIndexHandler } from './utils';
 import useSharedRef from '../../utils/useSharedRef';
+import setRef from '../../utils/setRef';
 import useDidUpdate from '../../utils/use-did-update';
 
 export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   type: 'confirmation' | 'caution' | 'error' | 'action-needed' | 'info';
   onDismiss?: () => void;
   dismissText?: string;
+  /**
+   * @deprecated Use the forwarded `ref` instead. Will be removed in the next major version.
+   */
   toastRef?: React.Ref<HTMLDivElement>;
   focus?: boolean;
   show?: boolean;
@@ -20,134 +30,146 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * The cauldron toast notification component
  */
-const Toast = ({
-  type,
-  children,
-  onDismiss = () => {
-    // noop
-  },
-  dismissText = 'Dismiss',
-  toastRef,
-  focus = true,
-  show = false,
-  dismissible = true,
-  className,
-  ...otherProps
-}: ToastProps) => {
-  const elRef = useSharedRef<HTMLDivElement>(toastRef ?? null);
-  const isolatorRef = useRef<AriaIsolate | null>(null);
-  const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
-  const [animationClass, setAnimationClass] = useState<string>(
-    show ? 'FadeIn--flex' : 'is--hidden'
-  );
+const Toast = forwardRef<HTMLDivElement, ToastProps>(
+  (
+    {
+      type,
+      children,
+      onDismiss = () => {
+        // noop
+      },
+      dismissText = 'Dismiss',
+      toastRef,
+      focus = true,
+      show = false,
+      dismissible = true,
+      className,
+      ...otherProps
+    }: ToastProps,
+    ref
+  ) => {
+    const elRef = useSharedRef<HTMLDivElement>(ref);
+    const isolatorRef = useRef<AriaIsolate | null>(null);
+    const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+    const [animationClass, setAnimationClass] = useState<string>(
+      show ? 'FadeIn--flex' : 'is--hidden'
+    );
 
-  // Timeout because CSS display: none/block and opacity:
-  // 0/1 properties cannot be toggled in the same tick
-  // see: https://codepen.io/isnerms/pen/eyQaLP
-  const scheduleNextTick = (fn: () => void) => {
-    const id = setTimeout(() => {
-      timeoutsRef.current.delete(id);
-      fn();
-    });
-    timeoutsRef.current.add(id);
-  };
+    // Backwards-compat: propagate to the deprecated toastRef prop as well
+    useEffect(() => {
+      if (!toastRef) return;
+      setRef(toastRef, elRef.current ?? null);
+      return () => setRef(toastRef, null);
+    }, [toastRef]);
 
-  const showToast = useCallback(() => {
-    setAnimationClass('FadeIn--flex FadeIn');
+    // Timeout because CSS display: none/block and opacity:
+    // 0/1 properties cannot be toggled in the same tick
+    // see: https://codepen.io/isnerms/pen/eyQaLP
+    const scheduleNextTick = (fn: () => void) => {
+      const id = setTimeout(() => {
+        timeoutsRef.current.delete(id);
+        fn();
+      });
+      timeoutsRef.current.add(id);
+    };
 
-    if (type === 'action-needed' && elRef.current) {
-      const isolator = new AriaIsolate(elRef.current);
-      tabIndexHandler(false, elRef.current);
-      isolatorRef.current = isolator;
-      isolator.activate();
-    }
+    const showToast = useCallback(() => {
+      setAnimationClass('FadeIn--flex FadeIn');
 
-    if (elRef.current && !!focus) {
-      elRef.current.focus();
-    }
-  }, [type, focus]);
-
-  const dismissToast = useCallback(() => {
-    if (!elRef.current) {
-      return;
-    }
-
-    setAnimationClass('FadeIn--flex');
-
-    scheduleNextTick(() => {
-      if (type === 'action-needed') {
-        tabIndexHandler(true, elRef.current);
-        isolatorRef.current?.deactivate();
+      if (type === 'action-needed' && elRef.current) {
+        const isolator = new AriaIsolate(elRef.current);
+        tabIndexHandler(false, elRef.current);
+        isolatorRef.current = isolator;
+        isolator.activate();
       }
 
-      setAnimationClass('is--hidden');
-      onDismiss();
-    });
-  }, [type, onDismiss]);
+      if (elRef.current && !!focus) {
+        elRef.current.focus();
+      }
+    }, [type, focus]);
 
-  useEffect(() => {
-    if (show) {
-      scheduleNextTick(showToast);
-    }
+    const dismissToast = useCallback(() => {
+      if (!elRef.current) {
+        return;
+      }
 
-    return () => {
-      timeoutsRef.current.forEach(clearTimeout);
-      timeoutsRef.current.clear();
-      isolatorRef.current?.deactivate();
-    };
-  }, []);
-
-  useDidUpdate(() => {
-    if (show) {
       setAnimationClass('FadeIn--flex');
-      scheduleNextTick(showToast);
-    } else {
-      dismissToast();
+
+      scheduleNextTick(() => {
+        if (type === 'action-needed') {
+          tabIndexHandler(true, elRef.current);
+          isolatorRef.current?.deactivate();
+        }
+
+        setAnimationClass('is--hidden');
+        onDismiss();
+      });
+    }, [type, onDismiss]);
+
+    useEffect(() => {
+      if (show) {
+        scheduleNextTick(showToast);
+      }
+
+      return () => {
+        timeoutsRef.current.forEach(clearTimeout);
+        timeoutsRef.current.clear();
+        isolatorRef.current?.deactivate();
+      };
+    }, []);
+
+    useDidUpdate(() => {
+      if (show) {
+        setAnimationClass('FadeIn--flex');
+        scheduleNextTick(showToast);
+      } else {
+        dismissToast();
+      }
+    }, [show]);
+
+    const scrim =
+      type === 'action-needed' && show ? (
+        <div className="Scrim--light Scrim--show Scrim--fade-in" />
+      ) : null;
+
+    const defaultProps: React.HTMLAttributes<HTMLDivElement> = {
+      tabIndex: -1,
+      className: classNames(
+        'Toast',
+        `Toast--${typeMap[type].className}`,
+        animationClass,
+        { 'Toast--non-dismissible': !dismissible },
+        className
+      )
+    };
+
+    if (!focus) {
+      defaultProps.role = 'alert';
     }
-  }, [show]);
 
-  const scrim =
-    type === 'action-needed' && show ? (
-      <div className="Scrim--light Scrim--show Scrim--fade-in" />
-    ) : null;
-
-  const defaultProps: React.HTMLAttributes<HTMLDivElement> = {
-    tabIndex: -1,
-    className: classNames(
-      'Toast',
-      `Toast--${typeMap[type].className}`,
-      animationClass,
-      { 'Toast--non-dismissible': !dismissible },
-      className
-    )
-  };
-
-  if (!focus) {
-    defaultProps.role = 'alert';
-  }
-
-  return (
-    <>
-      <div ref={elRef} {...defaultProps} {...otherProps}>
-        <div className="Toast__message">
-          <Icon type={typeMap[type].icon} />
-          <div className="Toast__message-content">{children}</div>
+    return (
+      <>
+        <div ref={elRef} {...defaultProps} {...otherProps}>
+          <div className="Toast__message">
+            <Icon type={typeMap[type].icon} />
+            <div className="Toast__message-content">{children}</div>
+          </div>
+          {type !== 'action-needed' && dismissible && (
+            <button
+              type="button"
+              className="Toast__dismiss"
+              aria-label={dismissText}
+              onClick={dismissToast}
+            >
+              <Icon type="close" />
+            </button>
+          )}
         </div>
-        {type !== 'action-needed' && dismissible && (
-          <button
-            type="button"
-            className="Toast__dismiss"
-            aria-label={dismissText}
-            onClick={dismissToast}
-          >
-            <Icon type="close" />
-          </button>
-        )}
-      </div>
-      {scrim}
-    </>
-  );
-};
+        {scrim}
+      </>
+    );
+  }
+);
 
 Toast.displayName = 'Toast';
 

--- a/packages/react/src/components/Toast/toast.test.tsx
+++ b/packages/react/src/components/Toast/toast.test.tsx
@@ -290,3 +290,31 @@ test('renders children within the "Toast__message-content" div', async () => {
   const elements = container.querySelectorAll('.Toast__message-content');
   expect(elements).toHaveLength(1);
 });
+
+test('forwarded ref is populated with the toast DOM element', async () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <Toast ref={ref} type="info" data-testid="toast">
+      {testString}
+    </Toast>
+  );
+
+  await waitFor(() => {
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toBe(screen.getByTestId('toast'));
+  });
+});
+
+test('deprecated toastRef prop is still populated with the toast DOM element', async () => {
+  const toastRef = React.createRef<HTMLDivElement>();
+  render(
+    <Toast toastRef={toastRef} type="info" data-testid="toast">
+      {testString}
+    </Toast>
+  );
+
+  await waitFor(() => {
+    expect(toastRef.current).not.toBeNull();
+    expect(toastRef.current).toBe(screen.getByTestId('toast'));
+  });
+});


### PR DESCRIPTION
## What

Wrap `Toast` in `React.forwardRef` so consumers can use the standard `ref` prop to access the toast's DOM node, and deprecate the existing `toastRef` prop for removal in the next major version.

## Why

`Toast` was the only functional component in `packages/react/src/components/` that exposed its DOM ref through a custom prop (`toastRef`) instead of the standard `React.forwardRef` convention used by every other ref-forwarding component in the package (`Drawer`, `Dialog`, `Combobox`, `Listbox`, etc.). Writing `<Toast ref={...} />` silently dropped the `ref`, requiring consumers to discover `toastRef` from the type definitions or docs.

Closes: #2360

## Changes

- `packages/react/src/components/Toast/index.tsx`
  - Wrapped component in `forwardRef<HTMLDivElement, ToastProps>`; forwarded `ref` is now the primary input to `useSharedRef`
  - Added a `useEffect` that also propagates the DOM node to the deprecated `toastRef` prop, keeping existing consumers working without changes
  - Imported `setRef` utility (already used internally by `useSharedRef`) to drive the backwards-compat effect
  - Added `@deprecated` JSDoc to `toastRef` in `ToastProps` marking it for removal in the next major version
- `packages/react/src/components/Toast/toast.test.tsx`
  - Added test: forwarded `ref` is populated with the toast DOM element
  - Added test: deprecated `toastRef` prop is still populated with the toast DOM element
