### PR TITLE
ci(amplify): add repo configured amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,17 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install -g pnpm@11.4.0
+        - pnpm install --frozen-lockfile
+    build:
+      commands:
+        - pnpm build
+  artifacts:
+    baseDirectory: docs/dist
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*

--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,11 @@ frontend:
     preBuild:
       commands:
         - npm install -g pnpm@11.4.0
+        # Point pnpm's content-addressed store inside the repo so Amplify's
+        # cache (repo-relative paths only) can actually persist it. Caching
+        # node_modules/** is ineffective under pnpm — it's a symlink farm into
+        # the store, not the package contents.
+        - pnpm config set store-dir .pnpm-store
         - pnpm install --frozen-lockfile
     build:
       commands:
@@ -14,4 +19,4 @@ frontend:
       - '**/*'
   cache:
     paths:
-      - node_modules/**/*
+      - .pnpm-store/**/*


### PR DESCRIPTION
Amplify was previously configured in the Amplify console, and not the repo. Adding it to the repo means that we can keep changes alongside the code, and keep it version-controlled.

> This silently broke with the switch to pnpm, because the Amplify configuration in the AWS console was still referencing yarn.