### PR TITLE
chore(figma): make Notice body dynamic in Code Connect

### DIFF
--- a/packages/react/src/components/Notice/Notice.figma.tsx
+++ b/packages/react/src/components/Notice/Notice.figma.tsx
@@ -14,11 +14,12 @@ figma.connect(Notice, FIGMA_URL, {
     variant: figma.enum('Size', {
       Small: 'condensed'
     }),
-    title: figma.textContent('Title')
+    title: figma.textContent('Title'),
+    children: figma.textContent('Text')
   },
-  example: ({ type, variant, title }) => (
+  example: ({ type, variant, title, children }) => (
     <Notice type={type} variant={variant} title={title}>
-      Body
+      {children}
     </Notice>
   )
 });


### PR DESCRIPTION
## Summary
- The Notice Code Connect example was hardcoded to render `Body` as children, so Figma always previewed the same string regardless of the selected variant.
- Wires `children` to the `Text` layer via `figma.textContent('Text')` so the previewed body matches the design.

## Test plan
- [ ] Open the Notice component in Figma and confirm the Code Connect preview shows the actual body text from the selected variant.