### PR TITLE
fix(react): announce field errors to screen readers

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -65,6 +65,13 @@ test('should render error checkbox', () => {
   ).toBeInTheDocument();
 });
 
+test('should announce the error via a live region', () => {
+  renderCheckbox({ error: 'you should check this checkbox' });
+  const error = screen.getByRole('alert');
+  expect(error).toHaveTextContent('you should check this checkbox');
+  expect(error).toHaveAttribute('aria-live', 'polite');
+});
+
 test('should toggle checkbox correctly', async () => {
   const user = userEvent.setup();
   const input = renderCheckbox();

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -9,6 +9,7 @@ import React, {
 import classNames from 'classnames';
 import nextId from 'react-id-generator';
 import Icon, { type IconType } from '../Icon';
+import FieldError from '../internal/FieldError';
 import { addIdRef } from '../../utils/idRefs';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -164,9 +165,9 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           </span>
         )}
         {error && (
-          <div id={errorId} className="Error">
+          <FieldError id={errorId} className="Error" icon={false}>
             {error}
-          </div>
+          </FieldError>
         )}
       </div>
     );

--- a/packages/react/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/Combobox/Combobox.test.tsx
@@ -267,6 +267,13 @@ test('should render combobox with error', () => {
     'aria-describedby',
     `other-id ${errorId}`
   );
+
+  // The listbox is closed, so this is the field error rather than the
+  // "no results found" empty state, which is also an alert.
+  const error = screen.getByRole('alert');
+  expect(error).toHaveAttribute('id', errorId);
+  expect(error).toHaveTextContent('You forgot to choose a value.');
+  expect(error).toHaveAttribute('aria-live', 'polite');
 });
 
 test('should render combobox with both description and error', () => {

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -21,7 +21,7 @@ import { addIdRef } from '../../utils/idRefs';
 import TextFieldWrapper from '../internal/TextFieldWrapper';
 import { ListboxValue } from '../Listbox/ListboxOption';
 import ComboboxPill from './ComboboxPill';
-import Icon from '../Icon';
+import FieldError from '../internal/FieldError';
 
 // Event Keys
 const [Enter, Escape, Home, End, Backspace, Delete] = [
@@ -703,12 +703,7 @@ const Combobox = forwardRef<
             {description}
           </span>
         )}
-        {hasError && (
-          <div className="Field__error" id={errorId}>
-            <Icon type="caution" />
-            {error}
-          </div>
-        )}
+        {hasError && <FieldError id={errorId}>{error}</FieldError>}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <TextFieldWrapper
           className={classnames({ 'TextFieldWrapper--error': hasError })}

--- a/packages/react/src/components/FieldGroup/index.test.tsx
+++ b/packages/react/src/components/FieldGroup/index.test.tsx
@@ -63,6 +63,22 @@ test('should render with error message', () => {
   expect(error).toHaveClass('Field__error');
 });
 
+test('should announce the error via a live region', () => {
+  render(
+    <FieldGroup
+      label="Group Label"
+      error="You must include both first and last name"
+    >
+      <input type="text" placeholder="First Name" />
+      <input type="text" placeholder="Last Name" />
+    </FieldGroup>
+  );
+
+  const error = screen.getByRole('alert');
+  expect(error).toHaveTextContent('You must include both first and last name');
+  expect(error).toHaveAttribute('aria-live', 'polite');
+});
+
 test('should use provided id', () => {
   render(
     <FieldGroup

--- a/packages/react/src/components/FieldGroup/index.tsx
+++ b/packages/react/src/components/FieldGroup/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import classnames from 'classnames';
 import { useId } from 'react-id-generator';
-import Icon from '../Icon';
+import FieldError from '../internal/FieldError';
 import { addIdRef } from '../../utils/idRefs';
 
 interface FieldGroupProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -46,12 +46,7 @@ const FieldGroup = forwardRef<HTMLDivElement, FieldGroupProps>(
             {description}
           </div>
         )}
-        {error && (
-          <div className="Field__error" id={errorId}>
-            <Icon type="caution" />
-            {error}
-          </div>
-        )}
+        {error && <FieldError id={errorId}>{error}</FieldError>}
         {children}
       </div>
     );

--- a/packages/react/src/components/Select/index.test.tsx
+++ b/packages/react/src/components/Select/index.test.tsx
@@ -123,6 +123,8 @@ test('Should handle errors', () => {
     'Field__select--wrapper',
     'Field--has-error'
   );
+  expect(screen.getByRole('alert')).toHaveTextContent(errorText);
+  expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
 });
 
 test('Should support "controlled" select', () => {

--- a/packages/react/src/components/Select/index.tsx
+++ b/packages/react/src/components/Select/index.tsx
@@ -3,7 +3,7 @@ import uid from '../../utils/rndid';
 import classNames from 'classnames';
 import { addIdRef } from '../../utils/idRefs';
 import { ContentNode } from '../../types';
-import Icon from '../Icon';
+import FieldError from '../internal/FieldError';
 
 export interface SelectOption {
   key: string;
@@ -135,12 +135,7 @@ const Select = React.forwardRef(
             {description}
           </div>
         )}
-        {error && (
-          <div id={errorId} className="Field__error">
-            <Icon type="caution" />
-            {error}
-          </div>
-        )}
+        {error && <FieldError id={errorId}>{error}</FieldError>}
         <div
           className={classNames('Field__select--wrapper', {
             'Field__select--disabled': disabled,

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -63,6 +63,13 @@ test('should render error textfield', () => {
   ).toBeInTheDocument();
 });
 
+test('should announce the error via a live region', () => {
+  renderTextField({ error: 'there is an error with this field' });
+  const error = screen.getByRole('alert');
+  expect(error).toHaveTextContent('there is an error with this field');
+  expect(error).toHaveAttribute('aria-live', 'polite');
+});
+
 test('should render textfield with description', () => {
   const description = 'this is a description for the field';
   const input = renderTextField({

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import rndid from '../../utils/rndid';
 import setRef from '../../utils/setRef';
 import { addIdRef } from '../../utils/idRefs';
-import Icon from '../Icon';
+import FieldError from '../internal/FieldError';
 
 export interface TextFieldProps extends Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -118,12 +118,7 @@ export default class TextField extends React.Component<
             {description}
           </div>
         )}
-        {error && (
-          <div className="Field__error" id={this.errorId}>
-            <Icon type="caution" />
-            {error}
-          </div>
-        )}
+        {error && <FieldError id={this.errorId}>{error}</FieldError>}
         <Field
           className={classNames(className, {
             'Field__text-input': !multiline,

--- a/packages/react/src/components/internal/FieldError/FieldError.test.tsx
+++ b/packages/react/src/components/internal/FieldError/FieldError.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import FieldError from './';
+
+test('should render children', () => {
+  render(<FieldError>Something went wrong</FieldError>);
+  expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+});
+
+test('should render as a polite live region so the message is announced', () => {
+  render(<FieldError>Something went wrong</FieldError>);
+  const error = screen.getByRole('alert');
+  expect(error).toHaveTextContent('Something went wrong');
+  expect(error).toHaveAttribute('aria-live', 'polite');
+});
+
+test('should render the caution icon by default', () => {
+  const { container } = render(<FieldError>Something went wrong</FieldError>);
+  expect(container.querySelector('.Icon--caution')).toBeInTheDocument();
+});
+
+test('should omit the caution icon when icon is false', () => {
+  const { container } = render(
+    <FieldError icon={false}>Something went wrong</FieldError>
+  );
+  expect(container.querySelector('.Icon--caution')).not.toBeInTheDocument();
+});
+
+test('should default to the shared field error class', () => {
+  render(<FieldError>Something went wrong</FieldError>);
+  expect(screen.getByRole('alert')).toHaveClass('Field__error');
+});
+
+test('should support overriding className', () => {
+  render(<FieldError className="Error">Something went wrong</FieldError>);
+  const error = screen.getByRole('alert');
+  expect(error).toHaveClass('Error');
+  expect(error).not.toHaveClass('Field__error');
+});
+
+test('should support ref prop', () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(<FieldError ref={ref}>Something went wrong</FieldError>);
+  expect(ref.current).toBeInstanceOf(HTMLDivElement);
+});
+
+test('should render FieldError with other props', () => {
+  render(<FieldError id="banana">Something went wrong</FieldError>);
+  expect(screen.getByRole('alert')).toHaveAttribute('id', 'banana');
+});
+
+test('should have no axe violations with FieldError', async () => {
+  const { container } = render(<FieldError>Something went wrong</FieldError>);
+  expect(await axe(container)).toHaveNoViolations();
+});

--- a/packages/react/src/components/internal/FieldError/index.tsx
+++ b/packages/react/src/components/internal/FieldError/index.tsx
@@ -1,0 +1,49 @@
+import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import Icon from '../../Icon';
+
+export interface FieldErrorProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  /**
+   * Class applied to the error element. Defaults to the shared field error
+   * style; `Checkbox` styles its error differently.
+   */
+  className?: string;
+  /** Whether to render the caution icon before the message. */
+  icon?: boolean;
+}
+
+/**
+ * The error message for a form field, wired up as a live region.
+ *
+ * Field errors typically appear on submit, at which point focus has not moved.
+ * Screen readers only report a changed accessible description when the element
+ * it describes is re-focused, so associating the message via `aria-describedby`
+ * alone leaves it silent for the very interaction that produced it.
+ *
+ * `role="alert"` gets the message announced as soon as it is inserted, and
+ * `aria-live="polite"` stops a form that reveals several errors at once from
+ * interrupting itself.
+ *
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/status-messages
+ */
+const FieldError = forwardRef<HTMLDivElement, FieldErrorProps>(
+  (
+    { children, className = 'Field__error', icon = true, ...props },
+    ref
+  ): React.JSX.Element => (
+    <div
+      className={className}
+      role="alert"
+      aria-live="polite"
+      ref={ref}
+      {...props}
+    >
+      {icon && <Icon type="caution" />}
+      {children}
+    </div>
+  )
+);
+
+FieldError.displayName = 'FieldError';
+
+export default FieldError;


### PR DESCRIPTION
## Problem

Field errors are rendered into a plain element that is associated with the input only through `aria-describedby`. Errors typically appear **on submit**, when focus does not move — and screen readers only report a changed accessible description when the described element is re-focused. The result is that the message the interaction just produced is never announced.

This affects every component that renders a field error: `TextField`, `Select`, `Checkbox`, `Combobox`, and `FieldGroup`.

Reported downstream as a Serious VPAT finding (WCAG 4.1.3 Status Messages) against the axe Developer Hub — see dequelabs/walnut#14909. The "Edit name" modal there shows `Name is required.` with no announcement, but the defect is in the library, not the consumer.

## Change

Extract the error markup — duplicated near-identically in four of the five components — into an internal `FieldError` component that renders as a live region:

```tsx
<div className="Field__error" role="alert" aria-live="polite" id={errorId}>
```

Both attributes are load-bearing:

- **`role="alert"`** gets the message announced as soon as the node is *inserted*. A bare `aria-live` region inserted with its text already inside is frequently not announced at all, since AT watches pre-existing regions for mutations. The error node does not exist until submit, so this is the case that matters.
- **`aria-live="polite"`** explicitly overrides alert's implicit `assertive`, so a form that reveals several field errors at once queues them rather than interrupting itself.

This mirrors the pattern already used for the Combobox empty state (`Combobox.tsx:120`).

## Notes for review

- **Checkbox keeps its own styling.** It uses `class="Error"` with no caution icon, and `.Field__error` carries additional rules it must not inherit (`styles/forms.css:213`). `FieldError` therefore defaults `className` to `Field__error`, and Checkbox overrides with `className="Error" icon={false}`.
- **Rendered output is otherwise unchanged** — same classes, same icon, same text. The only DOM difference is the two ARIA attributes, so existing screenshots should not move.
- **Non-breaking** by the criteria in CONTRIBUTING.md: no renamed or removed export, no changed prop, no new required prop. `FieldError` is internal and not exported from the public barrel.