### PR TITLE
chore: test amplify preview is disabled

### DIFF
--- a/preview-deploy-test.md
+++ b/preview-deploy-test.md
@@ -1,0 +1,7 @@
+# Preview deploy test
+
+Temporary file to verify that Amplify pull request previews are disabled.
+
+This PR should build tests but should not post an `aws-amplify` preview link.
+
+Safe to delete once the check is done.


### PR DESCRIPTION
Temporary PR to verify AWS Amplify pull request previews are turned off for PRs into develop.

Expected: CI runs, but the aws-amplify bot posts no preview link and no Amplify preview build starts.

Delete this branch and PR once the check is done.