### PR TITLE
build: declare unist-util-visit, mdast-util-mdx-expression, minimatch as direct devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,10 @@
     "log-symbols": "4",
     "mdast-util-from-markdown": "^2.0.3",
     "mdast-util-mdx": "^3.0.0",
+    "mdast-util-mdx-expression": "^2.0.1",
     "micromark-extension-mdxjs": "^3.0.0",
     "mini-css-extract-plugin": "^2.10.2",
+    "minimatch": "^10.2.5",
     "node-fetch": "^3.3.0",
     "p-queue": "^9",
     "playwright": "^1.47.0",
@@ -122,6 +124,7 @@
     "terser-webpack-plugin": "^5.6.0",
     "ts-node": "^10.9.2",
     "typescript": "~6.0.2",
+    "unist-util-visit": "^5.0.0",
     "webpack": "^5.106.1",
     "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12635,7 +12635,7 @@ mdast-util-gfm@^3.0.0:
     mdast-util-gfm-task-list-item "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
-mdast-util-mdx-expression@^2.0.0:
+mdast-util-mdx-expression@^2.0.0, mdast-util-mdx-expression@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz#43f0abac9adc756e2086f63822a38c8d3c3a5096"
   integrity sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==
@@ -13272,7 +13272,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@^10.0.1, minimatch@^10.1.1, minimatch@^10.2.2:
+minimatch@^10.0.1, minimatch@^10.1.1, minimatch@^10.2.2, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==


### PR DESCRIPTION
Relates to: #2402

Three root-level files in `docs/` import packages that aren't declared in the root `package.json`. They've worked under yarn's hoisting because they're transitive deps of other declared packages, but pnpm is a strict-isolation package manager that won't follow that fallback. The docs build will fail with `Cannot find package '<x>' imported from <y>` without explicit declarations.

> These are root `devDependencies`, and the root is `private: true` (never published). The `@deque/cauldron-react` and `@deque/cauldron-styles` packages are untouched.