### PR TITLE
chore: connect components to Figma (batch 3/5)

### DIFF
--- a/packages/react/src/components/EmptyState/EmptyState.figma.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.figma.tsx
@@ -7,10 +7,9 @@ const FIGMA_URL =
 
 figma.connect(EmptyState, FIGMA_URL, {
   props: {
-    heading: figma.textContent('Heading'),
-    description: figma.textContent('Description text')
+    heading: figma.textContent('Heading')
   },
-  example: ({ heading, description }) => (
-    <EmptyState heading={heading} description={description} />
+  example: ({ heading }) => (
+    <EmptyState heading={heading} description="Description" />
   )
 });

--- a/packages/react/src/components/EmptyState/EmptyState.figma.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.figma.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { EmptyState } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=4894-29059&m=dev';
+
+figma.connect(EmptyState, FIGMA_URL, {
+  props: {
+    heading: figma.textContent('Heading'),
+    description: figma.textContent('Description text')
+  },
+  example: ({ heading, description }) => (
+    <EmptyState heading={heading} description={description} />
+  )
+});

--- a/packages/react/src/components/FieldGroup/FieldGroup.figma.tsx
+++ b/packages/react/src/components/FieldGroup/FieldGroup.figma.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { FieldGroup } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=5348-2712&m=dev';
+
+figma.connect(FieldGroup, FIGMA_URL, {
+  props: {
+    label: figma.textContent('Label'),
+    description: figma.boolean('Description', {
+      true: 'Description',
+      false: undefined
+    }),
+    error: figma.enum('Property 1', {
+      Error: 'Error message'
+    })
+  },
+  example: ({ label, description, error }) => (
+    <FieldGroup label={label} description={description} error={error}>
+      Children
+    </FieldGroup>
+  )
+});

--- a/packages/react/src/components/Modal/Modal.figma.tsx
+++ b/packages/react/src/components/Modal/Modal.figma.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Modal } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=144-705&m=dev';
+
+figma.connect(Modal, FIGMA_URL, {
+  props: {
+    variant: figma.enum('Variant', {
+      'Info Modal': 'info'
+    }),
+    heading: figma.textContent('Heading')
+  },
+  example: ({ variant, heading }) => (
+    <Modal show heading={heading} variant={variant} onClose={() => {}}>
+      Modal content
+    </Modal>
+  )
+});

--- a/packages/react/src/components/Modal/Modal.figma.tsx
+++ b/packages/react/src/components/Modal/Modal.figma.tsx
@@ -13,7 +13,12 @@ figma.connect(Modal, FIGMA_URL, {
     heading: figma.textContent('Heading')
   },
   example: ({ variant, heading }) => (
-    <Modal show heading={heading} variant={variant} onClose={() => {}}>
+    <Modal
+      show
+      heading={heading}
+      variant={variant}
+      onClose={() => undefined}
+    >
       Modal content
     </Modal>
   )

--- a/packages/react/src/components/Modal/Modal.figma.tsx
+++ b/packages/react/src/components/Modal/Modal.figma.tsx
@@ -9,16 +9,10 @@ figma.connect(Modal, FIGMA_URL, {
   props: {
     variant: figma.enum('Variant', {
       'Info Modal': 'info'
-    }),
-    heading: figma.textContent('Heading')
+    })
   },
-  example: ({ variant, heading }) => (
-    <Modal
-      show
-      heading={heading}
-      variant={variant}
-      onClose={() => undefined}
-    >
+  example: ({ variant }) => (
+    <Modal show heading="Heading" variant={variant} onClose={() => undefined}>
       Modal content
     </Modal>
   )

--- a/packages/react/src/components/Notice/Notice.figma.tsx
+++ b/packages/react/src/components/Notice/Notice.figma.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Notice } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=235-3430&m=dev';
+
+figma.connect(Notice, FIGMA_URL, {
+  props: {
+    type: figma.enum('Type', {
+      caution: 'caution',
+      danger: 'danger'
+    }),
+    variant: figma.enum('Size', {
+      Small: 'condensed'
+    }),
+    title: figma.textContent('Title')
+  },
+  example: ({ type, variant, title }) => (
+    <Notice type={type} variant={variant} title={title}>
+      Body
+    </Notice>
+  )
+});

--- a/packages/react/src/components/Pagination/Pagination.figma.tsx
+++ b/packages/react/src/components/Pagination/Pagination.figma.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Pagination } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=912-2081&m=dev';
+
+figma.connect(Pagination, FIGMA_URL, {
+  example: () => <Pagination totalItems={100} currentPage={3} />
+});

