### PR TITLE
fix(ActionList): stop mirroring Listbox's active option

### DIFF
--- a/packages/react/src/components/ActionList/ActionList.tsx
+++ b/packages/react/src/components/ActionList/ActionList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import classnames from 'classnames';
 import { type ListboxOption } from '../Listbox/ListboxContext';
 import Listbox from '../Listbox';
@@ -26,21 +26,12 @@ interface ActionListProps extends Omit<
 
 const ActionList = forwardRef<HTMLUListElement, ActionListProps>(
   ({ selectionType = null, onAction, className, children, ...props }, ref) => {
-    const activeElement = useRef<HTMLLIElement | HTMLAnchorElement | null>(
-      null
-    );
+    // Listbox owns the active option. ActionList must not mirror it back down
+    // as a controlled prop: the two copies then race, and a downward sync
+    // carrying an already-stale value can revert a newer one and oscillate.
+    // `activeOption` below is only a one-shot mnemonic request, never a
+    // mirror. See cauldron#2512.
     const [activeOption, setActiveOption] = useState<ListboxOption>();
-
-    // Deliberately does not mirror the reported option back into
-    // `activeOption`. Listbox owns the active option; feeding its own value
-    // back down as a controlled prop makes the two copies race, and a
-    // downward sync carrying an already-stale value can revert a newer one
-    // and oscillate. See cauldron#2512.
-    const handleActiveChange = useCallback((value: ListboxOption) => {
-      activeElement.current = value?.element as
-        | HTMLLIElement
-        | HTMLAnchorElement;
-    }, []);
 
     const handleAction = useCallback(
       (key: string, event: onActionEvent) => {
@@ -86,7 +77,6 @@ const ActionList = forwardRef<HTMLUListElement, ActionListProps>(
         className={classnames('ActionList', className)}
         activeOption={activeOption}
         {...props}
-        onActiveChange={handleActiveChange}
         navigation="bound"
       >
         <ActionListProvider

--- a/packages/react/src/components/ActionList/ActionList.tsx
+++ b/packages/react/src/components/ActionList/ActionList.tsx
@@ -31,11 +31,15 @@ const ActionList = forwardRef<HTMLUListElement, ActionListProps>(
     );
     const [activeOption, setActiveOption] = useState<ListboxOption>();
 
+    // Deliberately does not mirror the reported option back into
+    // `activeOption`. Listbox owns the active option; feeding its own value
+    // back down as a controlled prop makes the two copies race, and a
+    // downward sync carrying an already-stale value can revert a newer one
+    // and oscillate. See cauldron#2512.
     const handleActiveChange = useCallback((value: ListboxOption) => {
       activeElement.current = value?.element as
         | HTMLLIElement
         | HTMLAnchorElement;
-      setActiveOption(value);
     }, []);
 
     const handleAction = useCallback(
@@ -47,10 +51,12 @@ const ActionList = forwardRef<HTMLUListElement, ActionListProps>(
       [onAction]
     );
 
+    // A new object every match, even for the same element: this is a one-shot
+    // request to Listbox rather than a mirror of its state, so re-using the
+    // previous object would leave the controlled prop unchanged and the
+    // request would never reach Listbox.
     const handleMnemonicMatch = useCallback((element: HTMLElement) => {
-      setActiveOption((prev) =>
-        prev?.element === element ? prev : { element }
-      );
+      setActiveOption({ element });
     }, []);
 
     const containerRef = useMnemonics<HTMLUListElement>({

--- a/packages/react/src/components/ActionList/ActionList.tsx
+++ b/packages/react/src/components/ActionList/ActionList.tsx
@@ -30,7 +30,8 @@ const ActionList = forwardRef<HTMLUListElement, ActionListProps>(
     // as a controlled prop: the two copies then race, and a downward sync
     // carrying an already-stale value can revert a newer one and oscillate.
     // `activeOption` below is only a one-shot mnemonic request, never a
-    // mirror. See cauldron#2512.
+    // mirror. See cauldron#2512; cauldron#2522 tracks making `activeOption`
+    // properly controlled so this constraint lives in the interface instead.
     const [activeOption, setActiveOption] = useState<ListboxOption>();
 
     const handleAction = useCallback(

--- a/packages/react/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/components/ActionMenu/ActionMenu.test.tsx
@@ -491,6 +491,50 @@ test('should set matching active item on mnemonic key press', async () => {
   });
 });
 
+// Regression test for cauldron#2512. ActionList no longer mirrors Listbox's
+// reported active option, so a mnemonic match must be a fresh request every
+// time -- otherwise re-matching an item that arrow keys have since moved away
+// from is silently dropped.
+test('should set matching active item on mnemonic key press after arrow navigation', async () => {
+  const user = userEvent.setup();
+  render(
+    <ActionMenu {...defaultProps}>
+      <ActionList>
+        <ActionListItem>Apple</ActionListItem>
+        <ActionListItem>Banana</ActionListItem>
+        <ActionListItem>Cherry</ActionListItem>
+      </ActionList>
+    </ActionMenu>
+  );
+
+  screen.getByRole('button', { name: 'Trigger' }).focus();
+  await user.keyboard('{ArrowDown}');
+  await waitForMenuFocus();
+
+  await user.keyboard('c');
+  await waitFor(() => {
+    expect(screen.queryAllByRole('menuitem')[2]).toHaveClass(
+      'ActionListItem--active'
+    );
+  });
+
+  // Move the active option off of Cherry with arrow navigation.
+  await user.keyboard('{ArrowUp}{ArrowUp}');
+  await waitFor(() => {
+    expect(screen.queryAllByRole('menuitem')[0]).toHaveClass(
+      'ActionListItem--active'
+    );
+  });
+
+  // Matching Cherry again must move the active option back to it.
+  await user.keyboard('c');
+  await waitFor(() => {
+    expect(screen.queryAllByRole('menuitem')[2]).toHaveClass(
+      'ActionListItem--active'
+    );
+  });
+});
+
 // Regression test for cauldron#1993
 test('should set first item active on open in TopBar+ActionMenu pattern', async () => {
   const user = userEvent.setup();

--- a/packages/react/src/components/Listbox/Listbox.tsx
+++ b/packages/react/src/components/Listbox/Listbox.tsx
@@ -304,7 +304,7 @@ const Listbox = forwardRef<
             ? options.find((option) => !isDisabledOption(option))
             : options[0];
 
-          if (firstOption) {
+          if (firstOption && firstOption.element !== activeOption?.element) {
             setActiveOption(firstOption);
           }
 
@@ -316,7 +316,7 @@ const Listbox = forwardRef<
             ? [...options].reverse().find((option) => !isDisabledOption(option))
             : options[options.length - 1];
 
-          if (lastOption) {
+          if (lastOption && lastOption.element !== activeOption?.element) {
             setActiveOption(lastOption);
           }
 

--- a/packages/react/src/components/Listbox/index.test.tsx
+++ b/packages/react/src/components/Listbox/index.test.tsx
@@ -982,3 +982,59 @@ test('should return no axe violations with multiselect', async () => {
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });
+
+test('should not update the active option on focus when it is already active', () => {
+  const handleActiveChange = jest.fn();
+  const Fixture = ({
+    activeOption
+  }: {
+    activeOption?: { element: HTMLElement };
+  }) => (
+    <Listbox
+      focusStrategy="first"
+      activeOption={activeOption}
+      onActiveChange={handleActiveChange}
+    >
+      <ListboxOption>Apple</ListboxOption>
+      <ListboxOption>Banana</ListboxOption>
+    </Listbox>
+  );
+
+  const { rerender } = render(<Fixture />);
+  const apple = screen.getByRole('option', { name: 'Apple' });
+
+  // The parent's copy of the active option is a different object than the
+  // listbox's own, which is how ActionList/ActionMenu mirror active state.
+  rerender(<Fixture activeOption={{ element: apple }} />);
+  handleActiveChange.mockClear();
+
+  fireEvent.focus(screen.getByRole('listbox'));
+  expect(handleActiveChange).not.toHaveBeenCalled();
+});
+
+test('should not update the active option on focus when it is already active with focusStrategy "last"', () => {
+  const handleActiveChange = jest.fn();
+  const Fixture = ({
+    activeOption
+  }: {
+    activeOption?: { element: HTMLElement };
+  }) => (
+    <Listbox
+      focusStrategy="last"
+      activeOption={activeOption}
+      onActiveChange={handleActiveChange}
+    >
+      <ListboxOption>Apple</ListboxOption>
+      <ListboxOption>Banana</ListboxOption>
+    </Listbox>
+  );
+
+  const { rerender } = render(<Fixture />);
+  const banana = screen.getByRole('option', { name: 'Banana' });
+
+  rerender(<Fixture activeOption={{ element: banana }} />);
+  handleActiveChange.mockClear();
+
+  fireEvent.focus(screen.getByRole('listbox'));
+  expect(handleActiveChange).not.toHaveBeenCalled();
+});

--- a/packages/react/src/components/Listbox/index.test.tsx
+++ b/packages/react/src/components/Listbox/index.test.tsx
@@ -1003,8 +1003,8 @@ test('should not update the active option on focus when it is already active', (
   const { rerender } = render(<Fixture />);
   const apple = screen.getByRole('option', { name: 'Apple' });
 
-  // The parent's copy of the active option is a different object than the
-  // listbox's own, which is how ActionList/ActionMenu mirror active state.
+  // The parent passes its own object wrapping the same element the listbox
+  // already holds, so the guard cannot rely on object identity.
   rerender(<Fixture activeOption={{ element: apple }} />);
   handleActiveChange.mockClear();
 
@@ -1021,6 +1021,33 @@ test('should not update the active option on focus when it is already active wit
   }) => (
     <Listbox
       focusStrategy="last"
+      activeOption={activeOption}
+      onActiveChange={handleActiveChange}
+    >
+      <ListboxOption>Apple</ListboxOption>
+      <ListboxOption>Banana</ListboxOption>
+    </Listbox>
+  );
+
+  const { rerender } = render(<Fixture />);
+  const banana = screen.getByRole('option', { name: 'Banana' });
+
+  rerender(<Fixture activeOption={{ element: banana }} />);
+  handleActiveChange.mockClear();
+
+  fireEvent.focus(screen.getByRole('listbox'));
+  expect(handleActiveChange).not.toHaveBeenCalled();
+});
+
+test('should not update the active option on focus when it is already active with the default focus strategy', () => {
+  const handleActiveChange = jest.fn();
+  const Fixture = ({
+    activeOption
+  }: {
+    activeOption?: { element: HTMLElement };
+  }) => (
+    <Listbox
+      defaultValue="Banana"
       activeOption={activeOption}
       onActiveChange={handleActiveChange}
     >


### PR DESCRIPTION
Closes #2512

## What this changes

The active option was stored in **two places** and synced in **both directions**:

- `Listbox` keeps `activeOption` in local state and reports every change upward via `onActiveChange`.
- `ActionList` stored that reported value in its own state and passed it straight back down as the `activeOption` controlled prop.

`Listbox`'s downward sync effect only re-runs when that prop's *object identity* changes, so it can fire late, carrying a value that is already out of date, and overwrite a newer local one. That stale revert is reported back up, the parent adopts it, and the two copies flip between two items until React's update-depth guard trips.

`Listbox` now owns the active option outright. `ActionList` keeps `activeOption` only as a one-shot mnemonic request — which must be a fresh object on every match, or the request never reaches `Listbox`.

## Why it only showed up under load

I instrumented every write on both sides and captured a real failing run. The healthy and broken orderings differ only in which effect runs first after a commit:

```
HEALTHY: report(180) → parent=180 → click(181) → downSync: no-op → report(181) → parent=181 → no-op
BROKEN:  report(180) → parent=180 → click(181) → report(181) → parent=181 → downSync applies stale 180
```

Under light load React batches the updates and they settle in one pass. Under load they split across separate commits, the downward sync is permanently one step behind, and the ping-pong never converges — ~1,250 alternations per item before the guard fires.

Note that the trigger in the captured trace was an ordinary click (`handleSelect`), **not** the focus handler. That is why the first commit here did not fix it on its own.

## Commits

- `f299065a` — the original focus-handler guard. Still a real improvement (avoids a redundant write and a redundant `onActiveChange` call on every focus) with its own tests, but **not** what resolves this issue. Kept deliberately.
- `466d5956` — the actual fix.
- `fa57a9fe` — drops `activeElement`, which was written on every active-option change and never read by anything. Removing the last mirror write left `handleActiveChange` with nothing to do but that dead write, so the ref, the callback, and the `onActiveChange` prop it was wired to all go together. No behavior change.

## Verification

The previous attempt was merged on reasoning alone and turned out not to fix the bug, so this time the claim is backed by runs against the suite that actually fails.

Method: built `packages/react` from this branch and pointed walnut's `packages/ui-issues` at it via a `file:` override in `pnpm-workspace.yaml`, then ran the failing suite repeatedly:

```
NODE_ENV=test node --require ts-node/register --require ./src/test-setup.ts \
  --test-reporter spec --test --test-concurrency=20 'src/**/*.test.tsx' 'src/**/*.test.ts'
```

| Build | Runs | Runaway loops |
|---|---|---|
| cauldron 7.5.0 (baseline) | 5 | 3 |
| first commit only (`f299065a`) | 14 | 3 |
| **this branch** | **35** | **0** |

A looping run hangs 140–180s and prints `Maximum update depth exceeded` ~13,800 times; a clean run finishes the whole suite in 13–16s. The failure is unmistakable when it happens.

Against the 21% failure rate the previous build showed, 35 clean runs would happen by luck roughly 0.02% of the time. Against the 60% baseline rate it is effectively impossible.

Cauldron's own suite: 1176 tests across 95 suites pass, plus typecheck, lint and format.

One caveat worth stating plainly: **the race itself cannot be reproduced deterministically in a unit test**, because it depends on how React splits commits under scheduling pressure. The new test in `ActionMenu.test.tsx` covers the behavior the fix changes — a mnemonic match must still move the active option after arrow keys have moved away from it — and was written RED first: it fails with the mirror removed but the one-shot request reusing its previous object, and passes with both halves of the fix in place. The 35-run walnut result is the evidence for the race being gone.

Also verified in passing: the 9 `act()` warnings in the walnut runs are unchanged from clean baseline runs, so they are pre-existing and unrelated.

## Follow-up

`Listbox` accepts `activeOption` as a controlled prop while continuing to write its own local copy from 13 internal call sites. Its other controlled prop (`value`) gates internal writes on `!isControlled`, and `Combobox` does the same — `activeOption` is the outlier, so the idiomatic controlled usage is the unsafe one.

I searched the `dequelabs` org: no repo outside cauldron passes `activeOption` to a `Listbox`, so this PR removes the only affected usage. Making `Listbox` properly controlled is a separate change, and per `CONTRIBUTING.md` it needs a deprecation flagged for at least two months first. Tracked separately in #2522 to avoid delaying the bugfix.

