### PR TITLE
fix(Dialog): make scrollable content keyboard accessible

### DIFF
--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -238,10 +238,8 @@ const DialogContent = ({
         'text--align-center': align === 'center',
         'text--align-right': align === 'right'
       })}
-      // A scrollable region whose content has no focusable children can only be
-      // scrolled by keyboard if the region itself is tabbable (WCAG 2.1.1). The
-      // rule exempts role="tabpanel" only, so it flags this; #680 (role="region"
-      // plus an accessible name) would remove the need for this disable.
+      // A keyboard user can only scroll this region if it is tabbable (WCAG
+      // 2.1.1). The rule allows that on role="tabpanel" only. See #680.
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={context?.scrollable ? 0 : undefined}
       {...other}

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -238,7 +238,10 @@ const DialogContent = ({
         'text--align-center': align === 'center',
         'text--align-right': align === 'right'
       })}
-      tabIndex={context?.scrollable ? -1 : undefined}
+      // A scrollable region has to be reachable by keyboard (WCAG 2.1.1), which
+      // the rule does not account for on scroll containers.
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={context?.scrollable ? 0 : undefined}
       {...other}
     >
       {children}

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -238,8 +238,10 @@ const DialogContent = ({
         'text--align-center': align === 'center',
         'text--align-right': align === 'right'
       })}
-      // A scrollable region has to be reachable by keyboard (WCAG 2.1.1), which
-      // the rule does not account for on scroll containers.
+      // A scrollable region whose content has no focusable children can only be
+      // scrolled by keyboard if the region itself is tabbable (WCAG 2.1.1). The
+      // rule exempts role="tabpanel" only, so it flags this; #680 (role="region"
+      // plus an accessible name) would remove the need for this disable.
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={context?.scrollable ? 0 : undefined}
       {...other}

--- a/packages/react/src/components/Modal/screenshots.e2e.tsx
+++ b/packages/react/src/components/Modal/screenshots.e2e.tsx
@@ -169,15 +169,27 @@ test('scrollable Modal content is keyboard-accessible', async ({
 
   const content = page.locator('.Dialog__content');
   await expect(content).toBeVisible();
-  // A scrollable region is keyboard-accessible per WCAG 2.1.1 when it is
-  // programmatically focusable and actually overflows — the browser then
-  // handles arrow/Page key scrolling natively.
-  await expect(content).toHaveAttribute('tabindex', '-1');
+  // The premise for the rest of this test: the region has to actually
+  // overflow, and it holds no focusable children of its own.
   await expect
     .poll(async () =>
       content.evaluate((el) => el.scrollHeight - el.clientHeight)
     )
     .toBeGreaterThan(0);
-  await content.focus();
+
+  // Dialog moves focus to the heading asynchronously once it opens.
+  await expect(page.locator('.Dialog__heading')).toBeFocused();
+
+  // WCAG 2.1.1 requires the region to be reachable by keyboard, not merely
+  // focusable by script: tabindex="-1" satisfies a .focus() call while
+  // leaving a keyboard user unable to reach the region at all.
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
   await expect(content).toBeFocused();
+
+  // Once focused, scrolling is the browser's native default action.
+  await content.press('PageDown');
+  await expect
+    .poll(async () => content.evaluate((el) => el.scrollTop))
+    .toBeGreaterThan(0);
 });


### PR DESCRIPTION
Scrollable `ModalContent` is given `tabindex="-1"`, which makes it focusable by script only. It is not in the tab order, so a keyboard user cannot reachit. When the content has no focusable children of its own, the region cannot
be scrolled by keyboard at all, and axe reports `scrollable-region-focusable`.

Same defect class as #448, which reports it for `Layout`

## Changes

- `DialogContent` now uses `tabIndex={0}` when scrollable, instead of `-1`
- Rewrites the scrollable Modal keyboard test to press `Tab` and assert the region actually scrolls, rather than calling `.focus()` directly

## Notes

The existing test could not catch this. It asserted `tabindex="-1"` and then called `.focus()`, which succeeds on `-1`, so it passed while the region was unreachable by keyboard

Consumers who worked around this by passing their own `tabIndex` to
`ModalContent` can remove that override
