### PR TITLE
chore: connect components to Figma (batch 2/5)

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.figma.tsx
+++ b/packages/react/src/components/Accordion/Accordion.figma.tsx
@@ -7,7 +7,7 @@ const FIGMA_URL =
 
 figma.connect(Accordion, FIGMA_URL, {
   props: {
-    open: figma.enum('Expanded', { True: true })
+    open: figma.boolean('Expanded', { true: true, false: undefined })
   },
   example: ({ open }) => (
     <Accordion open={open}>

--- a/packages/react/src/components/Accordion/Accordion.figma.tsx
+++ b/packages/react/src/components/Accordion/Accordion.figma.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Accordion, AccordionTrigger, AccordionContent } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=107-4348&m=dev';
+
+figma.connect(Accordion, FIGMA_URL, {
+  props: {
+    open: figma.enum('Expanded', { True: true })
+  },
+  example: ({ open }) => (
+    <Accordion open={open}>
+      <AccordionTrigger>Heading</AccordionTrigger>
+      <AccordionContent>Panel content</AccordionContent>
+    </Accordion>
+  )
+});

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.figma.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.figma.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=122-6269&m=dev';
+
+figma.connect(Breadcrumb, FIGMA_URL, {
+  example: () => (
+    <Breadcrumb aria-label="breadcrumb">
+      <BreadcrumbLink href="#">One</BreadcrumbLink>
+      <BreadcrumbLink href="#">Two</BreadcrumbLink>
+      <BreadcrumbItem>Three</BreadcrumbItem>
+    </Breadcrumb>
+  )
+});

--- a/packages/react/src/components/ProgressBar/ProgressBar.figma.tsx
+++ b/packages/react/src/components/ProgressBar/ProgressBar.figma.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { ProgressBar } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=324-8788&m=dev';
+
+figma.connect(ProgressBar, FIGMA_URL, {
+  props: {
+    progress: figma.enum('Progress', {
+      '0%': 0,
+      '25%': 25,
+      '50%': 50,
+      '75%': 75,
+      '100%': 100
+    })
+  },
+  example: ({ progress }) => (
+    <ProgressBar aria-label="Progress" progress={progress} />
+  )
+});

--- a/packages/react/src/components/SearchField/SearchField.figma.tsx
+++ b/packages/react/src/components/SearchField/SearchField.figma.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { SearchField } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=852-3579&m=dev';
+
+figma.connect(SearchField, FIGMA_URL, {
+  props: {
+    label: figma.textContent('Label')
+  },
+  example: ({ label }) => <SearchField label={label} />
+});


### PR DESCRIPTION
## Summary

Adds Figma Code Connect `.figma.tsx` files for Batch 2 components: Accordion, Breadcrumb, ProgressBar, SearchField.

Follows the same conventions established in Batch 1 and `IconButton` (#2370): bare display names (no `#suffix`), defaults omitted, relative `'../../index'` import.

## Components

- Accordion — `107:4348`
- Breadcrumb — `122:6269`
- ProgressBar — `324:8788`
- SearchField — `852:3579`

Related to #2373

## Test plan

- [ ] CI passes
- [ ] Snippets render correctly in Figma Dev Mode for each connected node