### PR TITLE
fix(ActionMenu): parameterize trigger element type

### DIFF
--- a/docs/pages/components/ActionMenu.mdx
+++ b/docs/pages/components/ActionMenu.mdx
@@ -440,11 +440,11 @@ function MixedSelectionExample() {
       name: 'trigger',
       type: [
         'React.ReactElement',
-        '(props: ActionMenuTriggerProps, open: boolean) => React.ReactElement'
+        '<E extends HTMLElement = HTMLButtonElement>(props: ActionMenuTriggerProps<E>, open: boolean) => React.ReactElement'
       ],
       required: true,
       description:
-        'Element that triggers the menu to open. Can be a React element or a render function that receives props and the current open state.'
+        'Element that triggers the menu to open. Can be a React element or a render function that receives props and the current open state. The trigger element type defaults to HTMLButtonElement; when nesting inside a TopBar/MenuBar, annotate the trigger param (e.g. (props: ActionMenuTriggerProps<HTMLLIElement>) => …) so the trigger ref and handlers type against the actual element without casts.'
     },
     {
       name: 'placement',

--- a/docs/pages/components/ActionMenu.mdx
+++ b/docs/pages/components/ActionMenu.mdx
@@ -430,10 +430,13 @@ The trigger element type defaults to `HTMLButtonElement`, but it is parameterize
 ```tsx
 <ActionMenu
   renderInTrigger
-  trigger={({ ref, children, ...props }: ActionMenuTriggerProps<HTMLLIElement>) => (
+  trigger={({
+    ref,
+    children,
+    ...props
+  }: ActionMenuTriggerProps<HTMLLIElement>) => (
     <TopBarItem menuItemRef={ref} {...props}>
-      …
-      {children}
+      …{children}
     </TopBarItem>
   )}
 >

--- a/docs/pages/components/ActionMenu.mdx
+++ b/docs/pages/components/ActionMenu.mdx
@@ -423,6 +423,24 @@ function MixedSelectionExample() {
 </ActionMenu>
 ```
 
+### Nested triggers
+
+The trigger element type defaults to `HTMLButtonElement`, but it is parameterized for nested menu patterns where the trigger is not a button — for example a `MenuItem`/`TopBarItem` (`<li>`) when an `ActionMenu` is nested inside a `TopBar`/`MenuBar`. Annotating the trigger param infers the element type, so the trigger's `ref` and event handlers type against the actual element without casts and no JSX type argument is required:
+
+```tsx
+<ActionMenu
+  renderInTrigger
+  trigger={({ ref, children, ...props }: ActionMenuTriggerProps<HTMLLIElement>) => (
+    <TopBarItem menuItemRef={ref} {...props}>
+      …
+      {children}
+    </TopBarItem>
+  )}
+>
+  {/* ... */}
+</ActionMenu>
+```
+
 ## Props
 
 ### ActionMenu

--- a/packages/react/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import ActionMenu from './ActionMenu';
+import ActionMenu, { type ActionMenuTriggerProps } from './ActionMenu';
 import {
   ActionList,
   ActionListGroup,
@@ -52,25 +52,37 @@ async function waitForMenuFocus() {
   });
 }
 
