### PR TITLE
fix(docs): use `title` frontmatter on PageHeader and SectionHeader docs pages

### DIFF
--- a/docs/pages/components/PageHeader.mdx
+++ b/docs/pages/components/PageHeader.mdx
@@ -1,5 +1,5 @@
 ---
-heading: PageHeader
+title: PageHeader
 description: A header component for pages, providing a heading and optional actions.
 source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/PageHeader/index.tsx
 ---

--- a/docs/pages/components/SectionHeader.mdx
+++ b/docs/pages/components/SectionHeader.mdx
@@ -1,5 +1,5 @@
 ---
-heading: SectionHeader
+title: SectionHeader
 description: A header component for sections, providing a heading and optional actions.
 source: https://github.com/dequelabs/cauldron/blob/develop/packages/react/src/components/SectionHeader/index.tsx
 ---


### PR DESCRIPTION
#1880 added PageHeader and SectionHeader with `heading:` in the frontmatter. `title` was undefined, but `ComponentLayout` only used it as `<h1>{title}</h1>`, so the pages rendered with an empty `h1`.

#2384 added `const storybookSlug = title.toLowerCase()...` at the top of `ComponentLayout` to derive a Storybook URL. That runs unconditionally before any JSX, so the long-latent missing-`title` bug became a hard crash.

This fixes the property name so that the Cauldron docs pages render correctly.

Slack thread: https://deque.slack.com/archives/C05G4UJ0M0U/p1779196116888459

---

Links to previously broken docs pages in the PR build:
- https://pr-2394.d15792l1n26ww3.amplifyapp.com/components/PageHeader
- https://pr-2394.d15792l1n26ww3.amplifyapp.com/components/SectionHeader