### PR TITLE
chore: connect form components to Figma via Code Connect

### DIFF
--- a/packages/react/src/components/Combobox/Combobox.figma.tsx
+++ b/packages/react/src/components/Combobox/Combobox.figma.tsx
@@ -7,7 +7,7 @@ const FIGMA_URL =
 
 figma.connect(Combobox, FIGMA_URL, {
   props: {
-    label: figma.textContent('Label'),
+    label: figma.textContent('Combo Box Label'),
     description: figma.boolean('Description', {
       true: figma.textContent('Label Description'),
       false: undefined

--- a/packages/react/src/components/Combobox/Combobox.figma.tsx
+++ b/packages/react/src/components/Combobox/Combobox.figma.tsx
@@ -3,7 +3,7 @@ import figma from '@figma/code-connect';
 import { Combobox, ComboboxOption } from '../../index';
 
 const FIGMA_URL =
-  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4614&m=dev';
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4620&m=dev';
 
 figma.connect(Combobox, FIGMA_URL, {
   props: {

--- a/packages/react/src/components/Combobox/Combobox.figma.tsx
+++ b/packages/react/src/components/Combobox/Combobox.figma.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Combobox, ComboboxOption } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4614&m=dev';
+
+figma.connect(Combobox, FIGMA_URL, {
+  props: {
+    label: figma.textContent('Label'),
+    description: figma.boolean('Description', {
+      true: 'Description text',
+      false: undefined
+    }),
+    error: figma.boolean('Error', {
+      true: 'Error message',
+      false: undefined
+    }),
+    required: figma.boolean('Required', { true: true, false: undefined }),
+    disabled: figma.boolean('Disabled', { true: true, false: undefined }),
+    multiselect: figma.boolean('Multiselect', { true: true, false: undefined })
+  },
+  example: ({ label, description, error, required, disabled, multiselect }) => (
+    <Combobox
+      label={label}
+      description={description}
+      error={error}
+      required={required}
+      disabled={disabled}
+      multiselect={multiselect}
+    >
+      <ComboboxOption>Option 1</ComboboxOption>
+      <ComboboxOption>Option 2</ComboboxOption>
+    </Combobox>
+  )
+});

--- a/packages/react/src/components/Combobox/Combobox.figma.tsx
+++ b/packages/react/src/components/Combobox/Combobox.figma.tsx
@@ -9,25 +9,22 @@ figma.connect(Combobox, FIGMA_URL, {
   props: {
     label: figma.textContent('Label'),
     description: figma.boolean('Description', {
-      true: 'Description text',
+      true: figma.textContent('Label Description'),
       false: undefined
     }),
-    error: figma.boolean('Error', {
-      true: 'Error message',
-      false: undefined
+    error: figma.enum('State', {
+      Error: figma.textContent('errorMessage')
     }),
     required: figma.boolean('Required', { true: true, false: undefined }),
-    disabled: figma.boolean('Disabled', { true: true, false: undefined }),
-    multiselect: figma.boolean('Multiselect', { true: true, false: undefined })
+    disabled: figma.enum('State', { Disabled: true })
   },
-  example: ({ label, description, error, required, disabled, multiselect }) => (
+  example: ({ label, description, error, required, disabled }) => (
     <Combobox
       label={label}
       description={description}
       error={error}
       required={required}
       disabled={disabled}
-      multiselect={multiselect}
     >
       <ComboboxOption>Option 1</ComboboxOption>
       <ComboboxOption>Option 2</ComboboxOption>

--- a/packages/react/src/components/Select/Select.figma.tsx
+++ b/packages/react/src/components/Select/Select.figma.tsx
@@ -3,7 +3,7 @@ import figma from '@figma/code-connect';
 import { Select } from '../../index';
 
 const FIGMA_URL =
-  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4259&m=dev';
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4265&m=dev';
 
 figma.connect(Select, FIGMA_URL, {
   props: {

--- a/packages/react/src/components/Select/Select.figma.tsx
+++ b/packages/react/src/components/Select/Select.figma.tsx
@@ -9,15 +9,14 @@ figma.connect(Select, FIGMA_URL, {
   props: {
     label: figma.textContent('Label'),
     description: figma.boolean('Description', {
-      true: 'Description text',
+      true: figma.textContent('Label Description'),
       false: undefined
     }),
-    error: figma.boolean('Error', {
-      true: 'Error message',
-      false: undefined
+    error: figma.enum('State', {
+      Error: figma.textContent('errorMessage')
     }),
     required: figma.boolean('Required', { true: true, false: undefined }),
-    disabled: figma.boolean('Disabled', { true: true, false: undefined })
+    disabled: figma.enum('State', { Disabled: true })
   },
   example: ({ label, description, error, required, disabled }) => (
     <Select

--- a/packages/react/src/components/Select/Select.figma.tsx
+++ b/packages/react/src/components/Select/Select.figma.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { Select } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4259&m=dev';
+
+figma.connect(Select, FIGMA_URL, {
+  props: {
+    label: figma.textContent('Label'),
+    description: figma.boolean('Description', {
+      true: 'Description text',
+      false: undefined
+    }),
+    error: figma.boolean('Error', {
+      true: 'Error message',
+      false: undefined
+    }),
+    required: figma.boolean('Required', { true: true, false: undefined }),
+    disabled: figma.boolean('Disabled', { true: true, false: undefined })
+  },
+  example: ({ label, description, error, required, disabled }) => (
+    <Select
+      label={label}
+      description={description}
+      error={error}
+      required={required}
+      disabled={disabled}
+      options={[
+        { key: '1', value: 'Option 1' },
+        { key: '2', value: 'Option 2' }
+      ]}
+    />
+  )
+});

--- a/packages/react/src/components/TextField/TextField.figma.tsx
+++ b/packages/react/src/components/TextField/TextField.figma.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import figma from '@figma/code-connect';
+import { TextField } from '../../index';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4747&m=dev';
+
+figma.connect(TextField, FIGMA_URL, {
+  props: {
+    label: figma.textContent('Label'),
+    description: figma.boolean('Description', {
+      true: 'Description text',
+      false: undefined
+    }),
+    error: figma.boolean('Error', {
+      true: 'Error message',
+      false: undefined
+    }),
+    required: figma.boolean('Required', { true: true, false: undefined }),
+    disabled: figma.boolean('Disabled', { true: true, false: undefined }),
+    multiline: figma.boolean('Multiline', { true: true, false: undefined })
+  },
+  example: ({ label, description, error, required, disabled, multiline }) => (
+    <TextField
+      label={label}
+      description={description}
+      error={error}
+      required={required}
+      disabled={disabled}
+      multiline={multiline}
+    />
+  )
+});

--- a/packages/react/src/components/TextField/TextField.figma.tsx
+++ b/packages/react/src/components/TextField/TextField.figma.tsx
@@ -3,7 +3,7 @@ import figma from '@figma/code-connect';
 import { TextField } from '../../index';
 
 const FIGMA_URL =
-  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4747&m=dev';
+  'https://www.figma.com/design/CEFVdiecqDjLSjhorjHUzI/Product-Foundations--Cauldron--Library?node-id=8534-4753&m=dev';
 
 figma.connect(TextField, FIGMA_URL, {
   props: {

--- a/packages/react/src/components/TextField/TextField.figma.tsx
+++ b/packages/react/src/components/TextField/TextField.figma.tsx
@@ -9,15 +9,14 @@ figma.connect(TextField, FIGMA_URL, {
   props: {
     label: figma.textContent('Label'),
     description: figma.boolean('Description', {
-      true: 'Description text',
+      true: figma.textContent('Label Description'),
       false: undefined
     }),
-    error: figma.boolean('Error', {
-      true: 'Error message',
-      false: undefined
+    error: figma.enum('State', {
+      Error: figma.textContent('errorMessage')
     }),
     required: figma.boolean('Required', { true: true, false: undefined }),
-    disabled: figma.boolean('Disabled', { true: true, false: undefined }),
+    disabled: figma.enum('State', { Disabled: true }),
     multiline: figma.boolean('Multiline', { true: true, false: undefined })
   },
   example: ({ label, description, error, required, disabled, multiline }) => (


### PR DESCRIPTION
## Summary

Connects `TextField`, `Select`, and `Combobox` to Figma via Code Connect. These were Batch 6 in the [#2373](https://github.com/dequelabs/cauldron/issues/2373) plan, blocked on the shared `Forms` set being split. The designer has now split them into three dedicated sets, so each connect is a clean 1:1 with no `variant: { Type: ... }` filter.

Related to #2373.

## What's actually mapped

| Prop | Source | Notes |
|---|---|---|
| `label` | `figma.textContent(...)` | TextField/Select use layer `Label`; Combobox uses `Combo Box Label` (verified via Figma inspect panel) |
| `description` | `figma.boolean('Description', { true: figma.textContent('Label Description'), false: undefined })` | Pulls the real designer-authored description string when the boolean is on |
| `error` | `figma.enum('State', { Error: figma.textContent('errorMessage') })` | See note below |
| `required` | `figma.boolean('Required', { true: true, false: undefined })` | |
| `disabled` | `figma.enum('State', { Disabled: true })` | See note below |
| `multiline` (TextField only) | `figma.boolean('Multiline', { true: true, false: undefined })` | |

### Why `error` and `disabled` use `figma.enum('State', …)` and not `figma.boolean`

The original #2373 plan called for promoting `Error`/`Disabled` to real BOOLEAN properties. On the actual split sets the designer shipped, those are values of a consolidated **`State`** VARIANT (alongside `Resting`, `Hover`, `Focus`, etc.) — not separate booleans. We map against the variant so the bindings work today. Promoting to true booleans is a follow-up worth coordinating with the designer.

### Figma component-set node ids

- TextField → `8534-4753`
- Select    → `8534-4265`
- Combobox  → `8534-4620`

(These are the COMPONENT_SET ids — first iteration of this PR used variant ids by mistake; publish validation flagged it and we corrected.)

## Known gap

- `Combobox.multiselect` is **not yet mapped**. The Figma set doesn't expose a property literally named `Multiselect`; we'll add it once the real property name is confirmed with the designer.

## Test plan

- [x] `npx eslint packages/react/src/components/{TextField,Select,Combobox}/*.figma.tsx` clean
- [x] `cd packages/react && npm run figma:parse` exit 0
- [x] `yarn figma:publish:dry-run` validation passes on the latest commit (label/description/error/disabled mappings resolve against the new sets)
- [ ] Dev Mode panel renders real Cauldron snippets for all three components in the published library after merge
- [ ] Designer confirmation that `Combobox.multiselect`'s Figma property name; follow-up PR to add the mapping