### PR TITLE
chore: add Storybook stories for 10 more components

### DIFF
--- a/docs/pages/components/Checkbox.mdx
+++ b/docs/pages/components/Checkbox.mdx
@@ -2,6 +2,7 @@
 title: Checkbox
 description: An interactive component that toggles between checked and unchecked states.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Checkbox/index.tsx
+storybook: true
 ---
 
 import { Checkbox, FieldWrap, FieldGroup } from '@deque/cauldron-react'

--- a/docs/pages/components/IconButton.mdx
+++ b/docs/pages/components/IconButton.mdx
@@ -2,6 +2,7 @@
 title: IconButton
 description: An interactive element that performs a programmable action when activated by the user displayed as a symbol image.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/IconButton/index.tsx
+storybook: true
 ---
 
 import { IconButton, Offscreen } from '@deque/cauldron-react'

--- a/docs/pages/components/ImpactBadge.mdx
+++ b/docs/pages/components/ImpactBadge.mdx
@@ -2,6 +2,7 @@
 title: ImpactBadge
 description: The ImpactBadge is an extension of the Badge component is designed to indicate the type of impact
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/ImpactBadge/index.tsx
+storybook: true
 ---
 
 import { ImpactBadge } from '@deque/cauldron-react';

--- a/docs/pages/components/Link.mdx
+++ b/docs/pages/components/Link.mdx
@@ -2,6 +2,7 @@
 title: Link
 description: An interactive component that creates a hyperlink to other web pages, files, email addresses, locations on the same page, etc.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Link/index.tsx
+storybook: true
 ---
 
 import { Link, Button } from '@deque/cauldron-react';

--- a/docs/pages/components/Loader.mdx
+++ b/docs/pages/components/Loader.mdx
@@ -2,6 +2,7 @@
 title: Loader
 description: A rotating spinner to indicate a loading state.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Loader/index.tsx
+storybook: true
 ---
 
 import { Loader } from '@deque/cauldron-react'

--- a/docs/pages/components/Notice.mdx
+++ b/docs/pages/components/Notice.mdx
@@ -2,6 +2,7 @@
 title: Notice
 description: A notification banner - similar to a Toast, but allows for more flexible positioning and control.
 source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/Notice/Notice.tsx
+storybook: true
 ---
 
 import { useState } from 'react';

--- a/docs/pages/components/ProgressBar.mdx
+++ b/docs/pages/components/ProgressBar.mdx
@@ -2,6 +2,7 @@
 title: ProgressBar
 description: A component to display the progress of some activity.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/ProgressBar/index.tsx
+storybook: true
 ---
 
 import { useState, useEffect, useRef } from 'react'

--- a/docs/pages/components/Tag.mdx
+++ b/docs/pages/components/Tag.mdx
@@ -2,6 +2,7 @@
 title: Tag
 description: A styled component with text representing a keyword, label, or property.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Tag/index.tsx
+storybook: true
 ---
 
 import { Tag, TagLabel } from '@deque/cauldron-react';

--- a/docs/pages/components/TextField.mdx
+++ b/docs/pages/components/TextField.mdx
@@ -2,6 +2,7 @@
 title: TextField
 description: A form element that allows users to type in text. Single and multi-line options.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/TextField/index.tsx
+storybook: true
 ---
 
 import { TextField, FieldWrap } from '@deque/cauldron-react';

--- a/docs/pages/components/Tooltip.mdx
+++ b/docs/pages/components/Tooltip.mdx
@@ -2,6 +2,7 @@
 title: Tooltip
 description: A small text box that gives more information about a UI element when a user hovers over or focuses on it.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/Tooltip/index.tsx
+storybook: true
 ---
 
 import { useRef } from 'react'

