### PR TITLE
fix: AccordionTrigger className should append, not replace

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -98,10 +98,12 @@ const Accordion = ({
         <PanelTrigger
           iconCollapsed="triangle-right"
           iconExpanded="triangle-down"
-          className={classnames('Accordion__trigger', trigger.props.className)}
           aria-controls={panelProps.id || `${elementId}-panel`}
           heading={trigger.props.heading}
           {...trigger.props}
+          // className must come after the spread so Accordion__trigger is not
+          // overwritten by trigger.props.className
+          className={classnames('Accordion__trigger', trigger.props.className)}
         >
           {trigger}
         </PanelTrigger>

--- a/packages/react/src/components/Accordion/index.test.tsx
+++ b/packages/react/src/components/Accordion/index.test.tsx
@@ -111,15 +111,18 @@ test('should set aria-expanded to true when open via the open prop', () => {
   expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
 });
 
-test('should set the className when passed a value in the className prop', () => {
+test('should append className to Accordion__trigger instead of replacing it', () => {
   render(
     <Accordion>
-      <AccordionTrigger className="test">Trigger</AccordionTrigger>
+      <AccordionTrigger className="extraTriggerClass">Trigger</AccordionTrigger>
       <AccordionContent>Content</AccordionContent>
     </Accordion>
   );
 
-  expect(screen.getByRole('button')).toHaveClass('test');
+  const trigger = screen.getByRole('button');
+  expect(trigger).toHaveClass('Accordion__trigger');
+  expect(trigger).toHaveClass('ExpandCollapse__trigger');
+  expect(trigger).toHaveClass('extraTriggerClass');
 });
 
 test('should set the heading level when passed a value in the heading prop', () => {


### PR DESCRIPTION
﻿## Summary
- `AccordionTrigger`'s `className` was applied before `{...trigger.props}`, so the custom class overwrote `Accordion__trigger`
- Move the merged `className` after the spread so both `Accordion__trigger` and the consumer class are kept
- Strengthen the unit test to assert `Accordion__trigger`, `ExpandCollapse__trigger`, and the custom class are all present

Closes #2480

## Test plan
- [x] `node scripts/buildIconTypes.js && pnpm exec jest src/components/Accordion/index.test.tsx --no-coverage` (21 passed)
