### PR TITLE
fix(styles): correct misspelled --accent-primary-disabled var

### DIFF
--- a/packages/styles/forms.css
+++ b/packages/styles/forms.css
@@ -22,7 +22,7 @@
   --field-icon-active-color: rgba(60, 122, 174, 0.25);
   --field-icon-error-active-color: rgba(217, 50, 81, 0.25);
   --field-icon-checked-color: var(--accent-primary);
-  --field-icon-checked-disabled-color: var(--accent-primary-dsiabled, #78a6d8);
+  --field-icon-checked-disabled-color: var(--accent-primary-disabled, #78a6d8);
   --field-icon-unchecked-disabled-color: var(--gray-40);
   --field-icon-focus-color: var(--focus-light);
   --field-error-text-color: var(--error);


### PR DESCRIPTION
## Summary
- Fix typo in [packages/styles/forms.css:25](packages/styles/forms.css#L25): `--accent-primary-dsiabled` → `--accent-primary-disabled`.
- The misspelled variable doesn't exist, so `--field-icon-checked-disabled-color` was silently resolving to the `#78a6d8` fallback instead of the design token defined in [variables.css:43](packages/styles/variables.css#L43).
- The literal value of the fallback happens to match the token, so this change is visually a no-op today, but it restores theming/override behavior for `--accent-primary-disabled`.

## Test plan
- [ ] Verify checked-disabled form icons (e.g. checkbox, radio) still render with the disabled accent color.
- [ ] Confirm overriding `--accent-primary-disabled` at `:root` now propagates to `--field-icon-checked-disabled-color`.