### PR TITLE
fix(Toast): restore focus to prior element on dismiss

### DIFF
--- a/packages/react/src/components/Toast/index.tsx
+++ b/packages/react/src/components/Toast/index.tsx
@@ -51,6 +51,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
     const elRef = useSharedRef<HTMLDivElement>(ref);
     const isolatorRef = useRef<AriaIsolate | null>(null);
     const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+    const previouslyFocusedRef = useRef<HTMLElement | null>(null);
     const [animationClass, setAnimationClass] = useState<string>(
       show ? 'FadeIn--flex' : 'is--hidden'
     );
@@ -84,9 +85,29 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
       }
 
       if (elRef.current && !!focus) {
+        const active = document.activeElement;
+        if (active instanceof HTMLElement && active !== elRef.current) {
+          previouslyFocusedRef.current = active;
+        }
         elRef.current.focus();
       }
     }, [type, focus]);
+
+    const restoreFocus = useCallback(() => {
+      const toRestore = previouslyFocusedRef.current;
+      previouslyFocusedRef.current = null;
+      if (
+        toRestore &&
+        document.contains(toRestore) &&
+        typeof toRestore.focus === 'function'
+      ) {
+        try {
+          toRestore.focus();
+        } catch {
+          // Element may no longer be focusable.
+        }
+      }
+    }, []);
 
     const dismissToast = useCallback(() => {
       if (!elRef.current) {
@@ -101,10 +122,12 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
           isolatorRef.current?.deactivate();
         }
 
+        // Restore before display:none so focus isn't dropped to <body>.
+        restoreFocus();
         setAnimationClass('is--hidden');
         onDismiss();
       });
-    }, [type, onDismiss]);
+    }, [type, onDismiss, restoreFocus]);
 
     useEffect(() => {
       if (show) {
@@ -115,6 +138,8 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         timeoutsRef.current.forEach(clearTimeout);
         timeoutsRef.current.clear();
         isolatorRef.current?.deactivate();
+        // If unmounted while shown/focused, return focus to the trigger.
+        restoreFocus();
       };
     }, []);
 

--- a/packages/react/src/components/Toast/toast.test.tsx
+++ b/packages/react/src/components/Toast/toast.test.tsx
@@ -236,6 +236,40 @@ test('should dismiss toast when dismiss button is clicked', async () => {
   });
 });
 
+test('should restore focus to the previously focused element on dismiss', async () => {
+  const user = userEvent.setup();
+  const trigger = document.createElement('button');
+  trigger.textContent = 'open toast';
+  document.body.appendChild(trigger);
+  trigger.focus();
+  expect(trigger).toHaveFocus();
+
+  render(
+    <Toast
+      show={true}
+      type="info"
+      dismissible={true}
+      dismissText="dismiss"
+      data-testid="toast"
+    >
+      {testString}
+    </Toast>
+  );
+
+  const toast = screen.getByTestId('toast');
+  await waitFor(() => {
+    expect(toast).toHaveFocus();
+  });
+
+  await user.click(screen.getByRole('button', { name: 'dismiss' }));
+
+  await waitFor(() => {
+    expect(trigger).toHaveFocus();
+  });
+
+  trigger.remove();
+});
+
 test('non-dismissible toast has no accessibility issues', async () => {
   const { container } = render(
     <Toast show type="info" dismissible={false}>


### PR DESCRIPTION
## Summary
- Capture `document.activeElement` before Toast steals focus on show.
- Restore that element on dismiss (before `is--hidden` / `display: none`) and on unmount while shown, so keyboard users are not dropped onto `<body>`.
- Adds a regression test covering dismiss → focus return.
- Fixes #2345

## Test plan
- [ ] `packages/react` Toast unit tests pass (`should restore focus to the previously focused element on dismiss`)
- [ ] Manual: focus a trigger, show a dismissible Toast, Tab to Dismiss, activate — focus returns to the trigger
- [ ] Manual: same flow with Toast portaled / away from the trigger in DOM order