### PR TITLE
fix(TreeView): make Enter run onAction consistently, and Space select

### DIFF
--- a/docs/pages/components/TreeView.mdx
+++ b/docs/pages/components/TreeView.mdx
@@ -4,6 +4,7 @@ description: A component that displays a hierarchical tree structure.
 source: https://github.com/dequelabs/cauldron/tree/develop/packages/react/src/components/TreeView/index.tsx
 ---
 
+import { useState } from 'react';
 import { TreeView } from '@deque/cauldron-react';
 
 ```jsx
@@ -179,13 +180,12 @@ function LabelledByTreeView() {
 
 ### Custom onAction
 
-TreeView with a custom action handler for item selection.
+`onAction` runs your own handler when an item is activated, in addition to the
+item's selection change.
 
 ```jsx example
 function ActionTreeView() {
-  const onAction = (key) => {
-    alert(`Selected item: ${key}`);
-  };
+  const [lastAction, setLastAction] = useState(null);
   const items = [
     {
       id: '1',
@@ -199,12 +199,17 @@ function ActionTreeView() {
     }
   ];
   return (
-    <TreeView
-      aria-label="Tree View with Action Handler"
-      selectionMode="single"
-      onAction={onAction}
-      items={items}
-    />
+    <>
+      <TreeView
+        aria-label="Tree View with Action Handler"
+        selectionMode="multiple"
+        onAction={setLastAction}
+        items={items}
+      />
+      <p role="status">
+        {lastAction ? `Last action: item ${lastAction}` : 'No action yet.'}
+      </p>
+    </>
   );
 }
 ```

--- a/docs/pages/components/TreeView.mdx
+++ b/docs/pages/components/TreeView.mdx
@@ -180,8 +180,15 @@ function LabelledByTreeView() {
 
 ### Custom onAction
 
-`onAction` runs your own handler when an item is activated, in addition to the
-item's selection change.
+`onAction` runs your own handler when an item is activated. Activation and
+selection are separate interactions, and each key does one thing only:
+
+- **Space** toggles the item's checkbox, exactly as a standalone checkbox would.
+- **Enter** runs `onAction`, and leaves the selection alone.
+
+Tell users what activation does before they trigger it, particularly if it opens
+a dialog or otherwise moves them somewhere — describe it in nearby instructions
+and point the tree at them with `aria-describedby`.
 
 ```jsx example
 function ActionTreeView() {
@@ -200,8 +207,12 @@ function ActionTreeView() {
   ];
   return (
     <>
+      <p id="action-tree-help">
+        Press Space to select an item, or Enter to run the action for it.
+      </p>
       <TreeView
         aria-label="Tree View with Action Handler"
+        aria-describedby="action-tree-help"
         selectionMode="multiple"
         onAction={setLastAction}
         items={items}

--- a/packages/react/src/components/TreeView/TreeView.test.tsx
+++ b/packages/react/src/components/TreeView/TreeView.test.tsx
@@ -454,3 +454,78 @@ test('cascade is inert in single selection mode', async () => {
   expect(getByRole('checkbox', { name: 'TreeView' })).toBeChecked();
   expect(getByRole('checkbox', { name: 'pizza' })).not.toBeChecked();
 });
+
+// --- onAction: Space selects, Enter acts ---
+
+test('Enter runs onAction every time, including once rows are selected', async () => {
+  const onAction = jest.fn();
+  const { getByRole } = render(
+    <TreeView
+      aria-label="Test TreeView"
+      selectionMode="multiple"
+      onAction={onAction}
+      items={items}
+    />
+  );
+  (getByRole('row', { name: /TreeView/ }) as HTMLElement).focus();
+
+  await userEvent.keyboard('{Enter}');
+  expect(onAction).toHaveBeenCalledTimes(1);
+
+  // react-aria stops treating a press as an action once anything is selected,
+  // so this is the case that used to go silent.
+  await userEvent.keyboard(' ');
+  await userEvent.keyboard('{Enter}');
+  expect(onAction).toHaveBeenCalledTimes(2);
+
+  await userEvent.keyboard('{Enter}');
+  expect(onAction).toHaveBeenCalledTimes(3);
+});
+
+test('Enter runs onAction without changing the selection', async () => {
+  const onAction = jest.fn();
+  const { getByRole } = render(
+    <TreeView
+      aria-label="Test TreeView"
+      selectionMode="multiple"
+      onAction={onAction}
+      items={items}
+    />
+  );
+  (getByRole('row', { name: /TreeView/ }) as HTMLElement).focus();
+  await userEvent.keyboard('{Enter}');
+  expect(onAction).toHaveBeenCalledTimes(1);
+  expect(getByRole('checkbox', { name: 'TreeView' })).not.toBeChecked();
+});
+
+test('Space toggles selection without running onAction', async () => {
+  const onAction = jest.fn();
+  const { getByRole } = render(
+    <TreeView
+      aria-label="Test TreeView"
+      selectionMode="multiple"
+      onAction={onAction}
+      items={items}
+    />
+  );
+  (getByRole('row', { name: /TreeView/ }) as HTMLElement).focus();
+  await userEvent.keyboard(' ');
+  expect(getByRole('checkbox', { name: 'TreeView' })).toBeChecked();
+  expect(onAction).not.toHaveBeenCalled();
+});
+
+test('Enter reports the focused row key', async () => {
+  const onAction = jest.fn();
+  const { getByRole } = render(
+    <TreeView
+      aria-label="Test TreeView"
+      selectionMode="multiple"
+      onAction={onAction}
+      defaultExpandedKeys={['1']}
+      items={items}
+    />
+  );
+  (getByRole('row', { name: /pizza/ }) as HTMLElement).focus();
+  await userEvent.keyboard('{Enter}');
+  expect(onAction).toHaveBeenCalledWith('2');
+});

--- a/packages/react/src/components/TreeView/index.tsx
+++ b/packages/react/src/components/TreeView/index.tsx
@@ -1,9 +1,10 @@
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { Tree, type Selection, type Key } from 'react-aria-components';
 import { Cauldron } from '../../types';
 import { TreeViewNode } from './types';
 import TreeViewItem from './TreeViewItem';
+import useSharedRef from '../../utils/useSharedRef';
 import {
   applyCascade,
   collectDisabledKeys,
@@ -15,6 +16,8 @@ export type { TreeViewNode } from './types';
 
 type TreeViewProps = Cauldron.LabelProps & {
   items: TreeViewNode[];
+  /** Runs when an item is activated: Enter, or a row press. Selection is a
+   *  separate interaction — Space toggles it. */
   onAction?: (key: string) => void;
   selectionMode?: 'none' | 'single' | 'multiple';
   /** When true (multiple selection only), selecting a parent also selects all
@@ -41,6 +44,7 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
     },
     ref
   ) => {
+    const treeRef = useSharedRef<HTMLDivElement>(ref);
     const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
     const cascade = { cascadeSelect, cascadeDeselect };
     // Cascade only applies to multiple selection.
@@ -81,6 +85,30 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
       onAction?.(key as string);
     };
 
+    // Space selects and Enter runs the action, consistently. react-aria only
+    // treats a press as an action while nothing is selected, so once a row is
+    // checked its Enter handling goes inert. Capture phase, so react-aria never
+    // sees the key and cannot vary the outcome.
+    useEffect(() => {
+      const node = treeRef.current;
+      if (!node || !onAction) return;
+
+      const handleEnter = (event: KeyboardEvent) => {
+        if (event.key !== 'Enter' || event.defaultPrevented) return;
+        const row = (event.target as HTMLElement | null)?.closest?.(
+          '[role="row"][data-key]'
+        );
+        const key = row?.getAttribute('data-key');
+        if (!key || row?.getAttribute('aria-disabled') === 'true') return;
+        event.preventDefault();
+        event.stopPropagation();
+        onAction(key);
+      };
+
+      node.addEventListener('keydown', handleEnter, true);
+      return () => node.removeEventListener('keydown', handleEnter, true);
+    }, [onAction]);
+
     // Disabled nodes are non-selectable; react-aria disables them via disabledKeys.
     const disabledKeys = useMemo(() => collectDisabledKeys(items), [items]);
 
@@ -93,7 +121,7 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
 
     return (
       <Tree
-        ref={ref}
+        ref={treeRef}
         className={classNames('TreeView', className)}
         selectionMode={selectionMode}
         defaultExpandedKeys={defaultExpandedKeys}


### PR DESCRIPTION
## Summary

Fixes the Enter key behaviour @VaniChinnam reported in #2519, implementing the
model she described: **Space selects, Enter runs the action**, each consistently.

## The bug

On a tree with checkboxes, Enter behaved differently from one press to the next
— sometimes running the action, sometimes toggling selection, and after the
first selection doing nothing at all. In her words: *"sometimes it opens the
modal, and sometimes it selects the checkbox. The users are unable to select the
other checkboxes as expected."*

react-aria treats a press as an action only while the selection is empty:

```js
hasPrimaryAction   = allowsActions && (selectionBehavior === 'replace' ? !allowsSelection : !allowsSelection || manager.isEmpty)
hasSecondaryAction = allowsActions && allowsSelection && selectionBehavior === 'replace'
hasAction          = hasPrimaryAction || hasSecondaryAction
```

Checkboxes force `selectionBehavior: 'toggle'`, so `hasSecondaryAction` is
always `false` and `hasPrimaryAction` collapses to `manager.isEmpty`. Selecting
something is the normal case for a checkbox tree, so from the first selection
onward `hasAction` is `false` — `onAction` became unreachable by keyboard, and
Enter stopped toggling selection too, because that path is gated on the same
flag.

Mouse users could still trigger the action on a first click. Same functionality,
available by mouse and not by keyboard — a **WCAG 2.1.1** failure, not just an
inconsistency.

## The fix

Enter is handled on the tree element in the capture phase, so react-aria never
sees it and cannot vary the outcome. Activation and selection are now separate,
and each key does exactly one thing:

- **Space** toggles the item's checkbox, as a standalone checkbox would (this
  already worked, and is unchanged).
- **Enter** runs `onAction` and leaves the selection alone.

Verified across the sequence that used to fail:

| step | action fires | selection |
| --- | --- | --- |
| Enter | yes | unchanged |
| Enter again | yes | unchanged |
| Space | no | toggled on |
| Enter, with a row now selected | **yes** | unchanged |
| Space on a second row | no | both stay selected |

Her second point from #2519 — that a context change should be announced before
it happens — is covered in the docs: the example carries visible instructions
referenced with `aria-describedby` telling users what Space and Enter do.

## Testing

- Four new unit tests, including the previously-silent case (Enter after
  something is selected). Mutation-checked: removing the handler fails two of
  them.
- Full react suite: 1128 tests pass. Docs build passes. eslint and `tsc` clean.

Note the `ActionMenu` suite intermittently reports "suite failed to run" from a
SIGTERM'd jest worker; that is the known leak in #2447 and unrelated to this
change, which touches `TreeView` only.

Closes #2519
