### PR TITLE
chore: exclude Storybook stories from jest coverage

### DIFF
--- a/packages/react/jest.config.ts
+++ b/packages/react/jest.config.ts
@@ -18,7 +18,8 @@ const config: Config = {
     '<rootDir>/src/contexts/**/*.{tsx,ts}',
     '!<rootDir>/src/utils/polymorphicComponent.test.tsx',
     '!<rootDir>/**/*.e2e.tsx',
-    '!<rootDir>/**/*.figma.tsx'
+    '!<rootDir>/**/*.figma.tsx',
+    '!<rootDir>/**/*.stories.{ts,tsx}'
   ],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
## Summary
- Adds `!<rootDir>/**/*.stories.{ts,tsx}` to `collectCoverageFrom` in [packages/react/jest.config.ts](packages/react/jest.config.ts).
- Story files contain no testable logic but were being counted as uncovered source, pulling the global statements/lines totals under the 90% threshold (e.g. CI run [25887728922](https://github.com/dequelabs/cauldron/actions/runs/25887728922/job/76083478327?pr=2392) failed at 87.84% / 87.98%).
- `.e2e.tsx` and `.figma.tsx` are already excluded; this brings stories in line with the same convention. Test files and `__snapshots__` are already excluded by Jest's defaults via `testMatch`, so no entries are added for them.

## Test plan
- [ ] CI `react` job passes (statements / lines back over 90%).