### PR TITLE
chore: connect components to Figma (batch 4/5)

### DIFF
--- a/packages/react/src/components/ActionList/ActionList.figma.tsx
+++ b/packages/react/src/components/ActionList/ActionList.figma.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import {
+  ActionList,
+  ActionListItem,
+  ActionListGroup,
+  ActionListLinkItem
+} from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=3322-2422&m=dev';
+
+// Standard action list item
+figma.connect(ActionListItem, FIGMA_URL, {
+  variant: { Element: 'Action list item' },
+  props: {
+    disabled: figma.boolean('disabled', { true: true, false: undefined }),
+    selected: figma.boolean('selected', { true: true, false: undefined }),
+    variant: figma.enum('variant', { danger: 'danger' })
+  },
+  example: ({ disabled, selected, variant }) => (
+    <ActionList>
+      <ActionListItem
+        disabled={disabled}
+        selected={selected}
+        variant={variant}
+      >
+        Action item
+      </ActionListItem>
+    </ActionList>
+  )
+});
+
+// Group label
+figma.connect(ActionListGroup, FIGMA_URL, {
+  variant: { Element: 'Group label' },
+  example: () => (
+    <ActionList>
+      <ActionListGroup label="Group label">
+        <ActionListItem>Action item</ActionListItem>
+      </ActionListGroup>
+    </ActionList>
+  )
+});
+
+// Link item
+figma.connect(ActionListLinkItem, FIGMA_URL, {
+  variant: { Element: 'Link item' },
+  props: {
+    disabled: figma.boolean('disabled', { true: true, false: undefined })
+  },
+  example: ({ disabled }) => (
+    <ActionList>
+      <ActionListLinkItem href="#" disabled={disabled}>
+        Link item
+      </ActionListLinkItem>
+    </ActionList>
+  )
+});

