### PR TITLE
fix(Combobox): preserve active descendant after deselecting in multiselect

### DIFF
--- a/packages/react/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/Combobox/Combobox.test.tsx
@@ -1100,6 +1100,41 @@ test('should handle multiple selections with "enter" keydown event', () => {
   fireEnterKeyPress();
 });
 
+test('should allow reselecting a deselected option in multiselect via keyboard', () => {
+  const onSelectionChange = spy();
+  render(
+    <Combobox label="label" multiselect onSelectionChange={onSelectionChange}>
+      <ComboboxOption>Apple</ComboboxOption>
+      <ComboboxOption>Banana</ComboboxOption>
+      <ComboboxOption>Cantaloupe</ComboboxOption>
+    </Combobox>
+  );
+  const combobox = screen.getByRole('combobox');
+
+  // Note: Combobox forwards events to Listbox via dispatchEvent, but this doesn't
+  // work correctly within jsdom so we fire the events directly on listbox
+  const fireArrowDownKeyPress = () =>
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowDown' });
+  const fireEnterKeyPress = () =>
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Enter' });
+
+  fireEvent.focus(combobox);
+  fireArrowDownKeyPress();
+  fireEnterKeyPress();
+  expect(onSelectionChange.lastCall.firstArg.value).toEqual(['Apple']);
+  assertOptionIsActive(0);
+
+  fireEnterKeyPress();
+  expect(onSelectionChange.lastCall.firstArg.value).toEqual([]);
+  // After deselecting, the active descendant must stay on the just-deselected
+  // option so the next Enter keypress can re-toggle it.
+  assertOptionIsActive(0);
+
+  fireEnterKeyPress();
+  expect(onSelectionChange.lastCall.firstArg.value).toEqual(['Apple']);
+  assertOptionIsActive(0);
+});
+
 test('should handle selection when autocomplete="automatic" and combobox input is blurred', () => {
   const onSelectionChange = spy();
   render(

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -253,6 +253,19 @@ const Combobox = forwardRef<
           ([, { value }]) => value === lastSelectedValue
         ) || [];
       if (autocomplete === 'manual') {
+        // In multiselect, the listbox manages its own active option via
+        // keyboard navigation. When the last-selected value no longer
+        // matches any option (e.g. after deselecting the only selected
+        // option), preserve the existing active descendant so the next
+        // Enter keypress can re-toggle the highlighted option.
+        if (
+          multiselect &&
+          !element &&
+          activeDescendant &&
+          matchingOptions.has(activeDescendant.element)
+        ) {
+          return;
+        }
         setActiveDescendant(!element ? null : { element, ...option });
       } else if (
         autocomplete === 'automatic' &&


### PR DESCRIPTION
## Summary
- In a multiselect Combobox, deselecting the only selected option via keyboard set `activeDescendant` to `null`, which caused the next Enter keypress on the input to be swallowed by the early return in `handleKeyDown`. Keyboard-only users hit a dead end trying to re-select the just-deselected option (WCAG 2.1.1 concern).
- The `useEffect` that syncs `activeDescendant` to the last-selected value now skips clobbering it in multiselect when the existing active descendant is still a valid matching option. The listbox tracks its own active option via keyboard navigation, so we follow that rather than reset it.

## Test plan
- [x] New regression test `should allow reselecting a deselected option in multiselect via keyboard` — verified to fail on `assertOptionIsActive` after deselect without the fix, passes with it
- [x] Full Combobox + Listbox suites green (141 tests)
- [x] Lint clean
- [x] Manual: open https://cauldron.dequelabs.com/components/Combobox#multiselect locally, navigate via keyboard, select an option, deselect it, re-select it without arrowing away

Fixes #2367