### PR TITLE
Add global radius primitives

### DIFF
--- a/.figma/make/dev
+++ b/.figma/make/dev
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# `pnpm dev` runs three watchers concurrently: the styles build, the react
+# library build, and the docs site (webpack-dev-server on port 8003). The docs
+# server is what renders in the browser preview.
+echo "Starting development server"
+pnpm dev

--- a/.figma/make/dev
+++ b/.figma/make/dev
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# The docs site resolves `@deque/cauldron-react` to packages/react/lib, which is
+# the library's *built* output. On a fresh start that JS build (lib/index.js)
+# doesn't exist yet, so the docs webpack compile fails with "Module not found"
+# before the rollup watcher has a chance to emit it. Build the library once up
+# front so the output exists when the docs server first compiles.
+if [ ! -f packages/react/lib/index.js ]; then
+  echo "Building cauldron-react library (first run)"
+  pnpm --filter @deque/cauldron-react build
+fi
+
 # `pnpm dev` runs three watchers concurrently: the styles build, the react
 # library build, and the docs site (webpack-dev-server on port 8003). The docs
 # server is what renders in the browser preview.

--- a/.figma/make/env
+++ b/.figma/make/env
@@ -1,0 +1,2 @@
+PORT=8003
+FIGMA_MAKE_URL=http://localhost:8003

--- a/.figma/make/install
+++ b/.figma/make/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+echo "Installing project dependencies with pnpm"
+pnpm install --frozen-lockfile
+echo "Dependencies installed"

--- a/.figma/make/setup
+++ b/.figma/make/setup
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+echo "Checking system dependencies..."
+
+# Node — this repo requires Node >=22 (see package.json engines / .nvmrc)
+NODE_VERSION="$(node --version 2>/dev/null || echo "none")"
+if [[ "$NODE_VERSION" == "none" ]]; then
+  echo "Installing node"
+  brew install node@22
+else
+  echo "Node $NODE_VERSION found"
+fi
+
+# pnpm — the project is a pnpm workspace (packageManager: pnpm@11.4.0).
+# Prefer corepack so the pinned version is used; fall back to a global install.
+PNPM_VERSION="$(pnpm --version 2>/dev/null || echo "none")"
+if [[ "$PNPM_VERSION" == "none" ]]; then
+  echo "Enabling pnpm via corepack"
+  corepack enable 2>/dev/null || npm install -g pnpm
+else
+  echo "pnpm $PNPM_VERSION found"
+fi
+
+echo "System dependencies verified."

--- a/.figma/make/verify
+++ b/.figma/make/verify
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+HEALTHCHECK_URL='http://localhost:8003/'
+MAX_WAIT=180 # 3 minutes — first build compiles react + styles + docs
+INTERVAL=2
+ELAPSED=0
+
+echo "Waiting for development server to be ready"
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  if curl -sf "$HEALTHCHECK_URL" >/dev/null 2>&1; then
+    echo "Dev server is up"
+    exit 0
+  fi
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "Error: Dev server did not start within ${MAX_WAIT}s"
+exit 1

--- a/docs/pages/components/Button.mdx
+++ b/docs/pages/components/Button.mdx
@@ -18,7 +18,7 @@ import { Button } from '@deque/cauldron-react';
 Primary buttons are the default variant for the `Button` component.
 
 ```jsx example
-<Button>Primary</Button>
+<Button style={{ borderRadius: '100px' }}>Primary</Button>
 ```
 
 ### Secondary

--- a/packages/styles/variables.css
+++ b/packages/styles/variables.css
@@ -52,7 +52,15 @@
   --issue-minor: var(--gray-20);
 
   /* radius */
+  --radius-0: 0;
+  --radius-4: 4px;
+  --radius-8: 8px;
+  --radius-12: 12px;
   --radius-16: 16px;
+  --radius-20: 20px;
+  --radius-24: 24px;
+  --radius-32: 32px;
+  --radius-9999: 9999px;
 
   /* text colours */
   --text-color-base: var(--gray-60);


### PR DESCRIPTION
## Summary
- Add the full `_Primitives` radius scale (`0` through `32`, plus `9999`) as CSS custom properties in `variables.css`

## Test plan
- [ ] Confirm `--radius-*` tokens are defined in `packages/styles/variables.css`
- [ ] Confirm Panel still uses `--radius-16`