--- a/packages/react/src/components/ActionList/ActionList.figma.tsx
+++ b/packages/react/src/components/ActionList/ActionList.figma.tsx
@@ -14,18 +14,30 @@ const FIGMA_URL =
 figma.connect(ActionListItem, FIGMA_URL, {
   variant: { Element: 'Action list item' },
   props: {
-    disabled: figma.boolean('disabled', { true: true, false: undefined }),
-    selected: figma.boolean('selected', { true: true, false: undefined }),
-    variant: figma.enum('variant', { danger: 'danger' })
+    // `State=Disabled` is the only State value that maps to React's `disabled`
+    // prop. Other State values (Hover/Focused/Resting/etc.) are purely visual
+    // and return undefined so the prop is dropped from the snippet.
+    disabled: figma.enum('State', { Disabled: true }),
+    selected: figma.boolean('Checked', { true: true, false: undefined }),
+    variant: figma.enum('Danger item', { True: 'danger' }),
+    label: figma.textContent('Label'),
+    // Description has a boolean toggle in Figma — when off, drop the prop.
+    // Note: the text layer name is `Opitional description text` (typo preserved
+    // intentionally — it must match the Figma layer exactly).
+    description: figma.boolean('Description text', {
+      true: figma.textContent('Opitional description text'),
+      false: undefined
+    })
   },
-  example: ({ disabled, selected, variant }) => (
+  example: ({ disabled, selected, variant, label, description }) => (
     <ActionList>
       <ActionListItem
         disabled={disabled}
         selected={selected}
         variant={variant}
+        description={description}
       >
-        Action item
+        {label}
       </ActionListItem>
     </ActionList>
   )
@@ -34,9 +46,12 @@ figma.connect(ActionListItem, FIGMA_URL, {
 // Group label
 figma.connect(ActionListGroup, FIGMA_URL, {
   variant: { Element: 'Group label' },
-  example: () => (
+  props: {
+    label: figma.textContent('Title')
+  },
+  example: ({ label }) => (
     <ActionList>
-      <ActionListGroup label="Group label">
+      <ActionListGroup label={label}>
         <ActionListItem>Action item</ActionListItem>
       </ActionListGroup>
     </ActionList>
@@ -47,12 +62,13 @@ figma.connect(ActionListGroup, FIGMA_URL, {
 figma.connect(ActionListLinkItem, FIGMA_URL, {
   variant: { Element: 'Link item' },
   props: {
-    disabled: figma.boolean('disabled', { true: true, false: undefined })
+    disabled: figma.enum('State', { Disabled: true }),
+    label: figma.textContent('Text')
   },
-  example: ({ disabled }) => (
+  example: ({ disabled, label }) => (
     <ActionList>
       <ActionListLinkItem href="#" disabled={disabled}>
-        Link item
+        {label}
       </ActionListLinkItem>
     </ActionList>
   )

--- a/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
@@ -18,10 +18,19 @@ figma.connect(ActionMenu, FIGMA_URL, {
     placement: figma.enum('Alignment', {
       Left: 'bottom-start',
       Right: 'bottom-end'
+    }),
+    // Scope the `Label` text lookup to the `Button` frame so it picks up the
+    // trigger label (e.g. "Trigger") and not any `Label` layers inside the
+    // menu's action items.
+    triggerProps: figma.nestedProps('Button', {
+      label: figma.textContent('Label')
     })
   },
-  example: ({ placement }) => (
-    <ActionMenu trigger={<Button>Menu</Button>} placement={placement}>
+  example: ({ placement, triggerProps }) => (
+    <ActionMenu
+      trigger={<Button>{triggerProps.label}</Button>}
+      placement={placement}
+    >
       <ActionList>
         <ActionListItem>Action one</ActionListItem>
         <ActionListItem>Action two</ActionListItem>

--- a/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import {
+  ActionMenu,
+  ActionList,
+  ActionListItem,
+  Button,
+  IconButton
+} from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=3322-2487&m=dev';
+
+// Button trigger
+figma.connect(ActionMenu, FIGMA_URL, {
+  variant: { Type: 'Button' },
+  props: {
+    placement: figma.enum('Alignment', {
+      Left: 'bottom-start',
+      Right: 'bottom-end'
+    })
+  },
+  example: ({ placement }) => (
+    <ActionMenu trigger={<Button>Menu</Button>} placement={placement}>
+      <ActionList>
+        <ActionListItem>Action one</ActionListItem>
+        <ActionListItem>Action two</ActionListItem>
+        <ActionListItem>Action three</ActionListItem>
+      </ActionList>
+    </ActionMenu>
+  )
+});
+
+// Icon Button trigger
+figma.connect(ActionMenu, FIGMA_URL, {
+  variant: { Type: 'Icon Button' },
+  props: {
+    placement: figma.enum('Alignment', {
+      Left: 'bottom-start',
+      Right: 'bottom-end'
+    })
+  },
+  example: ({ placement }) => (
+    <ActionMenu
+      trigger={<IconButton icon="kabob" label="Menu" />}
+      placement={placement}
+    >
+      <ActionList>
+        <ActionListItem>Action one</ActionListItem>
+        <ActionListItem>Action two</ActionListItem>
+        <ActionListItem>Action three</ActionListItem>
+      </ActionList>
+    </ActionMenu>
+  )
+});

--- a/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.figma.tsx
@@ -15,8 +15,9 @@ const FIGMA_URL =
 figma.connect(ActionMenu, FIGMA_URL, {
   variant: { Type: 'Button' },
   props: {
+    // `bottom-start` is the React default; omit the `Left` mapping so the prop
+    // is dropped from the snippet for the default alignment.
     placement: figma.enum('Alignment', {
-      Left: 'bottom-start',
       Right: 'bottom-end'
     }),
     // Scope the `Label` text lookup to the `Button` frame so it picks up the
@@ -44,8 +45,9 @@ figma.connect(ActionMenu, FIGMA_URL, {
 figma.connect(ActionMenu, FIGMA_URL, {
   variant: { Type: 'Icon Button' },
   props: {
+    // `bottom-start` is the React default; omit the `Left` mapping so the prop
+    // is dropped from the snippet for the default alignment.
     placement: figma.enum('Alignment', {
-      Left: 'bottom-start',
       Right: 'bottom-end'
     })
   },

--- a/packages/react/src/components/BottomSheet/BottomSheet.figma.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.figma.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { BottomSheet } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=4122-133&m=dev';
+
+figma.connect(BottomSheet, FIGMA_URL, {
+  example: () => (
+    <BottomSheet open label="Title">
+      Content
+    </BottomSheet>
+  )
+});

--- a/packages/react/src/components/BottomSheet/BottomSheet.figma.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.figma.tsx
@@ -7,7 +7,7 @@ const FIGMA_URL =
 
 figma.connect(BottomSheet, FIGMA_URL, {
   example: () => (
-    <BottomSheet open label="Title">
+    <BottomSheet open label="Title" onClose={() => undefined}>
       Content
     </BottomSheet>
   )


### PR DESCRIPTION
## Summary

Adds Figma Code Connect `.figma.tsx` files for Batch 4 components: ActionList, ActionMenu, BottomSheet.

Follows the same conventions established in Batch 1 and `IconButton` (#2370): bare display names (no `#suffix`), defaults omitted, relative `'../../index'` import.

`ActionList` uses three variant-filtered `figma.connect` calls (one per `Element` value); `ActionMenu` uses two (one per `Type` value).

## Components

- ActionList — `3322:2422`
- ActionMenu — `3322:2487`
- BottomSheet — `4122:133`

Related to #2373

## Test plan

- [ ] CI passes
- [ ] Snippets render correctly in Figma Dev Mode for each connected node