### PR TITLE
fix: replace innerText usage with textContent

### DIFF
--- a/packages/react/src/components/ActionList/ActionListItem.test.tsx
+++ b/packages/react/src/components/ActionList/ActionListItem.test.tsx
@@ -148,6 +148,31 @@ test('should use text content for onAction if actionKey is not provided', async 
   expect(onAction).toHaveBeenCalledWith('Label Text', expect.anything());
 });
 
+test('should derive action key from nested children when actionKey is not provided', async () => {
+  const user = userEvent.setup();
+  const onAction = jest.fn();
+  render(
+    <ActionListItem>
+      <span>Label</span> <span>Text</span>
+    </ActionListItem>,
+    { wrapper: withActionListContext({ onAction }) }
+  );
+
+  await user.click(screen.getByRole('listitem'));
+  expect(onAction).toHaveBeenCalledWith('Label Text', expect.anything());
+});
+
+test('should call onAction with empty string when actionKey and text content are absent', async () => {
+  const user = userEvent.setup();
+  const onAction = jest.fn();
+  render(<ActionListItem>{null}</ActionListItem>, {
+    wrapper: withActionListContext({ onAction })
+  });
+
+  await user.click(screen.getByRole('listitem'));
+  expect(onAction).toHaveBeenCalledWith('', expect.anything());
+});
+
 test('should be disabled when disabled prop is true', () => {
   render(<ActionListItem disabled>Label Text</ActionListItem>);
 

--- a/packages/react/src/components/ActionList/ActionListItem.tsx
+++ b/packages/react/src/components/ActionList/ActionListItem.tsx
@@ -94,7 +94,7 @@ const ActionListItem = forwardRef<HTMLLIElement, ActionListItemProps>(
         // istanbul ignore else
         if (typeof onActionListAction === 'function') {
           onActionListAction(
-            actionKey || labelRef?.current?.innerText?.trim() || '',
+            actionKey || labelRef.current?.textContent?.trim() || '',
             event
           );
         }

--- a/packages/react/src/components/ActionList/ActionListItem.tsx
+++ b/packages/react/src/components/ActionList/ActionListItem.tsx
@@ -94,7 +94,7 @@ const ActionListItem = forwardRef<HTMLLIElement, ActionListItemProps>(
         // istanbul ignore else
         if (typeof onActionListAction === 'function') {
           onActionListAction(
-            actionKey || labelRef?.current?.innerText.trim() || '',
+            actionKey || labelRef?.current?.innerText?.trim() || '',
             event
           );
         }

--- a/packages/react/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/Combobox/Combobox.test.tsx
@@ -75,9 +75,9 @@ test('should render combobox with options', () => {
   ];
   render(<Combobox label="label" options={options} />);
   expect(screen.queryByRole('combobox')).toBeTruthy();
-  expect(screen.queryAllByRole('option').at(0)?.innerText).toEqual('Apple');
-  expect(screen.queryAllByRole('option').at(1)?.innerText).toEqual('Banana');
-  expect(screen.queryAllByRole('option').at(2)?.innerText).toEqual(
+  expect(screen.queryAllByRole('option').at(0)?.textContent).toEqual('Apple');
+  expect(screen.queryAllByRole('option').at(1)?.textContent).toEqual('Banana');
+  expect(screen.queryAllByRole('option').at(2)?.textContent).toEqual(
     'Cantaloupe'
   );
 });
@@ -91,9 +91,9 @@ test('should render combobox with children', () => {
     </Combobox>
   );
   expect(screen.queryByRole('combobox')).toBeTruthy();
-  expect(screen.queryAllByRole('option').at(0)?.innerText).toEqual('Apple');
-  expect(screen.queryAllByRole('option').at(1)?.innerText).toEqual('Banana');
-  expect(screen.queryAllByRole('option').at(2)?.innerText).toEqual(
+  expect(screen.queryAllByRole('option').at(0)?.textContent).toEqual('Apple');
+  expect(screen.queryAllByRole('option').at(1)?.textContent).toEqual('Banana');
+  expect(screen.queryAllByRole('option').at(2)?.textContent).toEqual(
     'Cantaloupe'
   );
 });
@@ -213,22 +213,22 @@ test('should render combobox with groups', () => {
   expect(group2.tagName).toEqual('UL');
   expect(group1.getAttribute('aria-labelledby')).toBeTruthy();
   expect(group2.getAttribute('aria-labelledby')).toBeTruthy();
-  expect(within(group1).queryAllByRole('option').at(0)?.innerText).toEqual(
+  expect(within(group1).queryAllByRole('option').at(0)?.textContent).toEqual(
     'Apple'
   );
-  expect(within(group1).queryAllByRole('option').at(1)?.innerText).toEqual(
+  expect(within(group1).queryAllByRole('option').at(1)?.textContent).toEqual(
     'Banana'
   );
-  expect(within(group1).queryAllByRole('option').at(2)?.innerText).toEqual(
+  expect(within(group1).queryAllByRole('option').at(2)?.textContent).toEqual(
     'Cantaloupe'
   );
-  expect(within(group2).queryAllByRole('option').at(0)?.innerText).toEqual(
+  expect(within(group2).queryAllByRole('option').at(0)?.textContent).toEqual(
     'Artichoke'
   );
-  expect(within(group2).queryAllByRole('option').at(1)?.innerText).toEqual(
+  expect(within(group2).queryAllByRole('option').at(1)?.textContent).toEqual(
     'Broccoli'
   );
-  expect(within(group2).queryAllByRole('option').at(2)?.innerText).toEqual(
+  expect(within(group2).queryAllByRole('option').at(2)?.textContent).toEqual(
     'Carrots'
   );
 });
@@ -1238,7 +1238,7 @@ test('should render matching options when autocomplete="manual"', () => {
   expect(screen.getAllByRole('option').length).toEqual(3);
   fireEvent.change(combobox, { target: { value: 'ap' } });
   expect(screen.getAllByRole('option').length).toEqual(1);
-  expect(screen.getByRole('option').innerText).toEqual('Apple');
+  expect(screen.getByRole('option').textContent).toEqual('Apple');
 });
 
 test('should render results not found when no options match when autocomplete="manual"', () => {
@@ -1321,7 +1321,7 @@ test('should render matching options when autocomplete="automatic"', () => {
   expect(screen.getAllByRole('option').length).toEqual(3);
   fireEvent.change(combobox, { target: { value: 'ap' } });
   expect(screen.getAllByRole('option').length).toEqual(1);
-  expect(screen.getByRole('option').innerText).toEqual('Apple');
+  expect(screen.getByRole('option').textContent).toEqual('Apple');
 });
 
 test('should render results not found when no options match when autocomplete="automatic"', () => {

--- a/packages/react/src/components/Combobox/ComboboxOption.tsx
+++ b/packages/react/src/components/Combobox/ComboboxOption.tsx
@@ -122,7 +122,7 @@ const ComboboxOption = forwardRef<HTMLLIElement, ComboboxOptionProps>(
       const comboboxValue =
         typeof propValue !== 'undefined'
           ? propValue
-          : comboboxOptionRef.current?.innerText;
+          : (comboboxOptionRef.current?.textContent ?? undefined);
       const value =
         typeof formValue === 'undefined' ? comboboxValue : formValue;
 
@@ -149,7 +149,7 @@ const ComboboxOption = forwardRef<HTMLLIElement, ComboboxOptionProps>(
         const comboboxValue =
           typeof propValue !== 'undefined'
             ? propValue
-            : comboboxOptionRef.current?.innerText;
+            : (comboboxOptionRef.current?.textContent ?? undefined);
         setMatchingOptions((options) => {
           return new Map(
             options.set(comboboxOptionRef.current, {

--- a/packages/react/src/components/Listbox/ListboxOption.tsx
+++ b/packages/react/src/components/Listbox/ListboxOption.tsx
@@ -10,8 +10,9 @@ import type {
 
 export type ListboxValue = Readonly<string | number | undefined>;
 
-interface ListboxOptionProps
-  extends PolymorphicProps<React.HTMLAttributes<HTMLElement>> {
+interface ListboxOptionProps extends PolymorphicProps<
+  React.HTMLAttributes<HTMLElement>
+> {
   value?: ListboxValue;
   disabled?: boolean;
   selected?: boolean;
@@ -52,7 +53,7 @@ const ListboxOption = forwardRef<HTMLElement, ListboxOptionProps>(
     const optionValue =
       typeof value !== 'undefined'
         ? value
-        : listboxOptionRef.current?.innerText;
+        : (listboxOptionRef.current?.textContent ?? undefined);
 
     useEffect(() => {
       const element = listboxOptionRef.current;

--- a/packages/react/src/setupTests.ts
+++ b/packages/react/src/setupTests.ts
@@ -9,18 +9,6 @@ configureAxe({
   }
 });
 
-if (
-  !Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerText')
-) {
-  // JSDOM doesn't fully support innerText, but we can fall back to
-  // using textContent for now until this gets patched
-  Object.defineProperty(window.HTMLElement.prototype, 'innerText', {
-    get() {
-      return this.textContent;
-    }
-  });
-}
-
 if (!('clipboard' in global.navigator)) {
   Object.defineProperty(global.navigator, 'clipboard', {
     value: {


### PR DESCRIPTION
Replaces innerText with textContent across `ActionListItem`, `ListboxOption`, and `ComboboxOption` (and drops the JSDOM polyfill that masked the difference in tests), fixing the React 18 flake surfaced in axe-extension ([dequelabs/axe-extension#8379](https://github.com/dequelabs/axe-extension/pull/8379)).