### PR TITLE
test(docs): fail a11y run on blank/crashed docs pages

### DIFF
--- a/e2e/accessibility.ts
+++ b/e2e/accessibility.ts
@@ -98,86 +98,88 @@ const main = async (): Promise<void> => {
         const pageErrors: Error[] = [];
         page.on('pageerror', (error) => pageErrors.push(error as Error));
 
-        await page.goto(`http://localhost:${port}/`);
-
         const component = (url.split('/').pop() as string) || 'Index';
 
         try {
-          await page.goto(url, { waitUntil: 'networkidle0' });
-        } catch (ex) {
-          console.log(url);
-          throw ex;
-        }
+          await page.goto(`http://localhost:${port}/`);
 
-        if (pageErrors.length) {
-          await browser.close();
-          throw new Error(
-            `${url} threw while loading:\n${pageErrors
-              .map((error) => `  ${error.message}`)
-              .join('\n')}`
-          );
-        }
+          try {
+            await page.goto(url, { waitUntil: 'networkidle0' });
+          } catch (ex) {
+            console.log(url);
+            throw ex;
+          }
 
-        for (const theme of THEMES) {
-          await page.evaluate(
-            (theme) => {
-              document.body.className = '';
-              document.body.classList.add(`cauldron--theme-${theme}`);
-            },
-            [theme]
-          );
+          if (pageErrors.length) {
+            throw new Error(
+              `${url} threw while loading:\n${pageErrors
+                .map((error) => `  ${error.message}`)
+                .join('\n')}`
+            );
+          }
 
-          // Try to wait until there is an idle period up to a max of 5s
-          await Promise.race([
+          for (const theme of THEMES) {
             await page.evaluate(
-              () =>
-                new Promise((resolve) =>
-                  // Typescript does not implement experimental apis but this should exist within puppeteer
-                  // see: https://github.com/microsoft/TypeScript/issues/21309
-                  (window as any).requestIdleCallback(resolve)
-                )
-            ),
-            await new Promise((resolve) => setTimeout(resolve, 5000))
-          ]);
+              (theme) => {
+                document.body.className = '';
+                document.body.classList.add(`cauldron--theme-${theme}`);
+              },
+              [theme]
+            );
 
-          const axe = new AxePuppeteer(page, AXE_SOURCE).withTags([
-            'wcag2a',
-            'wcag2aa',
-            'wcag21a',
-            'wcag21aa',
-            'wcag22a',
-            'wcag22aa'
-          ]);
-          const { violations } = (await axe.analyze()) as AxeResults;
+            // Try to wait until there is an idle period up to a max of 5s
+            await Promise.race([
+              await page.evaluate(
+                () =>
+                  new Promise((resolve) =>
+                    // Typescript does not implement experimental apis but this should exist within puppeteer
+                    // see: https://github.com/microsoft/TypeScript/issues/21309
+                    (window as any).requestIdleCallback(resolve)
+                  )
+              ),
+              await new Promise((resolve) => setTimeout(resolve, 5000))
+            ]);
 
-          let symbol = logSymbols.success;
-          if (violations.length) {
-            symbol = logSymbols.warning;
-            foundViolations = true;
+            const axe = new AxePuppeteer(page, AXE_SOURCE).withTags([
+              'wcag2a',
+              'wcag2aa',
+              'wcag21a',
+              'wcag21aa',
+              'wcag22a',
+              'wcag22aa'
+            ]);
+            const { violations } = (await axe.analyze()) as AxeResults;
+
+            let symbol = logSymbols.success;
+            if (violations.length) {
+              symbol = logSymbols.warning;
+              foundViolations = true;
+            }
+
+            const title =
+              chalk.cyan(chalk.bold(component)) +
+              ' (' +
+              chalk.italic(theme) +
+              ')';
+            const dots = '.'.repeat(
+              MAX_WIDTH - component.length - symbol.length
+            );
+            console.log(title, dots, symbol);
+
+            for (const { id, help, nodes } of violations) {
+              console.log('↳', chalk.underline(chalk.magenta(id)), '━', help);
+              nodes.map((node) => {
+                console.log(
+                  '  ↳',
+                  chalk.bgGreen(chalk.black(`${node.target}`)),
+                  chalk.yellowBright(node.html)
+                );
+              });
+            }
           }
-
-          const title =
-            chalk.cyan(chalk.bold(component)) +
-            ' (' +
-            chalk.italic(theme) +
-            ')';
-          const dots = '.'.repeat(MAX_WIDTH - component.length - symbol.length);
-          console.log(title, dots, symbol);
-
-          for (const { id, help, nodes } of violations) {
-            console.log('↳', chalk.underline(chalk.magenta(id)), '━', help);
-            nodes.map((node) => {
-              console.log(
-                '  ↳',
-                chalk.bgGreen(chalk.black(`${node.target}`)),
-                chalk.yellowBright(node.html)
-              );
-            });
-          }
+        } finally {
+          await browser.close();
         }
-
-        await page.close();
-        await browser.close();
       });
     })
   );

--- a/e2e/accessibility.ts
+++ b/e2e/accessibility.ts
@@ -28,7 +28,23 @@ const getComponentUrls = async (port: number): Promise<Set<string>> => {
     executablePath: determineBrowserPath()
   });
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${port}/`);
+
+  // Fail loudly if the app throws while booting. A runtime crash (e.g. a doc
+  // page with missing frontmatter) leaves a blank page that otherwise sails
+  // through the axe pass with zero violations.
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error as Error));
+
+  await page.goto(`http://localhost:${port}/`, { waitUntil: 'networkidle0' });
+
+  if (pageErrors.length) {
+    await browser.close();
+    throw new Error(
+      `The docs site threw while loading "/":\n${pageErrors
+        .map((error) => `  ${error.message}`)
+        .join('\n')}`
+    );
+  }
 
   // Build a list of all URLs.
   const links = await page.$$('nav.Navigation a[href]');
@@ -39,6 +55,15 @@ const getComponentUrls = async (port: number): Promise<Set<string>> => {
   }
 
   await browser.close();
+
+  // If the navigation never rendered, the app booted into a broken/blank
+  // state. Bail rather than "passing" by testing only the index URL.
+  if (urls.size <= 1) {
+    throw new Error(
+      'No navigation links were found on the docs index — the site likely ' +
+        'failed to render. Refusing to run the a11y pass against a blank page.'
+    );
+  }
 
   return urls;
 };
@@ -69,6 +94,10 @@ const main = async (): Promise<void> => {
           executablePath: determineBrowserPath()
         });
         const page = await browser.newPage();
+
+        const pageErrors: Error[] = [];
+        page.on('pageerror', (error) => pageErrors.push(error as Error));
+
         await page.goto(`http://localhost:${port}/`);
 
         const component = (url.split('/').pop() as string) || 'Index';
@@ -78,6 +107,15 @@ const main = async (): Promise<void> => {
         } catch (ex) {
           console.log(url);
           throw ex;
+        }
+
+        if (pageErrors.length) {
+          await browser.close();
+          throw new Error(
+            `${url} threw while loading:\n${pageErrors
+              .map((error) => `  ${error.message}`)
+              .join('\n')}`
+          );
         }
 
         for (const theme of THEMES) {


### PR DESCRIPTION
#2349 was created to fix an issue where pages with missing front matter would make the docs site render blank.

However, that code itself made the docs site render blank because of a different reason. 😳 It had to be reverted.

This PR prevents that issue from happening in the future by expanding on the docs a11y test. It already loads and crawls every page, but it was treating a blank/crashed page as "no violations found" — which is exactly how the broken page slipped into production (and how others have in the past).