### PR TITLE
fix: add accessible dialog semantics to Drawer

### DIFF
--- a/packages/react/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react/src/components/Drawer/Drawer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Drawer from './';
+import Drawer, { DrawerHeading } from './';
 import axe from '../../axe';
 
 afterEach(() => {
@@ -9,18 +9,55 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+const renderHeading = () => <DrawerHeading>Drawer title</DrawerHeading>;
+
 test('should render children', () => {
   render(
     <Drawer position="left" open data-testid="drawer">
+      {renderHeading()}
       Hello World
     </Drawer>
   );
   expect(screen.getByText('Hello World')).toBeInTheDocument();
 });
 
+test('should render as a dialog', () => {
+  render(
+    <Drawer position="left" open>
+      {renderHeading()}
+      Children
+    </Drawer>
+  );
+
+  expect(screen.getByRole('dialog', { name: 'Drawer title' })).toBeVisible();
+});
+
+test('should set aria-modal when modal', () => {
+  render(
+    <Drawer position="left" open>
+      {renderHeading()}
+      Children
+    </Drawer>
+  );
+
+  expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+});
+
+test('should not set aria-modal when non-modal', () => {
+  render(
+    <Drawer position="left" behavior="non-modal" open>
+      {renderHeading()}
+      Children
+    </Drawer>
+  );
+
+  expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-modal');
+});
+
 test('should support className prop', () => {
   render(
     <Drawer position="left" className="bananas" open data-testid="drawer">
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -39,6 +76,7 @@ test('should support open prop', () => {
   expect(drawer).not.toBeVisible();
   rerender(
     <Drawer position="left" data-testid="drawer" open>
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -58,6 +96,7 @@ test('should support position prop', () => {
   };
   const { rerender } = render(
     <Drawer position="top" open data-testid="drawer">
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -87,6 +126,7 @@ test('should call onClose prop on esc keypress', async () => {
   const user = userEvent.setup();
   render(
     <Drawer position="left" data-testid="drawer" open onClose={onClose}>
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -101,6 +141,7 @@ test('should call onClose prop on click outside', async () => {
   const user = userEvent.setup();
   render(
     <Drawer position="left" data-testid="drawer" open onClose={onClose}>
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -120,6 +161,7 @@ test('should set focus to drawer by default when opened', () => {
   expect(screen.getByTestId('drawer')).not.toHaveFocus();
   rerender(
     <Drawer position="left" data-testid="drawer" open>
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -144,6 +186,7 @@ test('should set focus to focusable element when opened', () => {
         initialFocus: button
       }}
     >
+      {renderHeading()}
       <button>focus me</button>
     </Drawer>
   );
@@ -171,6 +214,7 @@ test('should set focus to custom element when opened', () => {
       focusOptions={{ initialFocus: ref.current as HTMLElement }}
       open
     >
+      {renderHeading()}
       <button>no focus me</button>
       <button ref={ref}>focus me</button>
     </Drawer>
@@ -199,6 +243,7 @@ test('should set focus to custom ref element', () => {
       focusOptions={{ initialFocus: ref }}
       open
     >
+      {renderHeading()}
       <button>no focus me</button>
       <button ref={ref}>focus me</button>
     </Drawer>
@@ -224,6 +269,7 @@ test('should return focus to triggering element when closed', () => {
     <>
       <button>trigger</button>
       <Drawer position="left" data-testid="drawer" open>
+        {renderHeading()}
         Children
       </Drawer>
     </>
@@ -260,6 +306,7 @@ test('should return focus to custom element when closed', () => {
       open
       focusOptions={{ returnFocus: button }}
     >
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -280,6 +327,7 @@ test('should support ref prop', () => {
   const ref = React.createRef<HTMLDivElement>();
   render(
     <Drawer position="left" open ref={ref} data-testid="drawer">
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -294,6 +342,7 @@ test('should not trap focus when behavior is non-modal', async () => {
     <>
       <button>outside</button>
       <Drawer position="left" behavior="non-modal" open>
+        {renderHeading()}
         <div>
           <button>inside</button>
         </div>
@@ -315,6 +364,7 @@ test('should not trap focus when behavior is non-modal', async () => {
 test('should return no axe violations when open', async () => {
   render(
     <Drawer position="left" open data-testid="drawer">
+      {renderHeading()}
       Children
     </Drawer>
   );
@@ -332,4 +382,16 @@ test('should return no axe violations when closed', async () => {
 
   const results = await axe(await screen.findByTestId('drawer'));
   expect(results).toHaveNoViolations();
+});
+
+test('should throw when opened without a DrawerHeading', () => {
+  expect(() =>
+    render(
+      <Drawer position="left" open>
+        Children
+      </Drawer>
+    )
+  ).toThrow(
+    'Drawer: No heading provided. Include a DrawerHeading component for accessibility.'
+  );
 });

--- a/packages/react/src/components/Drawer/DrawerContext.tsx
+++ b/packages/react/src/components/Drawer/DrawerContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext } from 'react';
+
+interface DrawerContextValue {
+  headingId: string;
+}
+
+const DrawerContext = createContext<DrawerContextValue | null>(null);
+
+function useDrawerContext(): DrawerContextValue {
+  const context = useContext(DrawerContext);
+  if (!context) {
+    throw new Error(
+      'Drawer compound components must be rendered within a Drawer'
+    );
+  }
+  return context;
+}
+
+export { DrawerContext, useDrawerContext };
+export type { DrawerContextValue };

--- a/packages/react/src/components/Drawer/index.tsx
+++ b/packages/react/src/components/Drawer/index.tsx
@@ -4,10 +4,12 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   useRef
 } from 'react';
 import { createPortal } from 'react-dom';
 import classnames from 'classnames';
+import { useId } from 'react-id-generator';
 import Scrim from '../Scrim';
 import ClickOutsideListener from '../ClickOutsideListener';
 import useEscapeKey from '../../utils/useEscapeKey';
@@ -16,6 +18,11 @@ import useFocusTrap from '../../utils/useFocusTrap';
 import resolveElement from '../../utils/resolveElement';
 import AriaIsolate from '../../utils/aria-isolate';
 import { isBrowser } from '../../utils/is-browser';
+import {
+  DrawerContext,
+  useDrawerContext,
+  type DrawerContextValue
+} from './DrawerContext';
 
 export interface DrawerProps<
   T extends HTMLElement = HTMLElement
@@ -50,6 +57,7 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
   ) => {
     const drawerRef = useSharedRef(ref);
     const openRef = useRef(!!open);
+    const [headingId] = useId(1, 'drawer-title-');
     const { initialFocus: focusInitial, returnFocus: focusReturn } =
       focusOptions;
     const [isTransitioning, setIsTransitioning] = useState(!!open);
@@ -115,6 +123,24 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
       returnFocusElement: focusReturn
     });
 
+    useEffect(() => {
+      if (open && drawerRef.current) {
+        const hasHeading = drawerRef.current.querySelector('.Drawer__heading');
+        if (process.env.NODE_ENV !== 'production' && !hasHeading) {
+          throw Error(
+            'Drawer: No heading provided. Include a DrawerHeading component for accessibility.'
+          );
+        }
+      }
+    }, [open]);
+
+    const contextValue: DrawerContextValue = useMemo(
+      () => ({
+        headingId
+      }),
+      [headingId]
+    );
+
     const portalElement = resolveElement(portal);
 
     return createPortal(
@@ -127,6 +153,7 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
         >
           <div
             ref={drawerRef}
+            role="dialog"
             className={classnames(className, 'Drawer', {
               'Drawer--open': !!open,
               'Drawer--top': position === 'top',
@@ -135,6 +162,8 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
               'Drawer--right': position === 'right'
             })}
             aria-hidden={!open || undefined}
+            aria-modal={isModal ? true : undefined}
+            aria-labelledby={headingId}
             style={{
               visibility: !open && !isTransitioning ? 'hidden' : undefined,
               ...style
@@ -142,7 +171,9 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
             tabIndex={open ? -1 : undefined}
             {...props}
           >
-            {children}
+            <DrawerContext.Provider value={contextValue}>
+              {children}
+            </DrawerContext.Provider>
           </div>
         </ClickOutsideListener>
         <Scrim show={!!open && !!isModal} />
@@ -156,4 +187,31 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
 
 Drawer.displayName = 'Drawer';
 
+export interface DrawerHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  children: React.ReactNode;
+  className?: string;
+  level?: number;
+}
+
+const DrawerHeading = ({
+  children,
+  className,
+  level = 2,
+  ...other
+}: DrawerHeadingProps) => {
+  const { headingId } = useDrawerContext();
+  const HeadingLevel = `h${level}` as 'h1';
+  return (
+    <HeadingLevel
+      className={classnames('Drawer__heading', className)}
+      id={headingId}
+      {...other}
+    >
+      {children}
+    </HeadingLevel>
+  );
+};
+DrawerHeading.displayName = 'DrawerHeading';
+
 export default Drawer;
+export { Drawer, DrawerHeading };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -140,7 +140,7 @@ export { default as Popover } from './components/Popover';
 export { default as Timeline, TimelineItem } from './components/Timeline';
 export { default as TextEllipsis } from './components/TextEllipsis';
 export { default as CopyButton } from './components/CopyButton';
-export { default as Drawer } from './components/Drawer';
+export { default as Drawer, DrawerHeading } from './components/Drawer';
 export { default as BottomSheet } from './components/BottomSheet';
 export { default as AnchoredOverlay } from './components/AnchoredOverlay';
 export { default as FieldGroup } from './components/FieldGroup';


### PR DESCRIPTION
## Summary

- gives Drawer dialog content accessible dialog semantics
- wires the dialog heading context/export so the drawer has an accessible name
- adds focused tests for the dialog/heading behavior

Closes #2428.

## Test plan

- `git diff --check`
- Full test run was not available in this local environment because dependency installation/linking was blocked by network/tooling issues.