### PR TITLE
chore: format mdx/yaml files in lint-staged pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{json,css,md}": [
+    "*.{json,css,md,mdx,yml,yaml}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
## Description

The `lint-staged` prettier glob covered `md` but not `mdx`, `yml`, or `yaml`. Staged files with those extensions skipped local formatting entirely and only failed later at CI's `prettier --check .` — as just happened on #2460, where a `.mdx` doc edit passed the pre-commit hook but failed the Lint job.

Widened the glob to `*.{json,css,md,mdx,yml,yaml}` so those file types are formatted at commit time, matching what CI checks.

## Notes

Kept the existing non-overlapping glob structure (rather than a `"*": prettier --ignore-unknown` catch-all) to avoid running prettier concurrently with `eslint --fix` on the same `.ts`/`.tsx` files.