### PR TITLE
fix(ci): read canary version from package.json directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,16 @@ jobs:
       - name: Publish @deque/cauldron-styles
         run: |
           cd packages/styles
-          PACKAGE_VERSION="$(npm pkg get version | tr -d \")"
+          # Read the package version directly from package.json. `npm pkg get`
+          # walks up to the workspace root and returns a JSON object keyed by
+          # package name once `workspaces` is declared there, which breaks the
+          # string concatenation below.
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           npm version "$PACKAGE_VERSION-canary.${GITHUB_SHA:0:8}" --allow-same-version --no-git-tag-version
           npm publish --tag=next
       - name: Publish @deque/cauldron-react
         run: |
           cd packages/react
-          PACKAGE_VERSION="$(npm pkg get version | tr -d \")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           npm version "$PACKAGE_VERSION-canary.${GITHUB_SHA:0:8}" --allow-same-version --no-git-tag-version
           npm publish --tag=next


### PR DESCRIPTION
Hotfix for canary publishes broken by the workspace conversion (#2410).

`npm pkg get version` inside `packages/styles` or `packages/react` now walks up to the workspace root, sees `workspaces: [packages/*]` declared there, and returns a workspace-aware **JSON object** keyed by package name instead of a plain string. The canary script's `tr -d \"` was extracting that object as `PACKAGE_VERSION`, producing invalid version concatenations like:

```
npm error Invalid version: {
npm error   @deque/cauldron-styles: 7.1.0
npm error }-canary.18aac2ec
```

Switched both canary publishes to `node -p "require('./package.json').version"` — reads the local `package.json` directly, no npm workspace traversal.

### Reproduction / verification

```sh
$ cd packages/styles
$ npm pkg get version | tr -d \"     # old, broken
{
  @deque/cauldron-styles: 7.1.0
}
$ node -p "require('./package.json').version"  # new, fixed
7.1.0
```

The non-canary `publish` job is untouched — it doesn't extract the version, just `npm publish`-es directly.