--- a/packages/react/src/components/Checkbox/index.stories.tsx
+++ b/packages/react/src/components/Checkbox/index.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Checkbox from './index';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  args: {
+    id: 'checkbox',
+    label: 'Checkbox'
+  },
+  argTypes: {
+    label: { control: 'text' },
+    labelDescription: { control: 'text' },
+    error: { control: 'text' },
+    checked: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    onChange: { action: 'changed', table: { disable: true } },
+    checkboxRef: { table: { disable: true } },
+    customIcon: { table: { disable: true } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {
+  args: { id: 'checkbox-default', label: 'Send me marketing emails' }
+};
+
+export const Checked: Story = {
+  args: { id: 'checkbox-checked', label: 'Subscribed', checked: true }
+};
+
+export const Indeterminate: Story = {
+  args: {
+    id: 'checkbox-indeterminate',
+    label: 'Select all',
+    indeterminate: true
+  }
+};
+
+export const WithDescription: Story = {
+  args: {
+    id: 'checkbox-described',
+    label: 'Enable beta features',
+    labelDescription: 'Beta features may change or be removed without notice.'
+  }
+};
+
+export const WithError: Story = {
+  args: {
+    id: 'checkbox-error',
+    label: 'Accept terms and conditions',
+    error: 'You must accept the terms to continue.'
+  }
+};
+
+export const Disabled: Story = {
+  args: { id: 'checkbox-disabled', label: 'Disabled', disabled: true }
+};

--- a/packages/react/src/components/IconButton/index.stories.tsx
+++ b/packages/react/src/components/IconButton/index.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import IconButton from './index';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Components/IconButton',
+  component: IconButton,
+  tags: ['autodocs'],
+  args: {
+    icon: 'pencil',
+    label: 'Edit'
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'error']
+    },
+    icon: { control: 'text' },
+    label: { control: 'text' },
+    large: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    onClick: { action: 'clicked', table: { disable: true } },
+    as: { table: { disable: true } },
+    tooltipProps: { table: { disable: true } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const Primary: Story = {
+  args: { variant: 'primary', icon: 'pencil', label: 'Edit' }
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary', icon: 'trash', label: 'Delete' }
+};
+
+export const Tertiary: Story = {
+  args: { variant: 'tertiary', icon: 'gears', label: 'Settings' }
+};
+
+export const Error: Story = {
+  args: { variant: 'error', icon: 'trash', label: 'Delete' }
+};
+
+export const Large: Story = {
+  args: { variant: 'primary', icon: 'pencil', label: 'Edit', large: true }
+};
+
+export const Disabled: Story = {
+  args: { variant: 'primary', icon: 'pencil', label: 'Edit', disabled: true }
+};

--- a/packages/react/src/components/ImpactBadge/index.stories.tsx
+++ b/packages/react/src/components/ImpactBadge/index.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ImpactBadge from './index';
+
+const meta: Meta<typeof ImpactBadge> = {
+  title: 'Components/ImpactBadge',
+  component: ImpactBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'radio',
+      options: ['critical', 'serious', 'moderate', 'minor']
+    },
+    label: { control: 'text' },
+    size: {
+      control: 'radio',
+      options: ['default', 'small']
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ImpactBadge>;
+
+export const Critical: Story = {
+  args: { type: 'critical' }
+};
+
+export const Serious: Story = {
+  args: { type: 'serious' }
+};
+
+export const Moderate: Story = {
+  args: { type: 'moderate' }
+};
+
+export const Minor: Story = {
+  args: { type: 'minor' }
+};
+
+export const Small: Story = {
+  args: { type: 'critical', size: 'small' }
+};

--- a/packages/react/src/components/Link/index.stories.tsx
+++ b/packages/react/src/components/Link/index.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Link from './index';
+
+const meta: Meta<typeof Link> = {
+  title: 'Components/Link',
+  component: Link,
+  tags: ['autodocs'],
+  args: {
+    href: '#',
+    children: 'Link'
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [undefined, 'button', 'button-secondary']
+    },
+    thin: { control: 'boolean' },
+    children: { control: 'text' },
+    linkRef: { table: { disable: true } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {
+  args: { children: 'Read the documentation' }
+};
+
+export const Button: Story = {
+  args: { variant: 'button', children: 'Primary link' }
+};
+
+export const ButtonSecondary: Story = {
+  args: { variant: 'button-secondary', children: 'Secondary link' }
+};
+
+export const Thin: Story = {
+  args: { variant: 'button', thin: true, children: 'Thin link' }
+};

--- a/packages/react/src/components/Loader/index.stories.tsx
+++ b/packages/react/src/components/Loader/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Loader from './index';
+
+const meta: Meta<typeof Loader> = {
+  title: 'Components/Loader',
+  component: Loader,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Loader>;
+
+export const Default: Story = {};
+
+export const WithLabel: Story = {
+  args: { label: 'Loading content' }
+};

--- a/packages/react/src/components/Notice/index.stories.tsx
+++ b/packages/react/src/components/Notice/index.stories.tsx
@@ -5,11 +5,6 @@ const meta: Meta<typeof Notice> = {
   title: 'Components/Notice',
   component: Notice,
   tags: ['autodocs'],
-  args: {
-    title: 'Heads up',
-    children:
-      'Use Notice to communicate persistent, contextual information to the user.'
-  },
   argTypes: {
     type: {
       control: 'radio',

--- a/packages/react/src/components/Notice/index.stories.tsx
+++ b/packages/react/src/components/Notice/index.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Notice from './index';
+
+const meta: Meta<typeof Notice> = {
+  title: 'Components/Notice',
+  component: Notice,
+  tags: ['autodocs'],
+  args: {
+    title: 'Heads up',
+    children:
+      'Use Notice to communicate persistent, contextual information to the user.'
+  },
+  argTypes: {
+    type: {
+      control: 'radio',
+      options: ['info', 'caution', 'danger']
+    },
+    variant: {
+      control: 'radio',
+      options: ['default', 'condensed']
+    },
+    title: { control: 'text' },
+    children: { control: 'text' },
+    icon: { control: 'text' }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Notice>;
+
+export const Info: Story = {
+  args: {
+    type: 'info',
+    title: 'New features available',
+    children: 'Check out the latest release notes for details.'
+  }
+};
+
+export const Caution: Story = {
+  args: {
+    type: 'caution',
+    title: 'This action requires review',
+    children: 'A team member must approve before it takes effect.'
+  }
+};
+
+export const Danger: Story = {
+  args: {
+    type: 'danger',
+    title: 'Something went wrong',
+    children: 'Please try again, or contact support if the problem persists.'
+  }
+};
+
+export const Condensed: Story = {
+  args: {
+    type: 'info',
+    variant: 'condensed',
+    title: 'Saved as draft'
+  }
+};

--- a/packages/react/src/components/ProgressBar/index.stories.tsx
+++ b/packages/react/src/components/ProgressBar/index.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProgressBar from './index';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+  args: {
+    'aria-label': 'Progress'
+  },
+  argTypes: {
+    progress: { control: { type: 'range', min: 0, max: 100, step: 1 } },
+    progressMin: { control: 'number' },
+    progressMax: { control: 'number' },
+    thin: { control: 'boolean' }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Default: Story = {
+  args: { progress: 40 }
+};
+
+export const Complete: Story = {
+  args: { progress: 100 }
+};
+
+export const Thin: Story = {
+  args: { progress: 60, thin: true }
+};

--- a/packages/react/src/components/Tag/index.stories.tsx
+++ b/packages/react/src/components/Tag/index.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Tag, { TagLabel } from './index';
+
+const meta: Meta<typeof Tag> = {
+  title: 'Components/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'radio',
+      options: ['default', 'small']
+    },
+    children: { control: 'text' }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+export const Default: Story = {
+  args: { size: 'default', children: 'Tag' }
+};
+
+export const Small: Story = {
+  args: { size: 'small', children: 'Tag' }
+};
+
+export const WithLabel: Story = {
+  argTypes: {
+    children: { table: { disable: true } }
+  },
+  args: {
+    children: (
+      <>
+        <TagLabel>Status:</TagLabel>
+        Active
+      </>
+    )
+  }
+};

--- a/packages/react/src/components/TextField/index.stories.tsx
+++ b/packages/react/src/components/TextField/index.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TextField from './index';
+
+const meta: Meta<typeof TextField> = {
+  title: 'Components/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  args: {
+    label: 'Label'
+  },
+  argTypes: {
+    label: { control: 'text' },
+    description: { control: 'text' },
+    error: { control: 'text' },
+    placeholder: { control: 'text' },
+    required: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    multiline: { control: 'boolean' },
+    onChange: { action: 'changed', table: { disable: true } },
+    fieldRef: { table: { disable: true } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {
+  args: { label: 'Name', placeholder: 'Jane Doe' }
+};
+
+export const WithDescription: Story = {
+  args: {
+    label: 'Email',
+    description: "We'll never share your email.",
+    placeholder: 'jane@example.com'
+  }
+};
+
+export const Required: Story = {
+  args: { label: 'Username', required: true }
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Password',
+    error: 'Password must be at least 8 characters.'
+  }
+};
+
+export const Multiline: Story = {
+  args: {
+    label: 'Bio',
+    multiline: true,
+    placeholder: 'Tell us about yourself…'
+  }
+};
+
+export const Disabled: Story = {
+  args: { label: 'Read only', disabled: true, defaultValue: 'Cannot edit' }
+};

--- a/packages/react/src/components/Tooltip/index.stories.tsx
+++ b/packages/react/src/components/Tooltip/index.stories.tsx
@@ -74,6 +74,9 @@ export const Info: Story = {
 
 export const Big: Story = {
   render: (args) => <Template {...args} />,
+  argTypes: {
+    children: { table: { disable: true } }
+  },
   args: {
     variant: 'big',
     placement: 'bottom',

--- a/packages/react/src/components/Tooltip/index.stories.tsx
+++ b/packages/react/src/components/Tooltip/index.stories.tsx
@@ -1,0 +1,90 @@
+import React, { useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Tooltip, { TooltipHead, TooltipContent } from './index';
+import Button from '../Button';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['text', 'info', 'big']
+    },
+    placement: {
+      control: 'select',
+      options: [
+        'auto',
+        'top',
+        'bottom',
+        'left',
+        'right',
+        'top-start',
+        'top-end',
+        'bottom-start',
+        'bottom-end'
+      ]
+    },
+    association: {
+      control: 'radio',
+      options: ['aria-describedby', 'aria-labelledby', 'none']
+    },
+    defaultShow: { control: 'boolean' },
+    children: { control: 'text' },
+    target: { table: { disable: true } },
+    portal: { table: { disable: true } }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+const Template = (
+  args: Omit<React.ComponentProps<typeof Tooltip>, 'target'>
+) => {
+  const targetRef = useRef<HTMLButtonElement>(null);
+  return (
+    <div style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}>
+      <Button buttonRef={targetRef}>Hover or focus me</Button>
+      <Tooltip {...args} target={targetRef} />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    children: 'Tooltip content',
+    placement: 'bottom',
+    defaultShow: true
+  }
+};
+
+export const Info: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    variant: 'info',
+    children: 'Additional information about this action.',
+    placement: 'bottom',
+    defaultShow: true
+  }
+};
+
+export const Big: Story = {
+  render: (args) => <Template {...args} />,
+  args: {
+    variant: 'big',
+    placement: 'bottom',
+    defaultShow: true,
+    children: (
+      <>
+        <TooltipHead>Keyboard shortcut</TooltipHead>
+        <TooltipContent>
+          Press <kbd>⌘</kbd> + <kbd>K</kbd> to open the command palette.
+        </TooltipContent>
+      </>
+    )
+  }
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories and Storybook playground links to component docs for 10 more components:

- Checkbox
- IconButton
- ImpactBadge
- Link
- Loader
- Notice
- ProgressBar
- Tag
- TextField
- Tooltip

Each component gets an \`index.stories.tsx\` covering its main variants/states with \`argTypes\` configured for Storybook controls, plus a Storybook playground link added to its corresponding \`docs/pages/components/*.mdx\`.

## Test plan

- [ ] \`yarn storybook\` — verify each new story renders and controls behave (variants, sizes, states)
- [ ] Verify the Storybook playground link on each updated docs page opens the correct story