### PR TITLE
fix: collapse AccordionContent child margins into panel padding

### DIFF
--- a/packages/styles/accordion.css
+++ b/packages/styles/accordion.css
@@ -79,6 +79,15 @@ button.Accordion__trigger {
   border-radius: 0 0 3px 3px;
 }
 
+/* Prevent child margins from stacking on top of panel padding. */
+.Accordion__panel > :first-child {
+  margin-top: 0;
+}
+
+.Accordion__panel > :last-child {
+  margin-bottom: 0;
+}
+
 .Accordion:has(> button[aria-expanded='true']) {
   box-shadow: var(--drop-shadow-raised);
 }


### PR DESCRIPTION
﻿## Summary
- Zero out top margin on the first child and bottom margin on the last child of `Accordion__panel`
- Prevents child `<p>` (and similar) margins from stacking on top of the panel's 16px padding

Closes #2482

## Test plan
- [ ] Open Accordion with `<p>` children inside AccordionContent
- [ ] Confirm spacing from panel edge to text is ~16px (panel padding only), not padding + paragraph margin
