### PR TITLE
fix(eslint): drop parserOptions.project to avoid pre-commit OOM under pnpm

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: 'tsconfig.json',
     sourceType: 'module'
   },
   env: {


### PR DESCRIPTION
## Summary

After the pnpm migration in #2411, the `lint-staged` → `eslint --fix` pre-commit step OOMs at the default 4 GB Node heap even for a one-line edit to a 17-line `.ts` file. Workaround in the field has been `NODE_OPTIONS=--max-old-space-size=8192 git commit ...`; this PR is the real fix.

## Root cause

`.eslintrc.js` sets `parserOptions.project: 'tsconfig.json'`, which makes `@typescript-eslint/parser` build a TypeScript `Program` before linting any file. The root `tsconfig.json` has no `include`, so the `Program`'s file set defaults to "all `.ts` files under the project" minus a single `node_modules` exclude.

Under pnpm strict-isolation, the program then walks dependency `.ts` source files via the `node_modules/.pnpm/*` symlink layout. `tsc --listFiles` on this `tsconfig` reports **762 files** under `node_modules/.pnpm/` — top contributors:

| files | package |
| ----- | ------- |
| 77 | `@testing-library/user-event` |
| 67 | `@types/node` |
| 46 | `typescript` |
| 46 | `@formatjs/ecma402-abstract` |
| 44 | `ajv` |
| 37 | `undici-types` |
| 23 | `mdast-util-to-markdown` |

`npx lint-staged` on a single staged file dies in ~8s at ~4.6 GB RSS, with the trace pinning the spike to `typescript-eslint`'s `createWatchProgram` step (before any rule runs).

Under the yarn-1 hoisted layout on develop this was wasteful but didn't OOM — pnpm's symlink fan-out (same package appearing under multiple `<pkg>@x.y.z_<peer>/` directories for different peer combos) is what tips it over.

## Why dropping `parserOptions.project` is correct, not a workaround

None of the rules enabled in `.eslintrc.js` need type information:

- `plugin:react/recommended` — syntactic
- `plugin:jsx-a11y/recommended` — syntactic
- `plugin:@typescript-eslint/eslint-recommended` — config-only (turns off base rules)
- `plugin:@typescript-eslint/recommended` — explicitly the *non-type-aware* preset; the type-aware preset is `recommended-requiring-type-checking`
- The four rule overrides in this file (`jsx-a11y/label-has-for`, `@typescript-eslint/camelcase` off, `explicit-function-return-type` off, `ban-ts-comment` warn) likewise don't read type info

So the `Program` was being built for no benefit even pre-pnpm — it just didn't OOM under yarn's hoisted layout.

## Measurements

All at default `NODE_OPTIONS` (no heap bump):

|  | before | after |
| --- | --- | --- |
| `eslint --fix` on one e2e/.ts file (4 GB heap) | **OOM** in 8.4s, 4.6 GB RSS | 1.0s, 262 MB |
| `npx lint-staged` on one staged file (default heap) | **OOM** | 2.0s, 262 MB |
| `eslint .` whole repo (4 GB heap) | n/a | passes, 0 errors, same 85 pre-existing warnings |

## Test plan

- [x] Reproduce the OOM on `chore/migrate-to-pnpm` (eslint at 4 GB heap, single file).
- [x] Apply the patch, re-run eslint on the same file at 4 GB heap — succeeds in ~1s.
- [x] `npx lint-staged` on a staged single-line edit at default heap — succeeds in ~2s, husky pre-commit clean.
- [x] `pnpm lint` over the whole repo — 0 errors, only pre-existing warnings.
- [ ] CI green on this branch.

## Notes

If at some point we want to enable type-aware rules (e.g. `@typescript-eslint/no-floating-promises`, `await-thenable`), we should re-introduce a TS `Program` deliberately at that time — ideally via typescript-eslint v8's `parserOptions.projectService`, with the root `tsconfig.json` either gaining a tight `include` (`packages/**/src/**/*`, `e2e/**/*`) or being split per workspace. That's out of scope here.