### PR TITLE
build(cauldron-react): declare @floating-ui/dom as a direct dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,6 +26,7 @@
     "figma:publish:dry-run": "figma connect publish --dry-run"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.0.0",
     "@floating-ui/react-dom": "^2.1.2",
     "classnames": "^2.2.6",
     "focusable": "^2.3.0",


### PR DESCRIPTION
Declares `@floating-ui/dom` as a direct dependency of `cauldron-react`. 

`AnchoredOverlay` imports from it directly and the build had been silently relying on hoisting (rollup was warning about it on every build).

This was discovered while migrating to pnpm -- it's a correctness/hygiene fixes that pnpm's strict isolation forced us to make. It isn't necessarily related to the pnpm migration so I'm issuing it as a separate PR.

Relates to: #2402.