### PR TITLE
chore(cauldron-react): reference React.JSX instead of the deprecated global JSX

### DIFF
--- a/packages/react/src/utils/polymorphicComponent.ts
+++ b/packages/react/src/utils/polymorphicComponent.ts
@@ -12,13 +12,13 @@ export type PolymorphicComponentProps<
   Props = {},
   ElementType extends React.ElementType = React.ElementType
 > = Merge<
-  ElementType extends keyof JSX.IntrinsicElements
+  ElementType extends keyof React.JSX.IntrinsicElements
     ? // Support intrinsic elements, e.g. as="a", as="button", as="div"...
-      React.PropsWithRef<JSX.IntrinsicElements[ElementType]>
+      React.PropsWithRef<React.JSX.IntrinsicElements[ElementType]>
     : ElementType extends React.ElementType
-    ? // Support components, e.g. as={MyComponent}
-      React.ComponentPropsWithRef<ElementType>
-    : never,
+      ? // Support components, e.g. as={MyComponent}
+        React.ComponentPropsWithRef<ElementType>
+      : never,
   PolymorphicProps<Props, ElementType>
 >;
 


### PR DESCRIPTION
Switches `polymorphicComponent.ts` from the bare global `JSX.IntrinsicElements` to `React.JSX.IntrinsicElements`. `@types/react@19` removed that global, and `React.JSX` has worked since `@types/react@17`.

This was discovered while migrating to pnpm -- it's a correctness/hygiene fixes that pnpm's strict isolation forced us to make. It isn't necessarily related to the pnpm migration so I'm issuing it as a separate PR.

Relates to: #2402