### PR TITLE
fix(react): guard ThemeProvider default context against undefined document

### DIFF
--- a/packages/react/src/contexts/theme.ssr.test.tsx
+++ b/packages/react/src/contexts/theme.ssr.test.tsx
@@ -18,11 +18,13 @@ const ThemeTester = () => {
 // values, not undeclared globals.
 test('ThemeProvider renders without error when document is undefined (SSR)', () => {
   expect(typeof document).toBe('undefined');
-  expect(() =>
-    renderToString(
+  let html = '';
+  expect(() => {
+    html = renderToString(
       <ThemeProvider initialTheme="dark">
         <ThemeTester />
       </ThemeProvider>
-    )
-  ).not.toThrow();
+    );
+  }).not.toThrow();
+  expect(html).toBe('<div></div>');
 });

--- a/packages/react/src/contexts/theme.ssr.test.tsx
+++ b/packages/react/src/contexts/theme.ssr.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { ThemeProvider, useThemeContext } from './theme';
+
+const ThemeTester = () => {
+  useThemeContext();
+  return <div />;
+};
+
+// This suite runs under the `node` environment (see the docblock above), where
+// `document` is not a declared global — the same condition as an SSR framework
+// prerendering a client component (e.g. Next.js App Router). A bare
+// `document?.body` default would throw `ReferenceError: document is not
+// defined` here, because optional chaining only guards against null/undefined
+// values, not undeclared globals.
+test('ThemeProvider renders without error when document is undefined (SSR)', () => {
+  expect(typeof document).toBe('undefined');
+  expect(() =>
+    renderToString(
+      <ThemeProvider initialTheme="dark">
+        <ThemeTester />
+      </ThemeProvider>
+    )
+  ).not.toThrow();
+});

--- a/packages/react/src/contexts/theme.tsx
+++ b/packages/react/src/contexts/theme.tsx
@@ -29,7 +29,7 @@ const ThemeContext = createContext<State & Methods>({
 const ThemeProvider = ({
   children,
   // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc
-  context = document?.body,
+  context = typeof document !== 'undefined' ? document.body : undefined,
   initialTheme = 'light'
 }: ProviderProps) => {
   const [theme, setTheme] = useState<Theme>(initialTheme);

--- a/packages/react/src/setupTests.ts
+++ b/packages/react/src/setupTests.ts
@@ -9,7 +9,13 @@ configureAxe({
   }
 });
 
-if (!('clipboard' in global.navigator)) {
+// Guard the DOM-dependent shims so this setup can also run under the `node`
+// test environment (used by SSR test suites), where `navigator`/`document` are
+// not declared globals.
+if (
+  typeof global.navigator !== 'undefined' &&
+  !('clipboard' in global.navigator)
+) {
   Object.defineProperty(global.navigator, 'clipboard', {
     value: {
       writeText: async () => null
@@ -19,7 +25,10 @@ if (!('clipboard' in global.navigator)) {
   });
 }
 
-if (!('execCommand' in global.document)) {
+if (
+  typeof global.document !== 'undefined' &&
+  !('execCommand' in global.document)
+) {
   Object.defineProperty(global.document, 'execCommand', {
     value: () => null,
     configurable: true,


### PR DESCRIPTION
## Summary

`ThemeProvider`'s default parameter `context = document?.body` throws `ReferenceError: document is not defined` under any SSR runtime (e.g. Next.js App Router prerendering a `"use client"` component). Optional chaining only guards against null/undefined **values** — it does **not** protect against an **undeclared global**, so evaluating the `document` identifier itself throws before `?.` ever runs.

This makes `<ThemeProvider>` (without an explicit `context` prop) unusable in any SSR framework. Passing `context={null}` works around it, confirming the default param is the cause.

### Root cause / history
Introduced on 2024-01-31 in #1328 — a PR that *intended* to make `ThemeProvider` SSR-safe (`document.body` → `document?.body`) but used optional chaining, which never actually protected against the undeclared global. This is a pre-existing bug on `develop`, independent of module format (reproduces on CJS today).

## Fix
```diff
-  context = document?.body,
+  context = typeof document !== 'undefined' ? document.body : undefined,
```
`typeof` is safe on undeclared globals. In the browser, behavior is identical (`document.body`); under SSR, `context` is `undefined`, and the component's existing `context?.` guards (effects + MutationObserver) already bail out on a falsy context.

## Tests
- **New:** `theme.ssr.test.tsx` runs under `@jest-environment node`, where `document` genuinely doesn't exist, and asserts `renderToString(<ThemeProvider …>)` doesn't throw. Verified **red without the fix** (exact `ReferenceError` at `theme.tsx:32`) → **green with it**. A separate node-env file is used rather than deleting `global.document` in the jsdom suite, which destabilizes jsdom's async teardown.
- **setupTests.ts:** guarded the `navigator.clipboard` / `document.execCommand` shims with `typeof … !== 'undefined'` so the shared setup also runs under the node environment.

## Verification
- All context tests pass; the clipboard/`execCommand`-dependent suites (CopyButton, Code) plus TreeView still pass — the setup guard preserves jsdom behavior.
- Lint + prettier clean on touched files.