-const defaultTopBarPatternProps: React.ComponentProps<typeof ActionMenu> = {
-  ...defaultProps,
-  tabIndex: -1,
-  renderInTrigger: true,
-  trigger: ({ ref, children, ...props }) => (
-    // @ts-expect-error - TopBarItem expects menuitems to be <li>, ActionMenu expects triggers to be <button>
-    <TopBarItem menuItemRef={ref} tabIndex={0} autoClickLink={false} {...props}>
-      Trigger
-      {children}
-    </TopBarItem>
-  ),
-  children: (
+// The documented TopBar/MenuBar nesting: the trigger is a TopBarItem (<li>),
+// not a button. Annotating the trigger param as ActionMenuTriggerProps<HTMLLIElement>
+// infers the element type, so the trigger's `ref` and spread handlers type
+// against the actual element without casts and without a JSX type argument.
+const TopBarPatternActionMenu = () => (
+  <ActionMenu
+    tabIndex={-1}
+    renderInTrigger
+    trigger={({
+      ref,
+      children,
+      ...props
+    }: ActionMenuTriggerProps<HTMLLIElement>) => (
+      <TopBarItem
+        menuItemRef={ref}
+        tabIndex={0}
+        autoClickLink={false}
+        {...props}
+      >
+        Trigger
+        {children}
+      </TopBarItem>
+    )}
+  >
     <ActionList>
       <ActionListLinkItem href="#target-1">Menu Link 1</ActionListLinkItem>
       <ActionListLinkItem href="#target-2">Menu Link 2</ActionListLinkItem>
       <ActionListLinkItem href="#target-3">Menu Link 3</ActionListLinkItem>
     </ActionList>
-  )
-};
+  </ActionMenu>
+);
 
 afterEach(() => {
   window.location.hash = '';
@@ -420,7 +432,7 @@ test('should set first item active on open in TopBar+ActionMenu pattern', async 
   render(
     <TopBar>
       <MenuBar>
-        <ActionMenu {...defaultTopBarPatternProps} />
+        <TopBarPatternActionMenu />
       </MenuBar>
     </TopBar>
   );
@@ -691,7 +703,7 @@ test('should not trigger action link items when toggling the open state in TopBa
   render(
     <TopBar>
       <MenuBar>
-        <ActionMenu {...defaultTopBarPatternProps} />
+        <TopBarPatternActionMenu />
       </MenuBar>
     </TopBar>
   );
@@ -707,7 +719,7 @@ test('should navigate to href when an action link item is clicked in TopBar+Acti
   render(
     <TopBar>
       <MenuBar>
-        <ActionMenu {...defaultTopBarPatternProps} />
+        <TopBarPatternActionMenu />
       </MenuBar>
     </TopBar>
   );
@@ -738,7 +750,7 @@ test('should close menu when focus moves outside in TopBar+ActionMenu pattern', 
     <>
       <TopBar>
         <MenuBar>
-          <ActionMenu {...defaultTopBarPatternProps} />
+          <TopBarPatternActionMenu />
         </MenuBar>
       </TopBar>
       <button>Outside</button>
@@ -972,7 +984,7 @@ test('should have no axe violations in TopBar+ActionMenu pattern', async () => {
   const { container } = render(
     <TopBar>
       <MenuBar>
-        <ActionMenu {...defaultTopBarPatternProps} />
+        <TopBarPatternActionMenu />
       </MenuBar>
     </TopBar>
   );
@@ -988,7 +1000,7 @@ test('should have no axe violations in TopBar+ActionMenu pattern when open', asy
   const { container } = render(
     <TopBar>
       <MenuBar>
-        <ActionMenu {...defaultTopBarPatternProps} />
+        <TopBarPatternActionMenu />
       </MenuBar>
     </TopBar>
   );

--- a/packages/react/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.tsx
@@ -36,6 +36,7 @@ export type ActionMenuTriggerProps<E extends HTMLElement = HTMLButtonElement> =
   Pick<
     React.HTMLAttributes<E>,
     | 'children'
+    | 'id'
     | 'onClick'
     | 'onKeyDown'
     | 'aria-expanded'

--- a/packages/react/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.tsx
@@ -266,11 +266,15 @@ ActionMenuComponent.displayName = 'ActionMenu';
  * This only widens the public types of the `trigger` function; the internal
  * implementation is unaffected. See the ActionMenu docs for a usage example.
  */
-const ActionMenu = ActionMenuComponent as (<
-  E extends HTMLElement = HTMLButtonElement
->(
-  props: ActionMenuProps<E> & React.RefAttributes<HTMLElement>
-) => React.ReactElement) &
-  Pick<typeof ActionMenuComponent, 'displayName'>;
+type ActionMenuType = Omit<
+  React.ForwardRefExoticComponent<ActionMenuProps>,
+  keyof CallableFunction
+> & {
+  <E extends HTMLElement = HTMLButtonElement>(
+    props: ActionMenuProps<E> & React.RefAttributes<HTMLElement>
+  ): React.ReactElement;
+};
+
+const ActionMenu = ActionMenuComponent as ActionMenuType;
 
 export default ActionMenu;

--- a/packages/react/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.tsx
@@ -260,26 +260,11 @@ const ActionMenuComponent = forwardRef<HTMLElement, ActionMenuProps>(
 ActionMenuComponent.displayName = 'ActionMenu';
 
 /**
- * The trigger element defaults to an `HTMLButtonElement`, but the element type
- * is parameterized for nested menu patterns where the trigger is not a button —
- * for example a `MenuItem`/`TopBarItem` (`<li>`) when an `ActionMenu` is nested
- * inside a `TopBar`/`MenuBar`. The internal implementation is unaffected; this
- * only widens the public types of the `trigger` function so consumers can type
- * the trigger's `ref` and event handlers against the actual element without
- * casts. Annotating the trigger param infers the element type, so no JSX type
- * argument is required:
- *
- * ```tsx
- * <ActionMenu
- *   renderInTrigger
- *   trigger={({ ref, children, ...props }: ActionMenuTriggerProps<HTMLLIElement>) => (
- *     <TopBarItem menuItemRef={ref} {...props}>
- *       …
- *       {children}
- *     </TopBarItem>
- *   )}
- * >
- * ```
+ * The trigger element type is parameterized (defaulting to `HTMLButtonElement`)
+ * so it can be widened for nested menu patterns where the trigger is not a
+ * button — e.g. a `MenuItem`/`TopBarItem` (`<li>`) inside a `TopBar`/`MenuBar`.
+ * This only widens the public types of the `trigger` function; the internal
+ * implementation is unaffected. See the ActionMenu docs for a usage example.
  */
 const ActionMenu = ActionMenuComponent as (<
   E extends HTMLElement = HTMLButtonElement

--- a/packages/react/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.tsx
@@ -25,26 +25,33 @@ interface ActionMenuListProps {
   [key: string]: unknown;
 }
 
-type ActionMenuTriggerProps = Pick<
-  React.HTMLAttributes<HTMLButtonElement>,
-  | 'children'
-  | 'onClick'
-  | 'onKeyDown'
-  | 'aria-expanded'
-  | 'aria-haspopup'
-  | 'aria-controls'
-> & {
-  ref: React.RefObject<HTMLButtonElement | null>;
-};
+/**
+ * Props passed to an `ActionMenu` trigger render function. The element type
+ * defaults to `HTMLButtonElement`; annotate it (e.g. `ActionMenuTriggerProps<HTMLLIElement>`)
+ * when the trigger is not a button — for example a `MenuItem`/`TopBarItem`
+ * (`<li>`) in the documented `TopBar`/`MenuBar` nesting — so the `ref` and
+ * spread handlers type against the actual element without casts.
+ */
+export type ActionMenuTriggerProps<E extends HTMLElement = HTMLButtonElement> =
+  Pick<
+    React.HTMLAttributes<E>,
+    | 'children'
+    | 'onClick'
+    | 'onKeyDown'
+    | 'aria-expanded'
+    | 'aria-haspopup'
+    | 'aria-controls'
+  > & {
+    ref: React.RefObject<E | null>;
+  };
 
-type ActionMenuTriggerFunction = (
-  props: ActionMenuTriggerProps,
-  open: boolean
-) => React.ReactElement;
+export type ActionMenuTriggerFunction<
+  E extends HTMLElement = HTMLButtonElement
+> = (props: ActionMenuTriggerProps<E>, open: boolean) => React.ReactElement;
 
-type ActionMenuProps = {
+type ActionMenuProps<E extends HTMLElement = HTMLButtonElement> = {
   children: React.ReactElement<ActionMenuListProps>;
-  trigger: React.ReactElement | ActionMenuTriggerFunction;
+  trigger: React.ReactElement | ActionMenuTriggerFunction<E>;
   /** Render the action menu in a different location in the dom. */
   portal?: React.RefObject<HTMLElement | null> | HTMLElement;
   /**
@@ -58,7 +65,7 @@ type ActionMenuProps = {
 } & Pick<React.ComponentProps<typeof AnchoredOverlay>, 'placement'> &
   React.HTMLAttributes<HTMLElement>;
 
-const ActionMenu = forwardRef<HTMLElement, ActionMenuProps>(
+const ActionMenuComponent = forwardRef<HTMLElement, ActionMenuProps>(
   (
     {
       className,
@@ -249,6 +256,35 @@ const ActionMenu = forwardRef<HTMLElement, ActionMenuProps>(
   }
 );
 
-ActionMenu.displayName = 'ActionMenu';
+ActionMenuComponent.displayName = 'ActionMenu';
+
+/**
+ * The trigger element defaults to an `HTMLButtonElement`, but the element type
+ * is parameterized for nested menu patterns where the trigger is not a button —
+ * for example a `MenuItem`/`TopBarItem` (`<li>`) when an `ActionMenu` is nested
+ * inside a `TopBar`/`MenuBar`. The internal implementation is unaffected; this
+ * only widens the public types of the `trigger` function so consumers can type
+ * the trigger's `ref` and event handlers against the actual element without
+ * casts. Annotating the trigger param infers the element type, so no JSX type
+ * argument is required:
+ *
+ * ```tsx
+ * <ActionMenu
+ *   renderInTrigger
+ *   trigger={({ ref, children, ...props }: ActionMenuTriggerProps<HTMLLIElement>) => (
+ *     <TopBarItem menuItemRef={ref} {...props}>
+ *       …
+ *       {children}
+ *     </TopBarItem>
+ *   )}
+ * >
+ * ```
+ */
+const ActionMenu = ActionMenuComponent as (<
+  E extends HTMLElement = HTMLButtonElement
+>(
+  props: ActionMenuProps<E> & React.RefAttributes<HTMLElement>
+) => React.ReactElement) &
+  Pick<typeof ActionMenuComponent, 'displayName'>;
 
 export default ActionMenu;

--- a/packages/react/src/components/ActionMenu/index.ts
+++ b/packages/react/src/components/ActionMenu/index.ts
@@ -1,1 +1,5 @@
 export { default as ActionMenu } from './ActionMenu';
+export type {
+  ActionMenuTriggerProps,
+  ActionMenuTriggerFunction
+} from './ActionMenu';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -154,7 +154,11 @@ export {
   ActionListSeparator,
   ActionListLinkItem
 } from './components/ActionList';
-export { ActionMenu } from './components/ActionMenu';
+export {
+  ActionMenu,
+  type ActionMenuTriggerProps,
+  type ActionMenuTriggerFunction
+} from './components/ActionMenu';
 export { default as TreeView, type TreeViewNode } from './components/TreeView';
 
 /**


### PR DESCRIPTION
Closes #2449

`ActionMenu`'s function-trigger props typed the `ref` and event handlers against `HTMLButtonElement`, which contradicted the documented `renderInTrigger` nesting pattern where the trigger is a `MenuItem`/`TopBarItem` (an `<li>`). Consumers following that pattern were forced to cast the ref via `as unknown as RefObject<HTMLLIElement>` and cast the spread handlers.

## Changes

- Made `ActionMenuTriggerProps`, `ActionMenuTriggerFunction`, and `ActionMenuProps` generic over the trigger element type `E extends HTMLElement`, defaulting to `HTMLButtonElement` so existing usage is unchanged.
- The documented `TopBar`/`MenuBar` nesting is now expressible without casts via `ActionMenu<HTMLLIElement>`; the common button case is untouched.
- The component's internal implementation is unchanged — the generic is exposed purely through the public type of the exported component (a cast on the `forwardRef` result), keeping the change additive and low-risk.
- Updated the TopBar-pattern test to use `ActionMenu<HTMLLIElement>` and dropped the `@ts-expect-error`/cast it previously required (now a regression guard).
- Updated the ActionMenu props docs to reflect the parameterized trigger type.

## Verification

- `tsc --noEmit` — clean
- ESLint — clean
- Prettier — clean
- ActionMenu test suite — 46/46 pass

## Related

Surfaces alongside #2448 when wrapping `TopBarItem` in an `ActionMenu` trigger.