### PR TITLE
fix(docs): use named minimatch import

### DIFF
--- a/docs/collections.ts
+++ b/docs/collections.ts
@@ -1,4 +1,4 @@
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 
 type Collection<T = {}> = {
   name: string;


### PR DESCRIPTION
`docs/collections.ts` imported minimatch as a default export, but minimatch v10 (which we pinned in [#2417](https://github.com/dequelabs/cauldron/pull/2417)) is ESM-only with named exports. This was breaking the docs site.