--- a/packages/react/src/components/Pagination/Pagination.figma.tsx
+++ b/packages/react/src/components/Pagination/Pagination.figma.tsx
@@ -6,5 +6,5 @@ const FIGMA_URL =
   'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=912-2081&m=dev';
 
 figma.connect(Pagination, FIGMA_URL, {
-  example: () => <Pagination totalItems={100} currentPage={3} />
+  example: () => <Pagination totalItems={20} />
 });

--- a/packages/react/src/components/Stepper/Stepper.figma.tsx
+++ b/packages/react/src/components/Stepper/Stepper.figma.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Stepper, Step } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=349-10784&m=dev';
+
+figma.connect(Stepper, FIGMA_URL, {
+  example: () => (
+    <Stepper>
+      <Step status="complete">Step 1</Step>
+      <Step status="current">Step 2</Step>
+      <Step status="future">Step 3</Step>
+    </Stepper>
+  )
+});

--- a/packages/react/src/components/Toast/Toast.figma.tsx
+++ b/packages/react/src/components/Toast/Toast.figma.tsx
@@ -13,5 +13,9 @@ figma.connect(Toast, FIGMA_URL, {
       Info: 'info'
     })
   },
-  example: ({ type }) => <Toast type={type}>Message</Toast>
+  example: ({ type }) => (
+    <Toast type={type} show>
+      Message
+    </Toast>
+  )
 });

--- a/packages/react/src/components/Toast/Toast.figma.tsx
+++ b/packages/react/src/components/Toast/Toast.figma.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Toast } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=119-5623&m=dev';
+
+figma.connect(Toast, FIGMA_URL, {
+  props: {
+    type: figma.enum('Type', {
+      Error: 'error',
+      Warning: 'caution',
+      Info: 'info'
+    }),
+    children: figma.textContent('Message')
+  },
+  example: ({ type, children }) => <Toast type={type}>{children}</Toast>
+});

--- a/packages/react/src/components/Toast/Toast.figma.tsx
+++ b/packages/react/src/components/Toast/Toast.figma.tsx
@@ -11,8 +11,7 @@ figma.connect(Toast, FIGMA_URL, {
       Error: 'error',
       Warning: 'caution',
       Info: 'info'
-    }),
-    children: figma.textContent('Message')
+    })
   },
-  example: ({ type, children }) => <Toast type={type}>{children}</Toast>
+  example: ({ type }) => <Toast type={type}>Message</Toast>
 });


### PR DESCRIPTION
## Summary

Adds Figma Code Connect `.figma.tsx` files for Batch 3 components: Notice, Modal, EmptyState, FieldGroup, Pagination, Stepper, Toast.

Follows the same conventions established in Batch 1 and `IconButton` (#2370): bare display names (no `#suffix`), defaults omitted, relative `'../../index'` import.

## Components

- Notice — `235:3430`
- Modal — `144:705`
- EmptyState — `4894:29059`
- FieldGroup — `5348:2712`
- Pagination — `912:2081`
- Stepper — `349:10784`
- Toast — `119:5623`

Related to #2373

## Test plan

- [ ] CI passes
- [ ] Snippets render correctly in Figma Dev Mode for each connected node