### PR TITLE
chore: fix typos and grammar in comments and docs

### DIFF
--- a/docs/pages/components/ImpactBadge.mdx
+++ b/docs/pages/components/ImpactBadge.mdx
@@ -1,6 +1,6 @@
 ---
 title: ImpactBadge
-description: The ImpactBadge is an extension of the Badge component is designed to indicate the type of impact
+description: The ImpactBadge is an extension of the Badge component that is designed to indicate the type of impact
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/ImpactBadge/index.tsx
 storybook: true
 ---

--- a/docs/pages/components/TooltipTabstop.mdx
+++ b/docs/pages/components/TooltipTabstop.mdx
@@ -1,6 +1,6 @@
 ---
 title: TooltipTabstop
-description: A keyboard-accesible tooltip for non-interactive elements.
+description: A keyboard-accessible tooltip for non-interactive elements.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/TooltipTabstop/index.tsx
 ---
 

--- a/docs/pages/intro.mdx
+++ b/docs/pages/intro.mdx
@@ -40,7 +40,7 @@ There are a few additional packages that you will need to install:
 
 ### Setup
 
-Once installed, you will need to add include cauldron's styles somewhere in the top level of your application. You will also need to load the required font family of Roboto before cauldron styles. This can be using [google fonts](https://fonts.google.com/specimen/Roboto) or with something like [fontsource](https://fontsource.org/fonts/roboto):
+Once installed, you will need to include cauldron's styles somewhere in the top level of your application. You will also need to load the required font family of Roboto before cauldron styles. This can be done using [google fonts](https://fonts.google.com/specimen/Roboto) or with something like [fontsource](https://fontsource.org/fonts/roboto):
 
 An example of this using the [fontsource](https://fontsource.org/fonts/roboto) package and loading cauldron styles as follows:
 

--- a/e2e/readme.md
+++ b/e2e/readme.md
@@ -21,7 +21,7 @@ pnpm screenshots --update-snapshots
 ```
 
 > [!NOTE]
-> Screenshot comparisons use a color threshhold of [0.2](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1-option-threshold) to help avoid unnecessary diffs from pixel anti-aliasing. If you need to generate a change to a component that has color changes only, you may want to first delete the previous snapshot before running the above command to get a clean component snapshot.
+> Screenshot comparisons use a color threshold of [0.2](https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1-option-threshold) to help avoid unnecessary diffs from pixel anti-aliasing. If you need to generate a change to a component that has color changes only, you may want to first delete the previous snapshot before running the above command to get a clean component snapshot.
 
 Finally, to run screenshot comparison tests run:
 

--- a/packages/react/src/components/Toast/utils.ts
+++ b/packages/react/src/components/Toast/utils.ts
@@ -37,7 +37,7 @@ export const typeMap: TypeMap = {
 
 export const tabIndexHandler = (reset: boolean, toast: HTMLElement | null) => {
   if (reset) {
-    // restore tab indicies that we clobbered
+    // restore tab indices that we clobbered
     return queryAll('[data-cached-tabindex]').forEach((el: HTMLElement) => {
       el.tabIndex = Number(el.getAttribute('data-cached-tabindex'));
     });

--- a/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.tsx
+++ b/packages/react/src/components/TwoColumnPanel/TwoColumnPanel.tsx
@@ -196,7 +196,7 @@ const TwoColumnPanel = forwardRef<HTMLDivElement, TwoColumnPanelProps>(
       };
     }, [columnLeftRef.current, isCollapsed]);
 
-    // When the collapsable panel starts to overlay content, it needs to become a focus trap and collapsed by default
+    // When the collapsible panel starts to overlay content, it needs to become a focus trap and collapsed by default
     useLayoutEffect(() => {
       const mediaQueryList = matchMedia(collapsedMediaQuery);
       const handleMatch = (matches: boolean) => {

--- a/packages/react/src/utils/polymorphicComponent.test.tsx
+++ b/packages/react/src/utils/polymorphicComponent.test.tsx
@@ -42,7 +42,7 @@ const htmlAnchorRef = React.createRef<HTMLAnchorElement>();
 
 /*
  * Note: The below components are statically typed and get validated with tsc
- * to ensure we don't arbitrarily break polymoprhic components. Valid component
+ * to ensure we don't arbitrarily break polymorphic components. Valid component
  * types should throw no errors, where @ts-expect-error is used to indicate
  * an invalid or missing property.
  */

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -1,6 +1,6 @@
 /*
  * variable naming convention:
- * --{component name (if applicable)}-{style property}-{...modifiers (if applicable, hypen separated)}
+ * --{component name (if applicable)}-{style property}-{...modifiers (if applicable, hyphen separated)}
  * example: --foo-background-color-light
  */
 


### PR DESCRIPTION
## Summary

Spelling and grammar cleanup across the repo, found via a `codespell` dictionary sweep plus an LLM review pass over user-facing docs prose. **No behavior change**, no shipped UI strings affected.

### Code-comment / dev-doc typos (codespell)

| File | Fix |
|------|-----|
| `e2e/readme.md` | threshh​old → threshold |
| `packages/styles/variables.css` | hypen → hyphen (comment) |
| `packages/react/src/utils/polymorphicComponent.test.tsx` | polymoprhic → polymorphic (comment) |
| `packages/react/src/components/Toast/utils.ts` | indicies → indices (comment) |
| `packages/react/src/components/TwoColumnPanel/TwoColumnPanel.tsx` | collapsable → collapsible (comment) |

### Docs-prose spelling / grammar (LLM review)

| File | Fix |
|------|-----|
| `docs/pages/components/TooltipTabstop.mdx` | keyboard-acces​ible → keyboard-accessible |
| `docs/pages/intro.mdx` | "add include cauldron's styles" → "include …"; "This can be using" → "This can be done using" |
| `docs/pages/components/ImpactBadge.mdx` | "Badge component is designed" → "Badge component that is designed" |

### Verified clean / intentionally skipped

- **Component source** (aria-labels, default labels, rendered strings): no errors found.
- `ActionList.figma.tsx` "Opitional": preserved deliberately to match the Figma layer name (per existing comment).
- Stylistic only, not changed: missing trailing periods in `TextEllipsis.mdx` / `colors.mdx` descriptions (description punctuation is inconsistent repo-wide).
- False positives ignored: `Deque` (company), `master` (branch), Testing Library APIs (`waitFor`, `focusIn`), `<thead>`.

Doc *example* fixes (duplicate `aria-current`, "Animated Progres") are in #2445.