### PR TITLE
fix(AnchoredOverlay): only track element resizes while open

### DIFF
--- a/packages/react/src/components/AnchoredOverlay/AnchoredOverlay.test.tsx
+++ b/packages/react/src/components/AnchoredOverlay/AnchoredOverlay.test.tsx
@@ -326,3 +326,48 @@ test('should return no axe violations when not open', async () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+test('should observe the target for resizes only while open', () => {
+  const observed: Element[] = [];
+  const disconnect = jest.fn();
+  const originalResizeObserver = global.ResizeObserver;
+
+  global.ResizeObserver = class implements ResizeObserver {
+    observe = (element: Element) => {
+      observed.push(element);
+    };
+    unobserve = jest.fn();
+    disconnect = disconnect;
+  };
+  jest.useFakeTimers();
+
+  const targetRef = { current: document.createElement('button') };
+  const overlay = (open: boolean) => (
+    <AnchoredOverlay target={targetRef} open={open} data-testid="overlay">
+      Content
+    </AnchoredOverlay>
+  );
+
+  try {
+    const { rerender } = render(overlay(false));
+    act(() => jest.runOnlyPendingTimers());
+
+    // A closed overlay measures nothing: the first measurement of a target
+    // that mounted into an already laid-out page is what leaves a
+    // ResizeObserver notification undelivered.
+    expect(observed).toEqual([]);
+
+    rerender(overlay(true));
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(observed).toContain(targetRef.current);
+    expect(observed).toContain(screen.getByTestId('overlay'));
+
+    rerender(overlay(false));
+
+    expect(disconnect).toHaveBeenCalled();
+  } finally {
+    jest.useRealTimers();
+    global.ResizeObserver = originalResizeObserver;
+  }
+});

--- a/packages/react/src/components/AnchoredOverlay/index.tsx
+++ b/packages/react/src/components/AnchoredOverlay/index.tsx
@@ -89,6 +89,17 @@ const preventTopOverflowMiddleware: Middleware = {
   }
 };
 
+// Element-resize tracking is split out of `whileElementsMounted` so it can be
+// scoped to the open state. This function's identity must stay stable:
+// floating-ui keys its positioning effect on whether one was passed, and a
+// re-run calls `update()` again, which on close pulls focus back out of the
+// trigger.
+const autoUpdateWithoutElementResize: typeof autoUpdate = (
+  reference,
+  floating,
+  update
+) => autoUpdate(reference, floating, update, { elementResize: false });
+
 const AnchoredOverlay = forwardRef(
   <
     Overlay extends HTMLElement = HTMLElement,
@@ -115,7 +126,14 @@ const AnchoredOverlay = forwardRef(
     const ref = useSharedRef<HTMLElement | null>(refProp);
     const Component = as || 'div';
 
-    const { refs, floatingStyles, placement, middlewareData } = useFloating({
+    const {
+      refs,
+      floatingStyles,
+      placement,
+      middlewareData,
+      update,
+      elements
+    } = useFloating({
       open,
       // default to initial placement on top when placement is auto
       // @ts-expect-error auto placement is not a valid placement for floating-ui
@@ -138,8 +156,40 @@ const AnchoredOverlay = forwardRef(
       elements: {
         reference: resolveElement(target)
       },
-      whileElementsMounted: autoUpdate
+      whileElementsMounted: autoUpdateWithoutElementResize
     });
+
+    // Observing the target while the overlay is closed measures it for the
+    // first time mid-layout, which leaves a ResizeObserver notification
+    // undelivered and has the browser report an uncaught error.
+    useEffect(() => {
+      const { reference, floating } = elements;
+
+      if (
+        !open ||
+        !reference ||
+        !floating ||
+        typeof ResizeObserver !== 'function'
+      ) {
+        return;
+      }
+
+      // Deferred a task: starting it re-positions, and a render in the middle
+      // of the open sequence loses the overlay's initial focus target.
+      let stopObserving: (() => void) | undefined;
+      const timeout = setTimeout(() => {
+        stopObserving = autoUpdate(reference, floating, update, {
+          ancestorScroll: false,
+          ancestorResize: false,
+          layoutShift: false
+        });
+      });
+
+      return () => {
+        clearTimeout(timeout);
+        stopObserving?.();
+      };
+    }, [open, elements, update]);
 
     useEscapeKey({
       active: open,

--- a/packages/react/src/components/AnchoredOverlay/index.tsx
+++ b/packages/react/src/components/AnchoredOverlay/index.tsx
@@ -181,7 +181,8 @@ const AnchoredOverlay = forwardRef(
         stopObserving = autoUpdate(reference, floating, update, {
           ancestorScroll: false,
           ancestorResize: false,
-          layoutShift: false
+          layoutShift: false,
+          elementResize: true
         });
       });
 


### PR DESCRIPTION
## What

`AnchoredOverlay` no longer watches its target for size changes while the overlay is closed. floating-ui's `autoUpdate` still runs from mount for scroll, ancestor-resize and layout-shift; element-resize tracking now starts when `open` becomes true.

## Why

`autoUpdate` observes the target with a `ResizeObserver` as soon as both elements mount, open or not. Measuring a freshly mounted target inside an already laid-out page leaves a shallower observation undelivered for that frame, and the browser reports:

> ResizeObserver loop completed with undelivered notifications.

The message reaches `window.onerror`, so applications pick it up as an uncaught error. It fires whenever a group of closed overlays mounts — a row of dropdown triggers, a toolbar of menus — and is far more frequent where scrollbars consume layout space, since the scrollbar appearing gives the shallower elements a width change to report in the same frame.

## How

`whileElementsMounted` is now a module-scope function passing `elementResize: false`. Its identity must stay stable - floating-ui keys its positioning effect on whether one was passed, so toggling it re-runs that effect and calls `update()` again, and on close, that extra render pulls focus back out of the trigger.

Element resizes move to an effect gated on `open`, calling `autoUpdate` with only `elementResize` enabled. Delegating to `autoUpdate` keeps its loop guard — it unobserves the floating element when the target reports and re-observes a frame later; a plain `ResizeObserver` there loops on the position it writes. The effect defers a task so its reposition doesn't land mid-open-sequence, where `ActionMenu` loses its initial active descendant.

## Note

Positioning was never wrong — the browser delivers the deferred notifications on the next frame, so overlays have always ended up where they belong. Only the error report is affected.