### PR TITLE
feat(react): tree-shakeable dual CJS/ESM build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,9 +24,15 @@ const config: StorybookConfig = {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-      '@deque/cauldron-react': path.resolve(
+      // Consume the built ESM output. `$` matches the bare barrel import only,
+      // so the `/cauldron.css` short-form falls through to its own alias.
+      '@deque/cauldron-react$': path.resolve(
         process.cwd(),
-        'packages/react/lib'
+        'packages/react/lib/esm/index.js'
+      ),
+      '@deque/cauldron-react/cauldron.css': path.resolve(
+        process.cwd(),
+        'packages/react/lib/cauldron.css'
       ),
       react: path.resolve(process.cwd(), 'node_modules/react'),
       'react-dom': path.resolve(process.cwd(), 'node_modules/react-dom')

--- a/docs/index.js
+++ b/docs/index.js
@@ -36,7 +36,7 @@ import '@fontsource/pt-mono';
 import '../packages/styles';
 import '@deque/cauldron-react/cauldron.css';
 import './index.css';
-import { useThemeContext } from '../packages/react/lib';
+import { useThemeContext } from '@deque/cauldron-react';
 
 const CAULDRON_THEME_STORAGE_KEY = 'cauldron_theme';
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,16 +7,17 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
   "style": "lib/cauldron.css",
-  "types": "lib/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
     "build": "pnpm build:lib && pnpm build:css",
     "prebuild:lib": "node scripts/buildIconTypes.js",
-    "build:lib": "rollup -c",
+    "build:lib": "rimraf lib && rollup -c",
     "build:css": "postcss --output=lib/cauldron.css src/index.css",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "verify:packaging": "pnpm build && node scripts/verifyPackaging.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,11 +7,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "lib/cjs/index.js",
+  "main": "lib/index.js",
   "module": "lib/esm/index.js",
   "style": "lib/cauldron.css",
-  "types": "lib/cjs/index.d.ts",
-  "sideEffects": false,
+  "types": "lib/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     "lib/"
   ],
@@ -32,6 +34,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.0.0",
     "@floating-ui/react-dom": "^2.1.2",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "classnames": "^2.2.6",
     "focusable": "^2.3.0",
     "keyname": "^0.1.0",
@@ -62,7 +65,6 @@
     "@types/node": "^17.0.42",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/react-syntax-highlighter": "^15.5.13",
     "@types/sinon": "^10",
     "autoprefixer": "^10.5.0",
     "babel-plugin-module-resolver": "^5.0.3",
@@ -80,6 +82,7 @@
     "publint": "^0.3.21",
     "react": "^19",
     "react-dom": "^19",
+    "rimraf": "^6.1.3",
     "rollup": "^2.23.0",
     "sinon": "^10.0.0",
     "ts-node": "^10.9.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,6 +11,7 @@
   "module": "lib/esm/index.js",
   "style": "lib/cauldron.css",
   "types": "lib/cjs/index.d.ts",
+  "sideEffects": false,
   "files": [
     "lib/"
   ],

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -42,30 +42,40 @@ const svgrOptions = {
 };
 
 /**
- * Writes a `package.json` into an output directory whose only job is to mark
- * the module kind of the emitted `.js` files (e.g. `{"type": "module"}` for the
- * ESM output). This lets us keep plain `.js` extensions in both builds while
- * Node still resolves each one as the correct module system.
+ * Writes `{"type": "module"}` into the ESM output directory so Node reads its
+ * plain `.js` files as ESM. Only the ESM build needs this: the package declares
+ * no top-level `type`, so `.js` already means CommonJS everywhere else.
+ *
+ * It also re-declares `sideEffects: false`. Bundlers read that flag from the
+ * `package.json` *nearest* the module, so this marker would otherwise shadow the
+ * root manifest and every emitted ESM module would fall back to "assumed to have
+ * side effects" — defeating the tree-shaking configured below.
  */
-function emitTypeMarker(type) {
+function emitEsmTypeMarker() {
   return {
-    name: 'emit-type-marker',
+    name: 'emit-esm-type-marker',
     generateBundle() {
       this.emitFile({
         type: 'asset',
         fileName: 'package.json',
-        source: `${JSON.stringify({ type }, null, 2)}\n`
+        source: `${JSON.stringify(
+          { type: 'module', sideEffects: false },
+          null,
+          2
+        )}\n`
       });
     }
   };
 }
 
 /**
- * Each build compiles from source independently so that its `.d.ts` files land
- * beside its `.js` files and are interpreted with the matching module kind —
- * this keeps `@arethetypeswrong/cli` happy (no types/runtime "masquerading").
+ * Each build compiles from source independently so its output matches the module
+ * kind it declares. Declarations are emitted only once, by the CJS build — see
+ * the `declaration` option below.
  */
-function build({ format, dir, type }) {
+function build({ format, dir }) {
+  const isEsm = format === 'es';
+
   return {
     input: 'src/index.ts',
     external,
@@ -77,7 +87,8 @@ function build({ format, dir, type }) {
       exports: 'named',
       // Preserve the source module graph (one output file per source module,
       // mirroring src/) instead of bundling everything into index.js. Combined
-      // with "sideEffects": false, this is what lets a consumer's bundler drop
+      // with `sideEffects` (the root manifest for the CJS tree, the emitted
+      // marker for the ESM tree), this is what lets a consumer's bundler drop
       // unused components — e.g. a Button-only import excludes Code and its
       // react-syntax-highlighter dependency.
       preserveModules: true,
@@ -87,8 +98,13 @@ function build({ format, dir, type }) {
     plugins: [
       typescript({
         tsconfig: './tsconfig.json',
-        declaration: true,
-        declarationDir: dir,
+        // Only the CJS build emits declarations. `types` points at that one tree
+        // and nothing exposes `lib/esm` to a type resolver, so a second copy
+        // would be both unreachable and invalid where it sat: its relative
+        // specifiers are extensionless, which is a TS2835 error for a directory
+        // marked `{"type": "module"}` under `moduleResolution` node16/nodenext.
+        declaration: !isEsm,
+        ...(isEsm ? {} : { declarationDir: dir }),
         exclude: [
           '**.test.ts',
           '**.test.tsx',
@@ -101,12 +117,18 @@ function build({ format, dir, type }) {
       commonjs(),
       svgr(svgrOptions),
       dynamicImportVar(),
-      emitTypeMarker(type)
+      // CJS gets no marker on purpose: one at `lib/` would shadow the root
+      // manifest's `sideEffects`, and a consumer's bundler could then drop
+      // `lib/cauldron.css`.
+      ...(isEsm ? [emitEsmTypeMarker()] : [])
     ]
   };
 }
 
+// The CJS build keeps the historical `lib/` layout so published deep paths
+// (`@deque/cauldron-react/lib/components/<Name>` and `/lib/types`, which
+// consumers import types from) keep resolving; the ESM build nests under it.
 export default [
-  build({ format: 'cjs', dir: 'lib/cjs', type: 'commonjs' }),
-  build({ format: 'es', dir: 'lib/esm', type: 'module' })
+  build({ format: 'cjs', dir: 'lib' }),
+  build({ format: 'es', dir: 'lib/esm' })
 ];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -4,62 +4,100 @@ import pkg from './package.json';
 import svgr from '@svgr/rollup';
 import dynamicImportVar from '@rollup/plugin-dynamic-import-vars';
 
-export default {
-  input: 'src/index.ts',
-  external: [
-    ...Object.keys(pkg.dependencies),
-    ...Object.keys(pkg.peerDependencies),
-    // Note: We directly import only the specific language syntax needed
-    // directly in the Code component. This ensures it is still treated as
-    // an external dependency since it won't match the dependencies or
-    // peerDependencies when pulled from package.json.
-    /^react-syntax-highlighter/
-  ],
-  output: {
-    dir: 'lib',
-    format: 'cjs',
-    exports: 'auto',
-    chunkFileNames: '[name].js'
-  },
-  plugins: [
-    typescript({
-      tsconfig: './tsconfig.json',
-      exclude: [
-        '**.test.ts',
-        '**.test.tsx',
-        '**.figma.tsx',
-        '**.stories.tsx',
-        './src/setupTests.ts',
-        './src/axe.ts'
-      ]
-    }),
-    commonjs(),
-    svgr({
-      svgoConfig: {
-        plugins: [
-          {
-            name: 'preset-default',
-            params: {
-              overrides: {
-                removeViewBox: false
-              }
-            }
-          },
-          {
-            name: 'removeDimensions',
-            params: {
-              active: true
-            }
-          },
-          {
-            name: 'addAttributesToSVGElement',
-            params: {
-              attributes: [{ height: 24 }, { width: 24 }]
-            }
+const external = [
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.peerDependencies),
+  // Note: We directly import only the specific language syntax needed
+  // directly in the Code component. This ensures it is still treated as
+  // an external dependency since it won't match the dependencies or
+  // peerDependencies when pulled from package.json.
+  /^react-syntax-highlighter/
+];
+
+const svgrOptions = {
+  svgoConfig: {
+    plugins: [
+      {
+        name: 'preset-default',
+        params: {
+          overrides: {
+            removeViewBox: false
           }
-        ]
+        }
+      },
+      {
+        name: 'removeDimensions',
+        params: {
+          active: true
+        }
+      },
+      {
+        name: 'addAttributesToSVGElement',
+        params: {
+          attributes: [{ height: 24 }, { width: 24 }]
+        }
       }
-    }),
-    dynamicImportVar()
-  ]
+    ]
+  }
 };
+
+/**
+ * Writes a `package.json` into an output directory whose only job is to mark
+ * the module kind of the emitted `.js` files (e.g. `{"type": "module"}` for the
+ * ESM output). This lets us keep plain `.js` extensions in both builds while
+ * Node still resolves each one as the correct module system.
+ */
+function emitTypeMarker(type) {
+  return {
+    name: 'emit-type-marker',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'package.json',
+        source: `${JSON.stringify({ type }, null, 2)}\n`
+      });
+    }
+  };
+}
+
+/**
+ * Each build compiles from source independently so that its `.d.ts` files land
+ * beside its `.js` files and are interpreted with the matching module kind —
+ * this keeps `@arethetypeswrong/cli` happy (no types/runtime "masquerading").
+ */
+function build({ format, dir, type }) {
+  return {
+    input: 'src/index.ts',
+    external,
+    output: {
+      dir,
+      format,
+      exports: 'auto',
+      chunkFileNames: '[name].js'
+    },
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: dir,
+        exclude: [
+          '**.test.ts',
+          '**.test.tsx',
+          '**.figma.tsx',
+          '**.stories.tsx',
+          './src/setupTests.ts',
+          './src/axe.ts'
+        ]
+      }),
+      commonjs(),
+      svgr(svgrOptions),
+      dynamicImportVar(),
+      emitTypeMarker(type)
+    ]
+  };
+}
+
+export default [
+  build({ format: 'cjs', dir: 'lib/cjs', type: 'commonjs' }),
+  build({ format: 'es', dir: 'lib/esm', type: 'module' })
+];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -72,8 +72,17 @@ function build({ format, dir, type }) {
     output: {
       dir,
       format,
-      exports: 'auto',
-      chunkFileNames: '[name].js'
+      // The public entry is the named-export barrel; per-module files expose
+      // their component as the `default` export (with `__esModule`) for interop.
+      exports: 'named',
+      // Preserve the source module graph (one output file per source module,
+      // mirroring src/) instead of bundling everything into index.js. Combined
+      // with "sideEffects": false, this is what lets a consumer's bundler drop
+      // unused components — e.g. a Button-only import excludes Code and its
+      // react-syntax-highlighter dependency.
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames: '[name].js'
     },
     plugins: [
       typescript({

--- a/packages/react/scripts/packaging-smoke/esm-output.mjs
+++ b/packages/react/scripts/packaging-smoke/esm-output.mjs
@@ -1,0 +1,68 @@
+// Exercises the ESM build specifically.
+//
+// `smoke.mjs` imports the bare specifier, which Node resolves through `main` to
+// the CJS tree at `lib/` — it never loads lib/esm, because Node does not read
+// the `module` field. So the ESM half of the dual build has no executing
+// coverage unless we import it by path, which is what this fixture does.
+//
+// Two failure modes it catches, both of which shipped on this branch before
+// being fixed:
+//   * A `default` import of an `__esModule`-shipping CJS dependency left
+//     un-unwrapped. Under strict ESM the value is the wrapper, so Code's
+//     module-scope `SyntaxHighlighter.registerLanguage(...)` throws at import
+//     time and takes the whole barrel down.
+//   * The same omission on `react-id-generator`, which throws at *render* time
+//     ("nextId is not a function") rather than import time — so importing the
+//     barrel is not enough, the components have to actually render.
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const require = createRequire(import.meta.url);
+const esmEntry = require.resolve('@deque/cauldron-react/lib/esm/index.js');
+
+// Importing the barrel runs Code's module-scope registerLanguage calls.
+const lib = await import(esmEntry);
+
+for (const name of ['Button', 'Code', 'Checkbox', 'TreeView', 'ThemeContext']) {
+  assert(lib[name], `esm: expected \`${name}\` named export from lib/esm`);
+}
+
+const { Code, Checkbox, TreeView } = lib;
+
+// Code: exercises the unwrapped react-syntax-highlighter default at render.
+const codeMarkup = renderToStaticMarkup(
+  React.createElement(Code, { language: 'javascript' }, 'const a = 1;')
+);
+assert(
+  codeMarkup.includes('const') && codeMarkup.includes('<pre'),
+  `esm: Code rendered no highlighted <pre> (got: ${codeMarkup.slice(0, 120)})`
+);
+
+// Checkbox: exercises the unwrapped react-id-generator default at render.
+const checkboxMarkup = renderToStaticMarkup(
+  React.createElement(Checkbox, { id: 'esm-checkbox', label: 'Accept' })
+);
+assert(
+  checkboxMarkup.includes('esm-checkbox'),
+  'esm: Checkbox did not render its input'
+);
+
+// TreeView with multiple selection renders TreeViewItem, the second
+// react-id-generator call site, which mints its own checkbox id.
+const treeMarkup = renderToStaticMarkup(
+  React.createElement(TreeView, {
+    'aria-label': 'Files',
+    selectionMode: 'multiple',
+    items: [{ id: 'root', textValue: 'Root' }]
+  })
+);
+assert(
+  treeMarkup.includes('Root'),
+  'esm: TreeView did not render its item text'
+);
+
+console.log(
+  'esm-output OK: lib/esm imports and renders interop-sensitive components'
+);

--- a/packages/react/scripts/packaging-smoke/single-copy.mjs
+++ b/packages/react/scripts/packaging-smoke/single-copy.mjs
@@ -1,0 +1,27 @@
+// Single-copy / dual-package-hazard guard.
+//
+// A consumer must resolve ONE copy of the package: `import` and `require` of the
+// specifier have to yield the same React context object. If a future change
+// (e.g. an `exports` map that splits `import`→ESM and `require`→CJS) makes them
+// differ, a runtime that mixes both would load two copies — and a <ThemeProvider>
+// from one copy would silently fail to reach consumers using the other.
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import * as imported from '@deque/cauldron-react';
+
+const require = createRequire(import.meta.url);
+const required = require('@deque/cauldron-react');
+
+const importedContext = imported.ThemeContext ?? imported.default?.ThemeContext;
+
+assert(importedContext, 'import: expected `ThemeContext` export');
+assert(required.ThemeContext, 'require: expected `ThemeContext` export');
+assert.strictEqual(
+  required.ThemeContext,
+  importedContext,
+  'Dual-package hazard: `import` and `require` resolved DIFFERENT copies of ' +
+    '@deque/cauldron-react (context identities differ), which would break ' +
+    'providers/compound components across the split.'
+);
+
+console.log('single-copy OK: import and require share one copy');

--- a/packages/react/scripts/packaging-smoke/treeshake.entry.js
+++ b/packages/react/scripts/packaging-smoke/treeshake.entry.js
@@ -1,0 +1,7 @@
+// Tree-shaking fixture: import ONLY Button. If the package is tree-shakeable,
+// a production bundler must drop Code, react-syntax-highlighter,
+// react-aria-components, and every other component from the output.
+import { Button } from '@deque/cauldron-react';
+
+// Reference it so it isn't dead-code-eliminated as an unused import.
+export default Button;

--- a/packages/react/scripts/packaging-smoke/treeshake.vite.config.js
+++ b/packages/react/scripts/packaging-smoke/treeshake.vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+
+// Bundle the Button-only entry as a library so we can inspect exactly what a
+// consumer's production bundler (Vite delegates to Rollup) keeps after
+// tree-shaking. Unminified so the assertion can match readable module paths.
+export default defineConfig({
+  build: {
+    minify: false,
+    lib: {
+      entry: 'treeshake.entry.js',
+      formats: ['es'],
+      fileName: 'treeshake.out'
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime']
+    }
+  }
+});

--- a/packages/react/scripts/packaging-smoke/webpack-checks.cjs
+++ b/packages/react/scripts/packaging-smoke/webpack-checks.cjs
@@ -1,0 +1,236 @@
+/**
+ * webpack-side packaging checks, run inside the throwaway consumer.
+ *
+ * The Vite tree-shake step cannot see three properties that only break under
+ * webpack's resolution rules, and each of them regressed in real life:
+ *
+ *   1. Stylesheet retention. webpack's production `sideEffects` pass will drop a
+ *      bindingless CSS import from a package whose nearest `package.json` says
+ *      `sideEffects: false`. Vite never sees this — the fixture imports no CSS.
+ *   2. Tree-shaking. webpack reads `sideEffects` from the `package.json` NEAREST
+ *      the module, so a nested marker file shadows the root manifest; Rollup (and
+ *      therefore Vite) reads it from the resolved package's manifest instead and
+ *      stays green either way.
+ *   3. Single copy. `single-copy.mjs` compares `import` vs `require` under Node,
+ *      where `module` is ignored and both land on `main` — so it cannot fail
+ *      today. A bundler picks entries differently, and that is the resolution
+ *      path real consumers actually use.
+ *
+ * Usage: node webpack-checks.cjs <workspace-node-modules> <forbidden-json>
+ *
+ * webpack and its loaders come from the workspace rather than a fresh install:
+ * they are tools, not the artifact under test, so borrowing the version the repo
+ * already pins keeps this step off the network and in lockstep with the docs and
+ * Storybook builds. The package under test still comes from the tarball, which
+ * is what this harness exists to validate — consumer `node_modules` is first in
+ * `resolve.modules` so the tarball copy always wins over any workspace copy.
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const [workspaceModules, forbiddenJson] = process.argv.slice(2);
+
+assert(
+  workspaceModules,
+  'usage: webpack-checks.cjs <workspace-node-modules> <forbidden-json>'
+);
+const forbidden = JSON.parse(forbiddenJson);
+
+const webpack = require(path.join(workspaceModules, 'webpack'));
+const MiniCssExtractPlugin = require(
+  path.join(workspaceModules, 'mini-css-extract-plugin')
+);
+
+const consumer = process.cwd();
+const work = path.join(consumer, 'webpack-checks');
+fs.rmSync(work, { recursive: true, force: true });
+fs.mkdirSync(work, { recursive: true });
+
+const write = (name, source) => {
+  const file = path.join(work, name);
+  fs.writeFileSync(file, source);
+  return file;
+};
+
+function compile(name, entry, extra = {}) {
+  const { resolve: resolveExtra = {}, ...config } = extra;
+  const outDir = path.join(work, 'out', name);
+
+  return new Promise((resolvePromise, reject) => {
+    webpack(
+      {
+        mode: 'production',
+        entry,
+        output: { path: outDir, filename: 'bundle.js' },
+        resolve: {
+          // Consumer first: the tarball copy must win over any workspace copy.
+          // The trailing relative 'node_modules' keeps webpack's default
+          // parent-directory walk-up, without which a dependency nested inside
+          // another package's node_modules (as pnpm lays them out) is unresolvable.
+          modules: [
+            path.join(consumer, 'node_modules'),
+            workspaceModules,
+            'node_modules'
+          ],
+          ...resolveExtra
+        },
+        resolveLoader: { modules: [workspaceModules] },
+        externals: {
+          react: 'commonjs react',
+          'react-dom': 'commonjs react-dom',
+          'react/jsx-runtime': 'commonjs react/jsx-runtime'
+        },
+        ...config
+      },
+      (err, stats) => {
+        if (err) return reject(err);
+        if (stats.hasErrors()) {
+          return reject(new Error(stats.toString({ errors: true })));
+        }
+        resolvePromise(outDir);
+      }
+    );
+  });
+}
+
+const readAll = (dir, ext) =>
+  fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(ext))
+    .map((file) => fs.readFileSync(path.join(dir, file), 'utf8'))
+    .join('\n');
+
+async function checkStylesheetSurvives() {
+  const installedCss = path.join(
+    consumer,
+    'node_modules/@deque/cauldron-react/lib/cauldron.css'
+  );
+  const source = fs.readFileSync(installedCss, 'utf8');
+
+  // Derive the probe selector from the stylesheet itself rather than hardcoding
+  // one, so this assertion cannot drift out of sync with the published CSS.
+  const selector = source.match(/\.([A-Za-z][\w-]{4,})/)?.[1];
+  assert(selector, `Could not find a class selector in ${installedCss}`);
+
+  const entry = write(
+    'css-entry.js',
+    "import '@deque/cauldron-react/lib/cauldron.css';\n"
+  );
+  const outDir = await compile('css', entry, {
+    module: {
+      rules: [
+        { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+      ]
+    },
+    plugins: [new MiniCssExtractPlugin({ filename: 'styles.css' })]
+  });
+
+  const emitted = readAll(outDir, '.css');
+  assert(
+    emitted.length > 0,
+    'webpack emitted no CSS at all: the published stylesheet was dropped from a ' +
+      'production build. A blanket `sideEffects: false` on this package does ' +
+      'exactly this — scope it to `["**/*.css"]`.'
+  );
+  assert(
+    emitted.includes(selector),
+    `Published stylesheet was pruned: selector .${selector} is in lib/cauldron.css ` +
+      'but absent from the webpack production build.'
+  );
+  console.log(
+    `  stylesheet OK: ${emitted.length} bytes emitted, .${selector} retained`
+  );
+}
+
+async function checkTreeShaking() {
+  const entry = write(
+    'treeshake-entry.js',
+    "import { Button } from '@deque/cauldron-react';\n" +
+      'if (!Button) throw new Error("Button missing");\n'
+  );
+  // mainFields mirrors a real bundler consumer: prefer the ESM build.
+  const outDir = await compile('treeshake', entry, {
+    resolve: { mainFields: ['module', 'main'] }
+  });
+
+  const bundle = readAll(outDir, '.js');
+  assert(bundle.length > 0, 'webpack emitted no JS for the tree-shake fixture');
+
+  const leaked = forbidden.filter((marker) => bundle.includes(marker));
+  assert.deepStrictEqual(
+    leaked,
+    [],
+    `Tree-shaking regressed under webpack: a Button-only bundle still contains ${leaked.join(
+      ', '
+    )}. webpack resolves \`sideEffects\` from the package.json nearest each ` +
+      "module, so check that every emitted output directory's marker carries " +
+      '`sideEffects: false`.'
+  );
+  console.log(
+    `  tree-shaking OK: ${bundle.length} bytes, none of [${forbidden.join(
+      ', '
+    )}]`
+  );
+}
+
+async function checkSingleCopy() {
+  write(
+    'copy-esm.mjs',
+    "import { ThemeContext } from '@deque/cauldron-react';\n" +
+      'export const ctx = ThemeContext;\n'
+  );
+  write(
+    'copy-cjs.cjs',
+    "const lib = require('@deque/cauldron-react');\n" +
+      'module.exports = { ctx: lib.ThemeContext };\n'
+  );
+  const entry = write(
+    'copy-entry.js',
+    "import { ctx as viaImport } from './copy-esm.mjs';\n" +
+      "const { ctx: viaRequire } = require('./copy-cjs.cjs');\n" +
+      "if (!viaImport) throw new Error('import: no ThemeContext');\n" +
+      "if (!viaRequire) throw new Error('require: no ThemeContext');\n" +
+      'console.log(viaImport === viaRequire ? "SAME" : "SPLIT");\n'
+  );
+
+  const outDir = await compile('single-copy', entry, {
+    mode: 'development',
+    devtool: false,
+    target: 'node'
+  });
+
+  const bundle = readAll(outDir, '.js');
+  const trees = {
+    esm: /cauldron-react\/lib\/esm\//.test(bundle),
+    cjs: /cauldron-react\/lib\/(?!esm\/)/.test(bundle)
+  };
+
+  const result = execFileSync('node', [path.join(outDir, 'bundle.js')], {
+    encoding: 'utf8'
+  }).trim();
+
+  assert.strictEqual(
+    result,
+    'SAME',
+    'Dual-package hazard under a bundler: a graph mixing `import` and ' +
+      '`require` loaded TWO copies of @deque/cauldron-react (ThemeContext ' +
+      `identities differ; trees loaded: esm=${trees.esm} cjs=${trees.cjs}). A ` +
+      'ThemeProvider from one copy cannot reach consumers of the other, and ' +
+      'compound components break across the split.'
+  );
+  console.log(
+    `  single copy OK: one copy in a mixed import/require graph (esm=${trees.esm} cjs=${trees.cjs})`
+  );
+}
+
+(async () => {
+  await checkStylesheetSurvives();
+  await checkTreeShaking();
+  await checkSingleCopy();
+  console.log('webpack-checks OK');
+})().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/packages/react/scripts/verifyPackaging.js
+++ b/packages/react/scripts/verifyPackaging.js
@@ -8,8 +8,11 @@
  *   3. `attw`     — check that types resolve for every module condition.
  *   4. Smoke test — install the tarball into a throwaway consumer and confirm
  *      it resolves under both `require(...)` and native `import`.
+ *   5. Tree-shaking — bundle a Button-only consumer with Vite (Rollup) and
+ *      assert the unused component graph (Code, react-syntax-highlighter,
+ *      react-aria-components) is dropped.
  *
- * The smoke consumer installs from the tarball (not a workspace symlink), so
+ * The consumers install from the tarball (not a workspace symlink), so
  * resolution matches what a real consumer would get from npm.
  *
  * Prerequisite: `lib/` must already be built (`pnpm build`). Run via the
@@ -123,6 +126,72 @@ try {
       `Published stylesheet missing or empty: ${installedStylesheet}`
     );
   }
+  step('Verifying tree-shaking (Button-only import drops unused components)');
+  const treeshakeDir = path.join(workDir, 'treeshake');
+  fs.mkdirSync(treeshakeDir);
+  fs.writeFileSync(
+    path.join(treeshakeDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'cauldron-treeshake',
+        version: '0.0.0',
+        private: true,
+        type: 'module'
+      },
+      null,
+      2
+    )
+  );
+  fs.copyFileSync(
+    path.join(smokeFixtures, 'treeshake.entry.js'),
+    path.join(treeshakeDir, 'treeshake.entry.js')
+  );
+  fs.copyFileSync(
+    path.join(smokeFixtures, 'treeshake.vite.config.js'),
+    path.join(treeshakeDir, 'vite.config.js')
+  );
+  run(
+    'npm',
+    [
+      'install',
+      tarball,
+      'react@^19',
+      'react-dom@^19',
+      'vite@^7',
+      '--no-audit',
+      '--no-fund',
+      '--no-package-lock'
+    ],
+    { cwd: treeshakeDir }
+  );
+  run('npx', ['vite', 'build'], { cwd: treeshakeDir });
+
+  // A Button-only bundle must not contain any of these — their presence means
+  // an unused component (and its heavy deps) failed to tree-shake.
+  const forbidden = [
+    'react-syntax-highlighter',
+    'react-aria',
+    'registerLanguage',
+    'hljs',
+    'lowlight'
+  ];
+  const outDir = path.join(treeshakeDir, 'dist');
+  const bundle = fs
+    .readdirSync(outDir)
+    .filter((file) => file.endsWith('.js'))
+    .map((file) => fs.readFileSync(path.join(outDir, file), 'utf8'))
+    .join('\n');
+  const leaked = forbidden.filter((marker) => bundle.includes(marker));
+  if (leaked.length > 0) {
+    throw new Error(
+      `Tree-shaking regressed: a Button-only bundle still contains ${leaked.join(
+        ', '
+      )}.`
+    );
+  }
+  console.log(
+    `Tree-shaking OK: Button-only bundle excludes ${forbidden.join(', ')}`
+  );
 
   console.log('\n✓ Packaging validation passed');
 } finally {

--- a/packages/react/scripts/verifyPackaging.js
+++ b/packages/react/scripts/verifyPackaging.js
@@ -33,9 +33,9 @@ function run(command, args, options = {}) {
   execFileSync(command, args, { stdio: 'inherit', ...options });
 }
 
-if (!fs.existsSync(path.join(libDir, 'index.js'))) {
+if (!fs.existsSync(path.join(libDir, 'cjs', 'index.js'))) {
   console.error(
-    'Missing build output at lib/index.js. Run `pnpm build` before verifying packaging.'
+    'Missing build output at lib/cjs/index.js. Run `pnpm build` before verifying packaging.'
   );
   process.exit(1);
 }

--- a/packages/react/scripts/verifyPackaging.js
+++ b/packages/react/scripts/verifyPackaging.js
@@ -8,7 +8,9 @@
  *   3. `attw`     — check that types resolve for every module condition.
  *   4. Smoke test — install the tarball into a throwaway consumer and confirm
  *      it resolves under both `require(...)` and native `import`.
- *   5. Tree-shaking — bundle a Button-only consumer with Vite (Rollup) and
+ *   5. Single-copy guard — assert `import` and `require` of the specifier yield
+ *      the same context object (no dual-package hazard from split resolution).
+ *   6. Tree-shaking — bundle a Button-only consumer with Vite (Rollup) and
  *      assert the unused component graph (Code, react-syntax-highlighter,
  *      react-aria-components) is dropped.
  *
@@ -84,6 +86,10 @@ try {
     path.join(smokeFixtures, 'smoke.mjs'),
     path.join(consumerDir, 'smoke.mjs')
   );
+  fs.copyFileSync(
+    path.join(smokeFixtures, 'single-copy.mjs'),
+    path.join(consumerDir, 'single-copy.mjs')
+  );
 
   // Install with npm into an isolated dir so resolution is hermetic and does
   // not touch the pnpm workspace. react/react-dom satisfy the peer range.
@@ -126,6 +132,9 @@ try {
       `Published stylesheet missing or empty: ${installedStylesheet}`
     );
   }
+  step('Verifying a single copy resolves (dual-package-hazard guard)');
+  run('node', ['single-copy.mjs'], { cwd: consumerDir });
+
   step('Verifying tree-shaking (Button-only import drops unused components)');
   const treeshakeDir = path.join(workDir, 'treeshake');
   fs.mkdirSync(treeshakeDir);

--- a/packages/react/scripts/verifyPackaging.js
+++ b/packages/react/scripts/verifyPackaging.js
@@ -8,9 +8,17 @@
  *   3. `attw`     — check that types resolve for every module condition.
  *   4. Smoke test — install the tarball into a throwaway consumer and confirm
  *      it resolves under both `require(...)` and native `import`.
- *   5. Single-copy guard — assert `import` and `require` of the specifier yield
+ *   5. Stylesheet — assert the published `lib/cauldron.css` survived the install.
+ *   6. Single-copy guard — assert `import` and `require` of the specifier yield
  *      the same context object (no dual-package hazard from split resolution).
- *   6. Tree-shaking — bundle a Button-only consumer with Vite (Rollup) and
+ *   7. ESM build — import `lib/esm` by path (Node resolves the bare specifier
+ *      through `main` to the CJS tree at `lib/`, so no other step covers it) and
+ *      render the components whose CJS-default interop only breaks under ESM.
+ *   8. webpack consumer — bundle with webpack and assert the three properties
+ *      only it can falsify: the published stylesheet survives a production
+ *      build, tree-shaking holds under its nearest-package.json `sideEffects`
+ *      lookup, and a mixed `import`/`require` graph loads a single copy.
+ *   9. Tree-shaking — bundle a Button-only consumer with Vite (Rollup) and
  *      assert the unused component graph (Code, react-syntax-highlighter,
  *      react-aria-components) is dropped.
  *
@@ -28,6 +36,20 @@ const path = require('node:path');
 const packageRoot = path.join(__dirname, '..');
 const smokeFixtures = path.join(__dirname, 'packaging-smoke');
 const libDir = path.join(packageRoot, 'lib');
+const workspaceModules = path.join(packageRoot, '..', '..', 'node_modules');
+
+// A Button-only bundle must not contain any of these — their presence means an
+// unused component (and its heavy deps) failed to tree-shake. Asserted against
+// both bundlers: Vite/Rollup below, and webpack via webpack-checks.cjs, which
+// resolves `sideEffects` differently and is the only one that sees a nested
+// marker file shadow the root manifest.
+const forbidden = [
+  'react-syntax-highlighter',
+  'react-aria',
+  'registerLanguage',
+  'hljs',
+  'lowlight'
+];
 
 function step(message) {
   console.log(`\n› ${message}`);
@@ -38,9 +60,9 @@ function run(command, args, options = {}) {
   execFileSync(command, args, { stdio: 'inherit', ...options });
 }
 
-if (!fs.existsSync(path.join(libDir, 'cjs', 'index.js'))) {
+if (!fs.existsSync(path.join(libDir, 'index.js'))) {
   console.error(
-    'Missing build output at lib/cjs/index.js. Run `pnpm build` before verifying packaging.'
+    'Missing build output at lib/index.js. Run `pnpm build` before verifying packaging.'
   );
   process.exit(1);
 }
@@ -90,6 +112,10 @@ try {
     path.join(smokeFixtures, 'single-copy.mjs'),
     path.join(consumerDir, 'single-copy.mjs')
   );
+  fs.copyFileSync(
+    path.join(smokeFixtures, 'esm-output.mjs'),
+    path.join(consumerDir, 'esm-output.mjs')
+  );
 
   // Install with npm into an isolated dir so resolution is hermetic and does
   // not touch the pnpm workspace. react/react-dom satisfy the peer range.
@@ -135,6 +161,26 @@ try {
   step('Verifying a single copy resolves (dual-package-hazard guard)');
   run('node', ['single-copy.mjs'], { cwd: consumerDir });
 
+  // Node resolves the bare specifier through `main` to the CJS tree at `lib/`,
+  // so the steps above never load lib/esm. Import it by path and render the
+  // components whose CJS-default interop only breaks under strict ESM.
+  step('Verifying the ESM build imports and renders (lib/esm)');
+  run('node', ['esm-output.mjs'], { cwd: consumerDir });
+
+  // Everything above is Node-only, and the Vite step below cannot observe
+  // webpack's nearest-package.json `sideEffects` lookup or its entry selection.
+  // These three assertions cover the properties only webpack can falsify.
+  step('Verifying webpack consumer (stylesheet, tree-shaking, single copy)');
+  fs.copyFileSync(
+    path.join(smokeFixtures, 'webpack-checks.cjs'),
+    path.join(consumerDir, 'webpack-checks.cjs')
+  );
+  run(
+    'node',
+    ['webpack-checks.cjs', workspaceModules, JSON.stringify(forbidden)],
+    { cwd: consumerDir }
+  );
+
   step('Verifying tree-shaking (Button-only import drops unused components)');
   const treeshakeDir = path.join(workDir, 'treeshake');
   fs.mkdirSync(treeshakeDir);
@@ -175,15 +221,6 @@ try {
   );
   run('npx', ['vite', 'build'], { cwd: treeshakeDir });
 
-  // A Button-only bundle must not contain any of these — their presence means
-  // an unused component (and its heavy deps) failed to tree-shake.
-  const forbidden = [
-    'react-syntax-highlighter',
-    'react-aria',
-    'registerLanguage',
-    'hljs',
-    'lowlight'
-  ];
   const outDir = path.join(treeshakeDir, 'dist');
   const bundle = fs
     .readdirSync(outDir)

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -7,9 +7,14 @@ import React, {
   useMemo
 } from 'react';
 import classNames from 'classnames';
-import nextId from 'react-id-generator';
+import nextIdImport from 'react-id-generator';
 import Icon, { type IconType } from '../Icon';
 import { addIdRef } from '../../utils/idRefs';
+import interopDefault from '../../utils/interopDefault';
+
+// react-id-generator ships `__esModule`; unwrap its double-wrapped default so
+// `nextId(...)` works under strict ESM (see interopDefault).
+const nextId = interopDefault(nextIdImport);
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,11 +1,17 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
-import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
+// Fully-specified (`.js`) cjs subpaths: react-syntax-highlighter has no
+// `exports` map, so the ESM build's `{"type":"module"}` marker makes strict
+// bundlers (webpack 5) resolve these fully-specified — an extensionless
+// specifier fails there. The cjs paths (not esm) are kept deliberately: they
+// resolve under Node `require`, Node ESM interop, and bundlers alike, whereas
+// the esm subpaths are bare ESM in a non-module package and break under Node.
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light.js';
 import classNames from 'classnames';
-import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript';
-import css from 'react-syntax-highlighter/dist/cjs/languages/hljs/css';
-import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml';
-import yaml from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml';
+import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript.js';
+import css from 'react-syntax-highlighter/dist/cjs/languages/hljs/css.js';
+import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml.js';
+import yaml from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml.js';
 import type { ContentNode } from '../../types';
 import { useId } from 'react-id-generator';
 import CopyButton, { CopyButtonProps } from '../CopyButton';

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -15,19 +15,10 @@ import yamlImport from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml.js
 import type { ContentNode } from '../../types';
 import { useId } from 'react-id-generator';
 import CopyButton, { CopyButtonProps } from '../CopyButton';
+import interopDefault from '../../utils/interopDefault';
 
-// Normalize a CommonJS default export. Under strict ESM (Next.js SSR, webpack,
-// Node-native) a CJS module that sets `__esModule` is delivered double-wrapped
-// (`{ __esModule, default }`), so the default import is the wrapper rather than
-// the value — without this, `SyntaxHighlighter.registerLanguage` is undefined
-// and module evaluation throws. Bundlers like Vite already unwrap, so this is a
-// no-op there.
-function interopDefault<T>(mod: T): T {
-  return (mod as { __esModule?: boolean; default?: T })?.__esModule
-    ? (mod as { default: T }).default
-    : mod;
-}
-
+// react-syntax-highlighter ships `__esModule`, so its default imports come back
+// double-wrapped under strict ESM; unwrap them (see interopDefault).
 const SyntaxHighlighter = interopDefault(SyntaxHighlighterImport);
 const js = interopDefault(jsImport);
 const css = interopDefault(cssImport);

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
+import type { SyntaxHighlighterProps } from 'react-syntax-highlighter';
 // Fully-specified (`.js`) cjs subpaths: react-syntax-highlighter has no
 // `exports` map, so the ESM build's `{"type":"module"}` marker makes strict
 // bundlers (webpack 5) resolve these fully-specified — an extensionless

--- a/packages/react/src/components/Code/index.tsx
+++ b/packages/react/src/components/Code/index.tsx
@@ -6,15 +6,33 @@ import { SyntaxHighlighterProps } from 'react-syntax-highlighter';
 // specifier fails there. The cjs paths (not esm) are kept deliberately: they
 // resolve under Node `require`, Node ESM interop, and bundlers alike, whereas
 // the esm subpaths are bare ESM in a non-module package and break under Node.
-import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light.js';
+import SyntaxHighlighterImport from 'react-syntax-highlighter/dist/cjs/light.js';
 import classNames from 'classnames';
-import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript.js';
-import css from 'react-syntax-highlighter/dist/cjs/languages/hljs/css.js';
-import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml.js';
-import yaml from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml.js';
+import jsImport from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript.js';
+import cssImport from 'react-syntax-highlighter/dist/cjs/languages/hljs/css.js';
+import xmlImport from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml.js';
+import yamlImport from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml.js';
 import type { ContentNode } from '../../types';
 import { useId } from 'react-id-generator';
 import CopyButton, { CopyButtonProps } from '../CopyButton';
+
+// Normalize a CommonJS default export. Under strict ESM (Next.js SSR, webpack,
+// Node-native) a CJS module that sets `__esModule` is delivered double-wrapped
+// (`{ __esModule, default }`), so the default import is the wrapper rather than
+// the value — without this, `SyntaxHighlighter.registerLanguage` is undefined
+// and module evaluation throws. Bundlers like Vite already unwrap, so this is a
+// no-op there.
+function interopDefault<T>(mod: T): T {
+  return (mod as { __esModule?: boolean; default?: T })?.__esModule
+    ? (mod as { default: T }).default
+    : mod;
+}
+
+const SyntaxHighlighter = interopDefault(SyntaxHighlighterImport);
+const js = interopDefault(jsImport);
+const css = interopDefault(cssImport);
+const xml = interopDefault(xmlImport);
+const yaml = interopDefault(yamlImport);
 
 SyntaxHighlighter.registerLanguage('javascript', js);
 SyntaxHighlighter.registerLanguage('css', css);

--- a/packages/react/src/components/TopBar/TopBarMenu.test.tsx
+++ b/packages/react/src/components/TopBar/TopBarMenu.test.tsx
@@ -3,7 +3,7 @@ import { OptionsMenuList } from '../OptionsMenu';
 import { fireEvent, render, screen } from '@testing-library/react';
 import TopBarMenu from './TopBarMenu';
 import { MenuBar, TopBar } from '../..';
-import { MenuItem } from '../../../lib';
+import { MenuItem } from '../../index';
 import axe from '../../axe';
 
 const [rightCode, leftCode, downCode] = [39, 37, 40];

--- a/packages/react/src/components/TopBar/topBar.test.tsx
+++ b/packages/react/src/components/TopBar/topBar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { ThemeProvider } from '../../../lib';
+import { ThemeProvider } from '../../index';
 import TopBar, { TopBarItem } from './';
 import MenuBar from '../MenuBar/';
 import axe from '../../axe';

--- a/packages/react/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/react/src/components/TreeView/TreeViewItem.tsx
@@ -6,10 +6,15 @@ import {
   TreeItemContent,
   TreeItemContentRenderProps
 } from 'react-aria-components';
-import nextId from 'react-id-generator';
+import nextIdImport from 'react-id-generator';
 import { TreeViewNode } from './types';
 import Icon from '../Icon';
 import Checkbox from '../Checkbox';
+import interopDefault from '../../utils/interopDefault';
+
+// react-id-generator ships `__esModule`; unwrap its double-wrapped default so
+// `nextId(...)` works under strict ESM (see interopDefault).
+const nextId = interopDefault(nextIdImport);
 
 const TreeViewItem = ({ id, textValue, children }: TreeViewNode) => {
   const checkboxId = useMemo(() => nextId('tree-view-item-'), []);

--- a/packages/react/src/react-syntax-highlighter.d.ts
+++ b/packages/react/src/react-syntax-highlighter.d.ts
@@ -1,0 +1,21 @@
+/**
+ * `@types/react-syntax-highlighter` only declares the extensionless subpaths
+ * (e.g. `.../dist/cjs/light`). The `Code` component imports the fully-specified
+ * `.js` subpaths — required so strict-ESM bundlers can resolve them out of our
+ * ESM build — so re-declare those to reuse the real types.
+ */
+declare module 'react-syntax-highlighter/dist/cjs/light.js' {
+  export { default } from 'react-syntax-highlighter/dist/cjs/light';
+}
+declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript.js' {
+  export { default } from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript';
+}
+declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/css.js' {
+  export { default } from 'react-syntax-highlighter/dist/cjs/languages/hljs/css';
+}
+declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/xml.js' {
+  export { default } from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml';
+}
+declare module 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml.js' {
+  export { default } from 'react-syntax-highlighter/dist/cjs/languages/hljs/yaml';
+}

--- a/packages/react/src/utils/interopDefault.test.ts
+++ b/packages/react/src/utils/interopDefault.test.ts
@@ -1,0 +1,41 @@
+import interopDefault from './interopDefault';
+
+test('should unwrap a double-wrapped CJS default export', () => {
+  const value = () => 'called';
+
+  expect(interopDefault({ __esModule: true, default: value })).toBe(value);
+});
+
+test('should unwrap a non-callable double-wrapped default', () => {
+  const value = { registerLanguage: () => undefined };
+
+  expect(interopDefault({ __esModule: true, default: value })).toBe(value);
+});
+
+test('should return a plain CJS export unchanged', () => {
+  const fn = () => 'called';
+  const object = { a: 1 };
+
+  expect(interopDefault(fn)).toBe(fn);
+  expect(interopDefault(object)).toBe(object);
+});
+
+test('should pass nullish input through', () => {
+  expect(interopDefault(null)).toBeNull();
+  expect(interopDefault(undefined)).toBeUndefined();
+});
+
+test('should not unwrap when __esModule is falsy', () => {
+  const value = () => 'called';
+  const wrapper = { __esModule: false, default: value };
+
+  expect(interopDefault(wrapper)).toBe(wrapper);
+});
+
+// Pins current behavior for a dependency that sets `__esModule` but ships no
+// `default`: there is nothing to unwrap, so callers get `undefined` and fail at
+// their own call site (e.g. Code's module-scope `registerLanguage`) rather than
+// here. Change this test deliberately if that should become a thrown error.
+test('should return undefined when __esModule is set without a default', () => {
+  expect(interopDefault({ __esModule: true })).toBeUndefined();
+});

--- a/packages/react/src/utils/interopDefault.ts
+++ b/packages/react/src/utils/interopDefault.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalizes a CommonJS default export.
+ *
+ * Under strict ESM (Next.js SSR, webpack 5, Node-native) a CommonJS dependency
+ * that sets `__esModule` is delivered double-wrapped (`{ __esModule, default }`),
+ * so a `default` import resolves to the wrapper rather than the value — calling
+ * it (or reading a static off it) then throws. Bundlers like Vite already
+ * unwrap this, so it is a no-op there.
+ *
+ * Use for `default` imports of CJS dependencies that ship `__esModule` (e.g.
+ * `react-id-generator`, `react-syntax-highlighter`). Plain CJS dependencies
+ * (`module.exports = fn`, no `__esModule`) such as `classnames` don't need it.
+ */
+export default function interopDefault<T>(mod: T): T {
+  return (mod as { __esModule?: boolean; default?: T })?.__esModule
+    ? (mod as { default: T }).default
+    : mod;
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -8,8 +8,6 @@
     "src/**/*.stories.tsx"
   ],
   "compilerOptions": {
-    "skipLibCheck": true,
-    "declarationDir": "lib",
-    "declaration": true
+    "skipLibCheck": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@floating-ui/react-dom':
         specifier: ^2.1.2
         version: 2.1.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
@@ -361,9 +364,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.15)
-      '@types/react-syntax-highlighter':
-        specifier: ^15.5.13
-        version: 15.5.13
       '@types/sinon':
         specifier: ^10
         version: 10.0.20
@@ -415,6 +415,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.6(react@19.2.6)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
       rollup:
         specifier: ^2.23.0
         version: 2.80.0

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -75,7 +75,16 @@ const config = {
     alias: {
       react: path.resolve(__dirname, './node_modules/react'),
       'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
-      '@deque/cauldron-react': path.resolve(__dirname, './packages/react/lib')
+      // Consume the built ESM output. `$` matches the bare barrel import only,
+      // so the `/cauldron.css` short-form falls through to its own alias below.
+      '@deque/cauldron-react$': path.resolve(
+        __dirname,
+        './packages/react/lib/esm/index.js'
+      ),
+      '@deque/cauldron-react/cauldron.css': path.resolve(
+        __dirname,
+        './packages/react/lib/cauldron.css'
+      )
     },
     fallback: {
       path: false


### PR DESCRIPTION
## Summary

**Phase 3 (+ the tree-shaking half of Phase 4) of #2466.** Rollup now emits a **tree-shakeable dual CJS/ESM build**. This is a complete, working, non-breaking deliverable — bundler consumers get the actual payoff (unused components shake out), and Node keeps resolving CJS.

> **Stacked on #2476 (Phase 1).** Base branch is `chore/2466-packaging-validation-harness`; review/merge that first.

## What changed

**Dual output**
- `lib/cjs/` + `lib/esm/`, each compiled independently with a per-dir `package.json` `type` marker and co-located `.d.ts` (so `attw` sees no masquerading).
- `output.preserveModules` keeps one output module per source file (mirroring `src/`) instead of bundling everything into `index.js` — this is what makes tree-shaking possible.
- `package.json`: `main` → `lib/cjs/index.js`, `module` → `lib/esm/index.js`, `types` → `lib/cjs/index.d.ts`, **`"sideEffects": false`**. `build:lib` cleans `lib/` first.

**Why `preserveModules` + `sideEffects` together:** dual formats alone don't tree-shake — Rollup previously bundled the whole library into one `index.js` (the old single CJS build did too), so a `Button`-only import pulled in *everything*. Preserving modules + declaring no side effects lets a consumer's bundler drop what it doesn't use. The only module-scope effect is `Code`'s `registerLanguage`, which is local to the Code module and safe to treat as side-effect-free.

**react-syntax-highlighter interop (folds in the dropped Phase 2)**
- `Code` imports the **fully-specified `.js`** cjs subpaths, required so strict-ESM bundlers (webpack 5, under our `type: module` marker) resolve them; the **cjs** (not esm) paths are kept deliberately (they work under Node `require`, Node ESM interop, and bundlers). Ambient shim re-declares the `.js` subpaths since `@types` only covers extensionless.

**Internal consumers** repointed to the relocated output (webpack/storybook `$`-exact barrel alias → `lib/esm` + explicit `/cauldron.css` alias; `docs/index.js` and two `TopBar` tests import the barrel/source instead of built `lib/`).

## Payoff — measured

| Consumer import | Before | After |
|---|---|---|
| `import { Button }` (nothing else) | 1.1 MB, 82 chunks, includes Code + react-syntax-highlighter + react-aria | **4 KB, 1 chunk, none of them** |
| full `<Code>` render | — | renders + highlights, no console errors |

## Deferred to Phase 4 (deliberately — it's breaking)
The conditional `exports` map: routes Node's `import` to the ESM build, exposes `./cauldron.css` / `./package.json`, and locks down deep imports. That last part breaks any consumer deep-reaching into `lib/*`, so it warrants its own PR + a loud changelog note. publint currently emits only non-fatal suggestions pointing at this.

## Test plan
- [x] **Tree-shaking (now an automated gate):** the packaging harness bundles a `Button`-only consumer with Vite/Rollup from the packed tarball and asserts the output excludes react-syntax-highlighter / react-aria / registerLanguage / hljs / lowlight. Measured 4 KB / 1 chunk (was 1.1 MB / 82 chunks). Locks in the payoff so the barrel/`sideEffects`/build can't silently regress it.
- [x] **Next.js App Router SSR:** a real App Router consumer building against the tarball — initially this exposed a **ship-blocker** (SSR prerender threw `registerLanguage is not a function`: under strict ESM, Next/webpack delivers react-syntax-highlighter's CJS default double-wrapped). **Fixed** by an `interopDefault` normalization in Code; Next build + SSR prerender now succeed and the ThemeProvider value propagates.
- [x] **Single-copy / dual-package-hazard gate (automated):** the harness asserts `import` and `require` resolve to the same context object. Measured with a `react-dom/server` harness — a forced two-copy setup breaks provider→consumer propagation (theme falls back to default); single-copy propagates. Standard Next App Router loads **one copy** (no hazard).
- [x] Packaging harness: publint `--strict` clean, `attw` all-green (no masquerading), `require()` + `import` smoke pass.
- [x] Vite consumer renders `<Code>` (highlighting), `<Tabs>` (child detection), `<Button>` from the ESM build; no console errors.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build:docs`, `pnpm build:storybook`, and Code/TopBar tests pass.
- [ ] **Screenshots CI** — the Playwright specs consume the built package (dir import → `module`), so they now bundle the ESM output via Vite. Rendered DOM is identical locally; relying on the screenshot job to confirm no visual diff.

## Notes / caveats
- **`"sideEffects": false` audit:** the only module-scope side effect is Code's `registerLanguage` (local, safe); no CSS imports, globals, or prototype patching. Compound components detect children via identity (`child.type === Tab`), verified intact through the ESM build. Full audit in the thread.
- **Dual-package hazard:** shipping `main`(CJS)+`module`(ESM) means a runtime that loads *both* builds gets two copies with split React-context identity. Pure bundler, pure Node, and standard Next App Router are all single-copy (measured). The narrow exposure is a runtime that mixes bundled-ESM and `require`'d-CJS in one process. The single-copy gate guards against a future change widening this.
- **Out of scope (pre-existing):** `ThemeProvider` is not SSR-safe — its `context = document?.body` default throws `document is not defined` under SSR regardless of module format. Flagged separately.

Part of #2466.

