### PR TITLE
chore: connect components to Figma (batch 5/5)

### DIFF
--- a/packages/react/src/components/DescriptionList/DescriptionList.figma.tsx
+++ b/packages/react/src/components/DescriptionList/DescriptionList.figma.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import {
+  DescriptionList,
+  DescriptionListItem,
+  DescriptionTerm,
+  DescriptionDetails
+} from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=240-4209&m=dev';
+
+figma.connect(DescriptionList, FIGMA_URL, {
+  props: {
+    collapsed: figma.enum('Collapsed', { True: true })
+  },
+  example: ({ collapsed }) => (
+    <DescriptionList collapsed={collapsed}>
+      <DescriptionListItem>
+        <DescriptionTerm>Term 1</DescriptionTerm>
+        <DescriptionDetails>Details 1</DescriptionDetails>
+      </DescriptionListItem>
+      <DescriptionListItem>
+        <DescriptionTerm>Term 2</DescriptionTerm>
+        <DescriptionDetails>Details 2</DescriptionDetails>
+      </DescriptionListItem>
+    </DescriptionList>
+  )
+});

--- a/packages/react/src/components/NavBar/NavBar.figma.tsx
+++ b/packages/react/src/components/NavBar/NavBar.figma.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { NavBar, NavItem } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=82-137&m=dev';
+
+figma.connect(NavBar, FIGMA_URL, {
+  example: () => (
+    <NavBar>
+      <NavItem active>Home</NavItem>
+      <NavItem active={false}>About</NavItem>
+      <NavItem active={false}>Contact</NavItem>
+    </NavBar>
+  )
+});

--- a/packages/react/src/components/RadioGroup/RadioGroup.figma.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.figma.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { RadioGroup } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=231-2042&m=dev';
+
+figma.connect(RadioGroup, FIGMA_URL, {
+  example: () => (
+    <RadioGroup
+      name="example"
+      radios={[{ id: 'option-a', value: 'a', label: 'Option A' }]}
+    />
+  )
+});

--- a/packages/react/src/components/Tabs/Tabs.figma.tsx
+++ b/packages/react/src/components/Tabs/Tabs.figma.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react';
+import figma from '@figma/code-connect';
+import { Tabs, Tab, TabPanel } from '../../index';
+
+const TAB_FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=259-6525&m=dev';
+
+const TAB_PANEL_FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=3409-1057&m=dev';
+
+figma.connect(Tab, TAB_FIGMA_URL, {
+  example: () => {
+    const panelOneRef = useRef<HTMLDivElement>(null);
+    const panelTwoRef = useRef<HTMLDivElement>(null);
+    return (
+      <>
+        <Tabs aria-label="Example tabs">
+          <Tab target={panelOneRef}>Tab 1</Tab>
+          <Tab target={panelTwoRef}>Tab 2</Tab>
+        </Tabs>
+        <TabPanel ref={panelOneRef}>Panel 1 content</TabPanel>
+        <TabPanel ref={panelTwoRef}>Panel 2 content</TabPanel>
+      </>
+    );
+  }
+});
+
+figma.connect(TabPanel, TAB_PANEL_FIGMA_URL, {
+  example: () => {
+    const panelOneRef = useRef<HTMLDivElement>(null);
+    const panelTwoRef = useRef<HTMLDivElement>(null);
+    return (
+      <>
+        <Tabs aria-label="Example tabs">
+          <Tab target={panelOneRef}>Tab 1</Tab>
+          <Tab target={panelTwoRef}>Tab 2</Tab>
+        </Tabs>
+        <TabPanel ref={panelOneRef}>Panel 1 content</TabPanel>
+        <TabPanel ref={panelTwoRef}>Panel 2 content</TabPanel>
+      </>
+    );
+  }
+});

--- a/packages/react/src/components/TopBar/TopBar.figma.tsx
+++ b/packages/react/src/components/TopBar/TopBar.figma.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { TopBar, TopBarItem, TopBarTrigger } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=515-2774&m=dev';
+
+figma.connect(TopBar, FIGMA_URL, {
+  example: () => (
+    <TopBar>
+      <TopBarItem>Home</TopBarItem>
+      <TopBarItem>About</TopBarItem>
+      <TopBarTrigger>Menu</TopBarTrigger>
+    </TopBar>
+  )
+});


### PR DESCRIPTION
## Summary

Adds Figma Code Connect `.figma.tsx` files for Batch 5 components: DescriptionList, RadioGroup, Tabs/TabPanel, NavBar, TopBar.

These are the "hard/compound" set — most have no clean prop mapping and use static, realistic compound-children examples instead.

Follows the same conventions established in Batch 1 and `IconButton` (#2370): bare display names (no `#suffix`), defaults omitted, relative `'../../index'` import.

## Components

- DescriptionList — `240:4209`
- RadioGroup — `231:2042`
- Tabs / TabPanel — `259:6525`, `3409:1057`
- NavBar — `82:137`
- TopBar — `515:2774`

Related to #2373

## Test plan

- [ ] CI passes
- [ ] Snippets render correctly in Figma Dev Mode for each connected node